### PR TITLE
Usability changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+*.rs.bk

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ os:
 script:
   - cargo fmt --all -- --write-mode=diff
   - cargo build --all --all-features
-  - cargo test
+  - cargo test --all
   - cargo doc --all --no-deps --all-features
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ os:
 script:
   - cargo fmt --all -- --write-mode=diff
   - cargo build --all --all-features
-  - cargo test --all
+  - cargo test
   - cargo doc --all --no-deps --all-features
 
 after_success:

--- a/tests/attach_null_to_surface.rs
+++ b/tests/attach_null_to_surface.rs
@@ -54,12 +54,16 @@ mod server_utils {
         }
     }
 
-    server_declare_handler!(CompositorHandler,
-                            wl_compositor::Handler,
-                            wl_compositor::WlCompositor);
-    server_declare_handler!(CompositorHandler,
-                            wl_surface::Handler,
-                            wl_surface::WlSurface);
+    server_declare_handler!(
+        CompositorHandler,
+        wl_compositor::Handler,
+        wl_compositor::WlCompositor
+    );
+    server_declare_handler!(
+        CompositorHandler,
+        wl_surface::Handler,
+        wl_surface::WlSurface
+    );
 
     pub fn insert_compositor(event_loop: &mut EventLoop) {
         let hid = event_loop.add_handler_with_init(CompositorHandler::new());

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -12,9 +12,9 @@ pub struct TestServer {
 impl TestServer {
     pub fn new() -> TestServer {
         let (mut display, event_loop) = ::ways::create_display();
-        let socket_name = display
-            .add_socket_auto()
-            .expect("Failed to create a server socket.");
+        let socket_name = display.add_socket_auto().expect(
+            "Failed to create a server socket.",
+        );
 
         TestServer {
             display: display,

--- a/wayland-client/examples/simple_window.rs
+++ b/wayland-client/examples/simple_window.rs
@@ -14,11 +14,13 @@ use wayland_client::{EnvHandler, EventQueueHandle};
 use wayland_client::protocol::{wl_compositor, wl_pointer, wl_seat, wl_shell, wl_shell_surface, wl_shm,
                                wl_surface};
 
-wayland_env!(WaylandEnv,
-             compositor: wl_compositor::WlCompositor,
-             seat: wl_seat::WlSeat,
-             shell: wl_shell::WlShell,
-             shm: wl_shm::WlShm);
+wayland_env!(
+    WaylandEnv,
+    compositor: wl_compositor::WlCompositor,
+    seat: wl_seat::WlSeat,
+    shell: wl_shell::WlShell,
+    shm: wl_shm::WlShm
+);
 
 struct MyHandler;
 
@@ -30,9 +32,11 @@ impl wl_shell_surface::Handler for MyHandler {
     // we ignore the other methods in this example, by default they do nothing
 }
 
-declare_handler!(MyHandler,
-                 wl_shell_surface::Handler,
-                 wl_shell_surface::WlShellSurface);
+declare_handler!(
+    MyHandler,
+    wl_shell_surface::Handler,
+    wl_shell_surface::WlShellSurface
+);
 
 impl wl_pointer::Handler for MyHandler {
     fn enter(&mut self, _: &mut EventQueueHandle, _me: &wl_pointer::WlPointer, _serial: u32,
@@ -49,15 +53,17 @@ impl wl_pointer::Handler for MyHandler {
     }
     fn button(&mut self, _: &mut EventQueueHandle, _me: &wl_pointer::WlPointer, _serial: u32, _time: u32,
               button: u32, state: wl_pointer::ButtonState) {
-        println!("Button {} ({}) was {:?}.",
-                 match button {
-                     272 => "Left",
-                     273 => "Right",
-                     274 => "Middle",
-                     _ => "Unknown",
-                 },
-                 button,
-                 state);
+        println!(
+            "Button {} ({}) was {:?}.",
+            match button {
+                272 => "Left",
+                273 => "Right",
+                274 => "Middle",
+                _ => "Unknown",
+            },
+            button,
+            state
+        );
     }
 
     // we ignore the other methods in this example, by default they do nothing
@@ -81,9 +87,9 @@ fn main() {
     let buf_y: u32 = 240;
 
     // create a tempfile to write the conents of the window on
-    let mut tmp = tempfile::tempfile()
-        .ok()
-        .expect("Unable to create a tempfile.");
+    let mut tmp = tempfile::tempfile().ok().expect(
+        "Unable to create a tempfile.",
+    );
     // write the contents to it, lets put a nice color gradient
     for i in 0..(buf_x * buf_y) {
         let x = (i % buf_x) as u32;
@@ -104,15 +110,18 @@ fn main() {
         let surface = env.compositor.create_surface();
         let shell_surface = env.shell.get_shell_surface(&surface);
 
-        let pool = env.shm
-            .create_pool(tmp.as_raw_fd(), (buf_x * buf_y * 4) as i32);
+        let pool = env.shm.create_pool(
+            tmp.as_raw_fd(),
+            (buf_x * buf_y * 4) as i32,
+        );
         // match a buffer on the part we wrote on
-        let buffer = pool.create_buffer(0,
-                                        buf_x as i32,
-                                        buf_y as i32,
-                                        (buf_x * 4) as i32,
-                                        wl_shm::Format::Argb8888)
-            .expect("The pool cannot be already dead");
+        let buffer = pool.create_buffer(
+            0,
+            buf_x as i32,
+            buf_y as i32,
+            (buf_x * 4) as i32,
+            wl_shm::Format::Argb8888,
+        ).expect("The pool cannot be already dead");
 
         // make our surface as a toplevel one
         shell_surface.set_toplevel();
@@ -121,9 +130,9 @@ fn main() {
         // commit
         surface.commit();
 
-        let pointer = env.seat
-            .get_pointer()
-            .expect("Seat cannot be already destroyed.");
+        let pointer = env.seat.get_pointer().expect(
+            "Seat cannot be already destroyed.",
+        );
 
         // we can let the other objects go out of scope
         // their associated wyland objects won't automatically be destroyed

--- a/wayland-client/src/cursor.rs
+++ b/wayland-client/src/cursor.rs
@@ -59,24 +59,30 @@ pub fn load_theme(name: Option<&str>, size: u32, shm: &WlShm) -> CursorTheme {
     let ptr = if let Some(theme) = name {
         let cstr = CString::new(theme).expect("Theme name contained an interior null.");
         unsafe {
-            ffi_dispatch!(WAYLAND_CURSOR_HANDLE,
-                          wl_cursor_theme_load,
-                          cstr.as_ptr(),
-                          size as c_int,
-                          shm.ptr())
+            ffi_dispatch!(
+                WAYLAND_CURSOR_HANDLE,
+                wl_cursor_theme_load,
+                cstr.as_ptr(),
+                size as c_int,
+                shm.ptr()
+            )
         }
     } else {
         unsafe {
-            ffi_dispatch!(WAYLAND_CURSOR_HANDLE,
-                          wl_cursor_theme_load,
-                          ptr::null(),
-                          size as c_int,
-                          shm.ptr())
+            ffi_dispatch!(
+                WAYLAND_CURSOR_HANDLE,
+                wl_cursor_theme_load,
+                ptr::null(),
+                size as c_int,
+                shm.ptr()
+            )
         }
     };
 
-    assert!(!ptr.is_null(),
-            "Memory allocation failure while loading a theme.");
+    assert!(
+        !ptr.is_null(),
+        "Memory allocation failure while loading a theme."
+    );
 
     CursorTheme { theme: ptr }
 }
@@ -90,18 +96,20 @@ impl CursorTheme {
     pub fn get_cursor(&self, name: &str) -> Option<Cursor> {
         let cstr = CString::new(name).expect("Cursor name contained an interior null.");
         let ptr = unsafe {
-            ffi_dispatch!(WAYLAND_CURSOR_HANDLE,
-                          wl_cursor_theme_get_cursor,
-                          self.theme,
-                          cstr.as_ptr())
+            ffi_dispatch!(
+                WAYLAND_CURSOR_HANDLE,
+                wl_cursor_theme_get_cursor,
+                self.theme,
+                cstr.as_ptr()
+            )
         };
         if ptr.is_null() {
             None
         } else {
             Some(Cursor {
-                     _theme: PhantomData,
-                     cursor: ptr,
-                 })
+                _theme: PhantomData,
+                cursor: ptr,
+            })
         }
     }
 }
@@ -143,10 +151,12 @@ impl<'a> Cursor<'a> {
     /// in milliseconds.
     pub fn frame(&self, duration: u32) -> usize {
         let frame = unsafe {
-            ffi_dispatch!(WAYLAND_CURSOR_HANDLE,
-                          wl_cursor_frame,
-                          self.cursor,
-                          duration)
+            ffi_dispatch!(
+                WAYLAND_CURSOR_HANDLE,
+                wl_cursor_frame,
+                self.cursor,
+                duration
+            )
         };
         frame as usize
     }
@@ -158,11 +168,13 @@ impl<'a> Cursor<'a> {
     pub fn frame_and_duration(&self, duration: u32) -> (usize, u32) {
         let mut out_duration = 0u32;
         let frame = unsafe {
-            ffi_dispatch!(WAYLAND_CURSOR_HANDLE,
-                          wl_cursor_frame_and_duration,
-                          self.cursor,
-                          duration,
-                          &mut out_duration as *mut u32)
+            ffi_dispatch!(
+                WAYLAND_CURSOR_HANDLE,
+                wl_cursor_frame_and_duration,
+                self.cursor,
+                duration,
+                &mut out_duration as *mut u32
+            )
         } as usize;
         (frame, out_duration)
     }
@@ -194,9 +206,9 @@ impl<'a> Cursor<'a> {
                 };
 
                 Some(CursorImageBuffer {
-                         _cursor: PhantomData,
-                         buffer: buffer,
-                     })
+                    _cursor: PhantomData,
+                    buffer: buffer,
+                })
             }
         }
     }
@@ -211,7 +223,13 @@ impl<'a> Cursor<'a> {
             None
         } else {
             let image = unsafe { &**(*self.cursor).images.offset(frame as isize) };
-            Some((image.width, image.height, image.hotspot_x, image.hotspot_y, image.delay))
+            Some((
+                image.width,
+                image.height,
+                image.hotspot_x,
+                image.hotspot_y,
+                image.delay,
+            ))
         }
     }
 }

--- a/wayland-client/src/display.rs
+++ b/wayland-client/src/display.rs
@@ -54,9 +54,11 @@ pub fn default_connect() -> Result<(WlDisplay, EventQueue), ConnectError> {
         return Err(ConnectError::NoWaylandLib);
     }
     let ptr = unsafe {
-        ffi_dispatch!(WAYLAND_CLIENT_HANDLE,
-                      wl_display_connect,
-                      ::std::ptr::null())
+        ffi_dispatch!(
+            WAYLAND_CLIENT_HANDLE,
+            wl_display_connect,
+            ::std::ptr::null()
+        )
     };
     if ptr.is_null() {
         Err(ConnectError::NoCompositorListening)
@@ -78,8 +80,9 @@ pub fn connect_to(name: &OsStr) -> Result<(WlDisplay, EventQueue), ConnectError>
     }
     // Only possible error is interior null, and in this case, no compositor will be listening to a socket
     // with null in its name.
-    let name = CString::new(name.as_bytes().to_owned())
-        .map_err(|_| ConnectError::NoCompositorListening)?;
+    let name = CString::new(name.as_bytes().to_owned()).map_err(|_| {
+        ConnectError::NoCompositorListening
+    })?;
     let ptr = unsafe { ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_display_connect, name.as_ptr()) };
     if ptr.is_null() {
         Err(ConnectError::NoCompositorListening)
@@ -99,9 +102,11 @@ impl WlDisplay {
     /// On success returns the number of written requests.
     pub fn flush(&self) -> io::Result<i32> {
         let ret = unsafe {
-            ffi_dispatch!(WAYLAND_CLIENT_HANDLE,
-                          wl_display_flush,
-                          self.ptr() as *mut _)
+            ffi_dispatch!(
+                WAYLAND_CLIENT_HANDLE,
+                wl_display_flush,
+                self.ptr() as *mut _
+            )
         };
         if ret >= 0 {
             Ok(ret)
@@ -115,9 +120,11 @@ impl WlDisplay {
     /// No object is by default attached to it.
     pub fn create_event_queue(&self) -> EventQueue {
         let evq = unsafe {
-            ffi_dispatch!(WAYLAND_CLIENT_HANDLE,
-                          wl_display_create_queue,
-                          self.ptr() as *mut _)
+            ffi_dispatch!(
+                WAYLAND_CLIENT_HANDLE,
+                wl_display_create_queue,
+                self.ptr() as *mut _
+            )
         };
         unsafe { create_event_queue(self.ptr() as *mut _, Some(evq)) }
     }
@@ -131,9 +138,11 @@ impl WlDisplay {
     /// an error might have been generated if I/O methods of EventQueue start returning errors.
     pub fn last_error(&self) -> Option<FatalError> {
         let err = unsafe {
-            ffi_dispatch!(WAYLAND_CLIENT_HANDLE,
-                          wl_display_get_error,
-                          self.ptr() as *mut _)
+            ffi_dispatch!(
+                WAYLAND_CLIENT_HANDLE,
+                wl_display_get_error,
+                self.ptr() as *mut _
+            )
         };
         if err == 0 {
             None
@@ -141,11 +150,13 @@ impl WlDisplay {
             let mut interface = ::std::ptr::null_mut();
             let mut id = 0;
             let code = unsafe {
-                ffi_dispatch!(WAYLAND_CLIENT_HANDLE,
-                              wl_display_get_protocol_error,
-                              self.ptr() as *mut _,
-                              &mut interface,
-                              &mut id)
+                ffi_dispatch!(
+                    WAYLAND_CLIENT_HANDLE,
+                    wl_display_get_protocol_error,
+                    self.ptr() as *mut _,
+                    &mut interface,
+                    &mut id
+                )
             };
             let interface = if interface.is_null() {
                 "<unkown interface>".to_owned()
@@ -155,10 +166,10 @@ impl WlDisplay {
                     .into_owned()
             };
             Some(FatalError::Protocol {
-                     interface: interface,
-                     proxy_id: id,
-                     error_code: code,
-                 })
+                interface: interface,
+                proxy_id: id,
+                error_code: code,
+            })
         } else {
             Some(FatalError::Io(io::Error::from_raw_os_error(err)))
         }
@@ -174,18 +185,22 @@ impl WlDisplay {
     /// Reading or writing anything to this FD will corrupt the internal state of
     /// the lib.
     pub unsafe fn get_fd(&self) -> ::std::os::unix::io::RawFd {
-        ffi_dispatch!(WAYLAND_CLIENT_HANDLE,
-                      wl_display_get_fd,
-                      self.ptr() as *mut _)
+        ffi_dispatch!(
+            WAYLAND_CLIENT_HANDLE,
+            wl_display_get_fd,
+            self.ptr() as *mut _
+        )
     }
 }
 
 impl Drop for WlDisplay {
     fn drop(&mut self) {
         unsafe {
-            ffi_dispatch!(WAYLAND_CLIENT_HANDLE,
-                          wl_display_disconnect,
-                          self.ptr() as *mut _)
+            ffi_dispatch!(
+                WAYLAND_CLIENT_HANDLE,
+                wl_display_disconnect,
+                self.ptr() as *mut _
+            )
         }
     }
 }

--- a/wayland-client/src/egl.rs
+++ b/wayland-client/src/egl.rs
@@ -46,11 +46,13 @@ impl WlEglSurface {
     ///
     /// This function is unsafe because `surface` must be a valid wl_surface pointer
     pub unsafe fn new_from_raw(surface: *mut wl_proxy, width: i32, height: i32) -> WlEglSurface {
-        let ptr = ffi_dispatch!(WAYLAND_EGL_HANDLE,
-                                wl_egl_window_create,
-                                surface,
-                                width,
-                                height);
+        let ptr = ffi_dispatch!(
+            WAYLAND_EGL_HANDLE,
+            wl_egl_window_create,
+            surface,
+            width,
+            height
+        );
         WlEglSurface { ptr: ptr }
     }
 
@@ -59,11 +61,13 @@ impl WlEglSurface {
         let mut w = 0i32;
         let mut h = 0i32;
         unsafe {
-            ffi_dispatch!(WAYLAND_EGL_HANDLE,
-                          wl_egl_window_get_attached_size,
-                          self.ptr,
-                          &mut w as *mut i32,
-                          &mut h as *mut i32);
+            ffi_dispatch!(
+                WAYLAND_EGL_HANDLE,
+                wl_egl_window_get_attached_size,
+                self.ptr,
+                &mut w as *mut i32,
+                &mut h as *mut i32
+            );
         }
         (w, h)
     }
@@ -76,13 +80,15 @@ impl WlEglSurface {
     /// direction of the resizing if necessary.
     pub fn resize(&self, width: i32, height: i32, dx: i32, dy: i32) {
         unsafe {
-            ffi_dispatch!(WAYLAND_EGL_HANDLE,
-                          wl_egl_window_resize,
-                          self.ptr,
-                          width,
-                          height,
-                          dx,
-                          dy)
+            ffi_dispatch!(
+                WAYLAND_EGL_HANDLE,
+                wl_egl_window_resize,
+                self.ptr,
+                width,
+                height,
+                dx,
+                dy
+            )
         }
     }
 

--- a/wayland-client/src/env.rs
+++ b/wayland-client/src/env.rs
@@ -99,9 +99,9 @@ impl<H: EnvHandlerInner> EnvHandler<H> {
 impl<H: EnvHandlerInner> ::std::ops::Deref for EnvHandler<H> {
     type Target = H;
     fn deref(&self) -> &H {
-        self.inner
-            .as_ref()
-            .expect("Tried to get contents of a not-ready EnvHandler.")
+        self.inner.as_ref().expect(
+            "Tried to get contents of a not-ready EnvHandler.",
+        )
     }
 }
 

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -212,7 +212,8 @@ pub trait Proxy {
     /// Will only succeed if the proxy is managed by this library and
     /// is still alive.
     fn clone(&self) -> Option<Self>
-        where Self: Sized
+    where
+        Self: Sized,
     {
         if self.status() == Liveness::Alive {
             Some(unsafe { self.clone_unchecked() })
@@ -227,7 +228,8 @@ pub trait Proxy {
     /// has no knowledge of its lifetime, and cannot ensure that the new handle
     /// will not outlive the object.
     unsafe fn clone_unchecked(&self) -> Self
-        where Self: Sized
+    where
+        Self: Sized,
     {
         // TODO: this can be more optimized with codegen help, but would be a
         // breaking change, so do it at next breaking release
@@ -276,7 +278,7 @@ pub unsafe trait Handler<T: Proxy> {
 }
 
 /// Represents the state of liveness of a wayland object
-#[derive(Copy,Clone,PartialEq,Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum Liveness {
     /// This object is alive and its requests can be called
     Alive,
@@ -295,18 +297,16 @@ mod generated {
 
     pub mod interfaces {
         //! Interfaces for the core protocol
-        //!
-        //! You might need them for the bindings generated for protocol extensions
+        // You might need them for the bindings generated for protocol extensions
         include!(concat!(env!("OUT_DIR"), "/wayland_interfaces.rs"));
     }
 
     pub mod client {
         //! The wayland core protocol
-        //!
-        //! This module contains all objects of the core wayland protocol.
-        //!
-        //! It has been generated from the `wayland.xml` protocol file
-        //! using `wayland_scanner`.
+        // This module contains all objects of the core wayland protocol.
+        //
+        // It has been generated from the `wayland.xml` protocol file
+        // using `wayland_scanner`.
 
         // Imports that need to be available to submodules
         // but should not be in public API.

--- a/wayland-protocols/build.rs
+++ b/wayland-protocols/build.rs
@@ -8,39 +8,64 @@ use wayland_scanner::{Side, generate_code, generate_interfaces};
 static BASE_PROTOCOL_DIR: &'static str = "./protocols/";
 
 static STABLE_PROTOCOLS: &'static [(&'static str, &'static str)] =
-    &[("presentation-time", "presentation-time/presentation-time.xml"),
-      ("viewporter", "viewporter/viewporter.xml")];
+    &[
+        (
+            "presentation-time",
+            "presentation-time/presentation-time.xml",
+        ),
+        ("viewporter", "viewporter/viewporter.xml"),
+    ];
 
 static UNSTABLE_PROTOCOLS: &'static [(&'static str, &'static str)] =
-    &[("fullscreen-shell", "fullscreen-shell/fullscreen-shell-unstable-v1.xml"),
-      ("idle-inhibit", "idle-inhibit/idle-inhibit-unstable-v1.xml"),
-      ("input-method", "input-method/input-method-unstable-v1.xml"),
-      ("linux-dmabuf", "linux-dmabuf/linux-dmabuf-unstable-v1.xml"),
-      ("pointer-constraints", "pointer-constraints/pointer-constraints-unstable-v1.xml"),
-      ("pointer-gestures", "pointer-gestures/pointer-gestures-unstable-v1.xml"),
-      ("relative-pointer", "relative-pointer/relative-pointer-unstable-v1.xml"),
-      ("tablet", "tablet/tablet-unstable-v2.xml"),
-      ("text-input", "text-input/text-input-unstable-v1.xml"),
-      ("xdg-foreign", "xdg-foreign/xdg-foreign-unstable-v1.xml"),
-      ("xdg-shell", "xdg-shell/xdg-shell-unstable-v6.xml")];
+    &[
+        (
+            "fullscreen-shell",
+            "fullscreen-shell/fullscreen-shell-unstable-v1.xml",
+        ),
+        ("idle-inhibit", "idle-inhibit/idle-inhibit-unstable-v1.xml"),
+        ("input-method", "input-method/input-method-unstable-v1.xml"),
+        ("linux-dmabuf", "linux-dmabuf/linux-dmabuf-unstable-v1.xml"),
+        (
+            "pointer-constraints",
+            "pointer-constraints/pointer-constraints-unstable-v1.xml",
+        ),
+        (
+            "pointer-gestures",
+            "pointer-gestures/pointer-gestures-unstable-v1.xml",
+        ),
+        (
+            "relative-pointer",
+            "relative-pointer/relative-pointer-unstable-v1.xml",
+        ),
+        ("tablet", "tablet/tablet-unstable-v2.xml"),
+        ("text-input", "text-input/text-input-unstable-v1.xml"),
+        ("xdg-foreign", "xdg-foreign/xdg-foreign-unstable-v1.xml"),
+        ("xdg-shell", "xdg-shell/xdg-shell-unstable-v6.xml"),
+    ];
 
 fn generate_protocol(name: &str, file: &Path, out_dir: &Path, client: bool, server: bool) {
 
     let protocol_file = Path::new(BASE_PROTOCOL_DIR).join(file);
 
-    generate_interfaces(&protocol_file,
-                        out_dir.join(&format!("{}_interfaces.rs", name)));
+    generate_interfaces(
+        &protocol_file,
+        out_dir.join(&format!("{}_interfaces.rs", name)),
+    );
 
     if client {
-        generate_code(&protocol_file,
-                      out_dir.join(&format!("{}_client_api.rs", name)),
-                      Side::Client);
+        generate_code(
+            &protocol_file,
+            out_dir.join(&format!("{}_client_api.rs", name)),
+            Side::Client,
+        );
     }
 
     if server {
-        generate_code(&protocol_file,
-                      out_dir.join(&format!("{}_server_api.rs", name)),
-                      Side::Server);
+        generate_code(
+            &protocol_file,
+            out_dir.join(&format!("{}_server_api.rs", name)),
+            Side::Server,
+        );
     }
 }
 
@@ -52,22 +77,26 @@ fn main() {
     let server = var("CARGO_FEATURE_SERVER").ok().is_some();
 
     for &(name, file) in STABLE_PROTOCOLS {
-        generate_protocol(name,
-                          &Path::new("stable").join(file),
-                          out_dir,
-                          client,
-                          server);
+        generate_protocol(
+            name,
+            &Path::new("stable").join(file),
+            out_dir,
+            client,
+            server,
+        );
     }
 
 
 
     if var("CARGO_FEATURE_UNSTABLE_PROTOCOLS").ok().is_some() {
         for &(name, file) in UNSTABLE_PROTOCOLS {
-            generate_protocol(name,
-                              &Path::new("unstable").join(file),
-                              out_dir,
-                              client,
-                              server);
+            generate_protocol(
+                name,
+                &Path::new("unstable").join(file),
+                out_dir,
+                client,
+                server,
+            );
         }
     }
 }

--- a/wayland-protocols/src/stable.rs
+++ b/wayland-protocols/src/stable.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(rustfmt, rustfmt_skip)]
+
 pub mod presentation_time {
     //! Presentation time protocol
     //!

--- a/wayland-protocols/src/unstable.rs
+++ b/wayland-protocols/src/unstable.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(rustfmt, rustfmt_skip)]
+
 pub mod fullscreen_shell {
     wayland_protocol!("fullscreen-shell",
                       (wl_surface, wl_surface_interface),

--- a/wayland-scanner/src/code_gen.rs
+++ b/wayland-scanner/src/code_gen.rs
@@ -36,8 +36,10 @@ fn write_interface<O: Write>(interface: &Interface, out: &mut O, side: Side) -> 
     writeln!(out, "use std::ptr;")?;
     writeln!(out, "use std::any::Any;")?;
     writeln!(out, "use std::sync::Arc;")?;
-    writeln!(out,
-             "use std::sync::atomic::{{AtomicBool, AtomicPtr, Ordering}};")?;
+    writeln!(
+        out,
+        "use std::sync::atomic::{{AtomicBool, AtomicPtr, Ordering}};"
+    )?;
     writeln!(out, "use std::os::raw::c_void;")?;
     match side {
         Side::Client => writeln!(out, "use wayland_sys::client::*;")?,
@@ -45,32 +47,41 @@ fn write_interface<O: Write>(interface: &Interface, out: &mut O, side: Side) -> 
     };
     writeln!(out, "use wayland_sys::RUST_MANAGED;")?;
 
-    writeln!(out,
-             r#"pub struct {} {{
+    writeln!(
+        out,
+        r#"pub struct {} {{
             ptr: *mut {},
             data: Option<Arc<(AtomicBool, AtomicPtr<()>)>>
         }}"#,
-             snake_to_camel(&interface.name),
-             side.object_ptr_type())?;
+        snake_to_camel(&interface.name),
+        side.object_ptr_type()
+    )?;
 
     // Wayland proxies/ressources are Send+Sync
-    writeln!(out,
-             r#"
+    writeln!(
+        out,
+        r#"
     unsafe impl Send for {0} {{}}
     unsafe impl Sync for {0} {{}}
     "#,
-             snake_to_camel(&interface.name))?;
+        snake_to_camel(&interface.name)
+    )?;
 
     // Generate object trait impl
-    writeln!(out,
-             "impl {} for {} {{",
-             side.object_trait(),
-             snake_to_camel(&interface.name))?;
-    writeln!(out,
-             "fn ptr(&self) -> *mut {} {{ self.ptr }}",
-             side.object_ptr_type())?;
-    writeln!(out,
-             r#"unsafe fn from_ptr_new(ptr: *mut {0}) -> {1} {{
+    writeln!(
+        out,
+        "impl {} for {} {{",
+        side.object_trait(),
+        snake_to_camel(&interface.name)
+    )?;
+    writeln!(
+        out,
+        "fn ptr(&self) -> *mut {} {{ self.ptr }}",
+        side.object_ptr_type()
+    )?;
+    writeln!(
+        out,
+        r#"unsafe fn from_ptr_new(ptr: *mut {0}) -> {1} {{
             let data = Box::into_raw(Box::new((
                 ptr::null_mut::<c_void>(),
                 ptr::null_mut::<c_void>(),
@@ -79,26 +90,33 @@ fn write_interface<O: Write>(interface: &Interface, out: &mut O, side: Side) -> 
             ffi_dispatch!({2}, {0}_set_user_data, ptr, data as *mut c_void);
             {1} {{ ptr: ptr, data: Some((&*data).2.clone()) }}
         }}"#,
-             side.object_ptr_type(),
-             snake_to_camel(&interface.name),
-             side.handle())?;
-    writeln!(out,
-             "unsafe fn from_ptr_initialized(ptr: *mut {0}) -> {1} {{",
-             side.object_ptr_type(),
-             snake_to_camel(&interface.name))?;
+        side.object_ptr_type(),
+        snake_to_camel(&interface.name),
+        side.handle()
+    )?;
+    writeln!(
+        out,
+        "unsafe fn from_ptr_initialized(ptr: *mut {0}) -> {1} {{",
+        side.object_ptr_type(),
+        snake_to_camel(&interface.name)
+    )?;
     if let Side::Client = side {
-        writeln!(out,
-                 r#"
+        writeln!(
+            out,
+            r#"
             let implem = ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_proxy_get_listener, ptr);
             let rust_managed = implem == &RUST_MANAGED as *const _ as *const _;
-        "#)?;
+        "#
+        )?;
     } else {
-        writeln!(out,
-                 r#"
+        writeln!(
+            out,
+            r#"
             let rust_managed = ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_instance_of,
                 ptr, Self::interface_ptr(), &RUST_MANAGED as *const _ as *const _
             ) != 0;
-        "#)?;
+        "#
+        )?;
     }
     try!(writeln!(out, r#"
             if rust_managed {{
@@ -112,27 +130,38 @@ fn write_interface<O: Write>(interface: &Interface, out: &mut O, side: Side) -> 
         snake_to_camel(&interface.name),
         side.handle()
     ));
-    writeln!(out,
-             "fn interface_ptr() -> *const wl_interface {{ unsafe {{ &{}_interface }} }}",
-             interface.name)?;
-    writeln!(out,
-             "fn interface_name() -> &'static str {{ \"{}\"  }}",
-             interface.name)?;
-    writeln!(out,
-             "fn supported_version() -> u32 {{ {} }}",
-             interface.version)?;
+    writeln!(
+        out,
+        "fn interface_ptr() -> *const wl_interface {{ unsafe {{ &{}_interface }} }}",
+        interface.name
+    )?;
+    writeln!(
+        out,
+        "fn interface_name() -> &'static str {{ \"{}\"  }}",
+        interface.name
+    )?;
+    writeln!(
+        out,
+        "fn supported_version() -> u32 {{ {} }}",
+        interface.version
+    )?;
     match side {
         Side::Client => {
-            writeln!(out,
-                     "fn version(&self) -> u32 {{ unsafe {{ ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_proxy_get_version, self.ptr()) }} }}")?
+            writeln!(
+                out,
+                "fn version(&self) -> u32 {{ unsafe {{ ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_proxy_get_version, self.ptr()) }} }}"
+            )?
         }
         Side::Server => {
-            writeln!(out,
-                     "fn version(&self) -> i32 {{ unsafe {{ ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_get_version, self.ptr()) }} }}")?
+            writeln!(
+                out,
+                "fn version(&self) -> i32 {{ unsafe {{ ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_get_version, self.ptr()) }} }}"
+            )?
         }
     };
-    writeln!(out,
-             r#"
+    writeln!(
+        out,
+        r#"
         fn status(&self) -> Liveness {{
             if let Some(ref data) = self.data {{
                 if data.0.load(Ordering::SeqCst) {{
@@ -143,16 +172,20 @@ fn write_interface<O: Write>(interface: &Interface, out: &mut O, side: Side) -> 
             }} else {{
                 Liveness::Unmanaged
             }}
-        }}"#)?;
+        }}"#
+    )?;
 
-    writeln!(out,
-             r#"fn equals(&self, other: &{}) -> bool {{
+    writeln!(
+        out,
+        r#"fn equals(&self, other: &{}) -> bool {{
             self.status() != Liveness::Dead && other.status() != Liveness::Dead && self.ptr == other.ptr
         }}"#,
-             snake_to_camel(&interface.name))?;
+        snake_to_camel(&interface.name)
+    )?;
 
-    writeln!(out,
-             r#"
+    writeln!(
+        out,
+        r#"
         fn set_user_data(&self, ptr: *mut ()) {{
             if let Some(ref data) = self.data {{
                 data.1.store(ptr, Ordering::SeqCst);
@@ -164,7 +197,8 @@ fn write_interface<O: Write>(interface: &Interface, out: &mut O, side: Side) -> 
             }} else {{
                 ::std::ptr::null_mut()
             }}
-        }}"#)?;
+        }}"#
+    )?;
 
     writeln!(out, "}}")?;
 
@@ -173,30 +207,36 @@ fn write_interface<O: Write>(interface: &Interface, out: &mut O, side: Side) -> 
 
     // client-side events of wl_display are handled by the lib
     if side != Side::Client || interface.name != "wl_display" {
-        write_handler_trait(match side {
-                                Side::Client => &interface.events,
-                                Side::Server => &interface.requests,
-                            },
-                            out,
-                            side,
-                            &interface.name)?;
+        write_handler_trait(
+            match side {
+                Side::Client => &interface.events,
+                Side::Server => &interface.requests,
+            },
+            out,
+            side,
+            &interface.name,
+        )?;
     }
 
-    write_opcodes(match side {
-                      Side::Client => &interface.requests,
-                      Side::Server => &interface.events,
-                  },
-                  out,
-                  &interface.name)?;
+    write_opcodes(
+        match side {
+            Side::Client => &interface.requests,
+            Side::Server => &interface.events,
+        },
+        out,
+        &interface.name,
+    )?;
 
-    write_impl(match side {
-                   Side::Client => &interface.requests,
-                   Side::Server => &interface.events,
-               },
-               out,
-               &interface.name,
-               side,
-               interface.destructor_sanitize().unwrap())?;
+    write_impl(
+        match side {
+            Side::Client => &interface.requests,
+            Side::Server => &interface.events,
+        },
+        out,
+        &interface.name,
+        side,
+        interface.destructor_sanitize().unwrap(),
+    )?;
 
     writeln!(out, "}}")?;
     Ok(())
@@ -204,11 +244,13 @@ fn write_interface<O: Write>(interface: &Interface, out: &mut O, side: Side) -> 
 
 fn write_opcodes<O: Write>(messages: &[Message], out: &mut O, iname: &str) -> IOResult<()> {
     for (i, msg) in messages.iter().enumerate() {
-        writeln!(out,
-                 "const {}_{}: u32 = {};",
-                 snake_to_screaming(&iname),
-                 snake_to_screaming(&msg.name),
-                 i)?;
+        writeln!(
+            out,
+            "const {}_{}: u32 = {};",
+            snake_to_screaming(&iname),
+            snake_to_screaming(&msg.name),
+            i
+        )?;
     }
     Ok(())
 }
@@ -233,46 +275,55 @@ fn write_enums<O: Write>(enums: &[Enum], out: &mut O) -> IOResult<()> {
     for enu in enums {
         if enu.bitfield {
             if let Some((ref short, ref long)) = enu.description {
-                writeln!(out,
-                         "bitflags! {{ #[doc = r#\"{}\n\n{}\"#] pub flags {}: u32 {{",
-                         short,
-                         long.lines()
-                             .map(|s| s.trim())
-                             .collect::<Vec<_>>()
-                             .join("\n"),
-                         snake_to_camel(&enu.name))?;
+                writeln!(
+                    out,
+                    "bitflags! {{ #[doc = r#\"{}\n\n{}\"#] pub flags {}: u32 {{",
+                    short,
+                    long.lines().map(|s| s.trim()).collect::<Vec<_>>().join(
+                        "\n",
+                    ),
+                    snake_to_camel(&enu.name)
+                )?;
             } else {
-                writeln!(out,
-                         "bitflags! {{ pub flags {}: u32 {{",
-                         snake_to_camel(&enu.name))?;
+                writeln!(
+                    out,
+                    "bitflags! {{ pub flags {}: u32 {{",
+                    snake_to_camel(&enu.name)
+                )?;
             }
             for entry in &enu.entries {
                 if let Some((ref short, ref long)) = entry.description {
                     write_doc(Some(short), long, false, out)?;
                 }
-                writeln!(out,
-                         "const {}{}{} = {},",
-                         if bitfields_conflicts {
-                             snake_to_camel(&enu.name)
-                         } else {
-                             String::new()
-                         },
-                         if entry.name.chars().next().unwrap().is_numeric() {
-                             "_"
-                         } else {
-                             ""
-                         },
-                         snake_to_camel(&entry.name),
-                         entry.value)?;
+                writeln!(
+                    out,
+                    "const {}{}{} = {},",
+                    if bitfields_conflicts {
+                        snake_to_camel(&enu.name)
+                    } else {
+                        String::new()
+                    },
+                    if entry.name.chars().next().unwrap().is_numeric() {
+                        "_"
+                    } else {
+                        ""
+                    },
+                    snake_to_camel(&entry.name),
+                    entry.value
+                )?;
             }
             writeln!(out, "}} }}")?;
             writeln!(out, "impl {} {{", snake_to_camel(&enu.name))?;
-            writeln!(out,
-                     "pub fn from_raw(n: u32) -> Option<{}> {{",
-                     snake_to_camel(&enu.name))?;
-            writeln!(out,
-                     "Some({}::from_bits_truncate(n))",
-                     snake_to_camel(&enu.name))?;
+            writeln!(
+                out,
+                "pub fn from_raw(n: u32) -> Option<{}> {{",
+                snake_to_camel(&enu.name)
+            )?;
+            writeln!(
+                out,
+                "Some({}::from_bits_truncate(n))",
+                snake_to_camel(&enu.name)
+            )?;
             writeln!(out, "}}")?;
             writeln!(out, "pub fn to_raw(&self) -> u32 {{")?;
             writeln!(out, "self.bits()")?;
@@ -283,41 +334,49 @@ fn write_enums<O: Write>(enums: &[Enum], out: &mut O) -> IOResult<()> {
             if let Some((ref short, ref long)) = enu.description {
                 write_doc(Some(short), long, false, out)?;
             }
-            writeln!(out,
-                     "#[repr(u32)]\n#[derive(Copy,Clone,Debug,PartialEq)]\npub enum {} {{",
-                     snake_to_camel(&enu.name))?;
+            writeln!(
+                out,
+                "#[repr(u32)]\n#[derive(Copy,Clone,Debug,PartialEq)]\npub enum {} {{",
+                snake_to_camel(&enu.name)
+            )?;
             for entry in &enu.entries {
                 if let Some((ref short, ref long)) = entry.description {
                     write_doc(Some(short), long, false, out)?;
                 }
-                writeln!(out,
-                         "{}{} = {},",
-                         if entry.name.chars().next().unwrap().is_numeric() {
-                             "_"
-                         } else {
-                             ""
-                         },
-                         snake_to_camel(&entry.name),
-                         entry.value)?;
+                writeln!(
+                    out,
+                    "{}{} = {},",
+                    if entry.name.chars().next().unwrap().is_numeric() {
+                        "_"
+                    } else {
+                        ""
+                    },
+                    snake_to_camel(&entry.name),
+                    entry.value
+                )?;
             }
             writeln!(out, "}}")?;
 
             writeln!(out, "impl {} {{", snake_to_camel(&enu.name))?;
-            writeln!(out,
-                     "pub fn from_raw(n: u32) -> Option<{}> {{",
-                     snake_to_camel(&enu.name))?;
+            writeln!(
+                out,
+                "pub fn from_raw(n: u32) -> Option<{}> {{",
+                snake_to_camel(&enu.name)
+            )?;
             writeln!(out, "match n {{")?;
             for entry in &enu.entries {
-                writeln!(out,
-                         "{} => Some({}::{}{}),",
-                         entry.value,
-                         snake_to_camel(&enu.name),
-                         if entry.name.chars().next().unwrap().is_numeric() {
-                             "_"
-                         } else {
-                             ""
-                         },
-                         snake_to_camel(&entry.name))?;
+                writeln!(
+                    out,
+                    "{} => Some({}::{}{}),",
+                    entry.value,
+                    snake_to_camel(&enu.name),
+                    if entry.name.chars().next().unwrap().is_numeric() {
+                        "_"
+                    } else {
+                        ""
+                    },
+                    snake_to_camel(&entry.name)
+                )?;
             }
             writeln!(out, "_ => Option::None")?;
             writeln!(out, "}}")?;
@@ -341,69 +400,77 @@ fn write_handler_trait<O: Write>(messages: &[Message], out: &mut O, side: Side, 
             write_doc(Some(short), long, false, out)?;
         }
         if let Some(Type::Destructor) = msg.typ {
-            writeln!(out,
-                     "///\n/// This is a destructor, you cannot send {} to this object once this method is called.",
-                     match side {
-                         Side::Server => "events",
-                         Side::Client => "requests",
-                     })?;
+            writeln!(
+                out,
+                "///\n/// This is a destructor, you cannot send {} to this object once this method is called.",
+                match side {
+                    Side::Server => "events",
+                    Side::Client => "requests",
+                }
+            )?;
         }
-        write!(out,
-               "fn {}{}(&mut self, evqh: &mut {}, {} {}: &{}",
-               msg.name,
-               if is_keyword(&msg.name) { "_" } else { "" },
-               side.handle_type(),
-               if side == Side::Server {
-                   "client: &Client, "
-               } else {
-                   ""
-               },
-               match side {
-                   Side::Client => "proxy",
-                   Side::Server => "resource",
-               },
-               snake_to_camel(iname))?;
+        write!(
+            out,
+            "fn {}{}(&mut self, evqh: &mut {}, {} {}: &{}",
+            msg.name,
+            if is_keyword(&msg.name) { "_" } else { "" },
+            side.handle_type(),
+            if side == Side::Server {
+                "client: &Client, "
+            } else {
+                ""
+            },
+            match side {
+                Side::Client => "proxy",
+                Side::Server => "resource",
+            },
+            snake_to_camel(iname)
+        )?;
         for arg in &msg.args {
-            write!(out,
-                   ", {}{}: {}{}{}",
-                   if is_keyword(&arg.name) { "_" } else { "" },
-                   arg.name,
-                   if arg.allow_null { "Option<" } else { "" },
-                   if let Some(ref name) = arg.enum_ {
-                       dotted_to_relname(name)
-                   } else {
-                       match arg.typ {
-                           // TODO handle unspecified interface
-                           Type::Object => {
-                               arg.interface
-                                   .as_ref()
-                                   .map(|s| format!("&super::{}::{}", s, snake_to_camel(s)))
-                                   .unwrap_or(format!("*mut {}", side.object_ptr_type()))
-                           }
-                           Type::NewId => {
-                               arg.interface
-                                   .as_ref()
-                                   .map(|s| format!("super::{}::{}", s, snake_to_camel(s)))
-                                   .unwrap_or("(&str, u32)".into())
-                           }
-                           _ => arg.typ.rust_type().into(),
-                       }
-                   },
-                   if arg.allow_null { ">" } else { "" })?;
+            write!(
+                out,
+                ", {}{}: {}{}{}",
+                if is_keyword(&arg.name) { "_" } else { "" },
+                arg.name,
+                if arg.allow_null { "Option<" } else { "" },
+                if let Some(ref name) = arg.enum_ {
+                    dotted_to_relname(name)
+                } else {
+                    match arg.typ {
+                        // TODO handle unspecified interface
+                        Type::Object => {
+                            arg.interface
+                                .as_ref()
+                                .map(|s| format!("&super::{}::{}", s, snake_to_camel(s)))
+                                .unwrap_or(format!("*mut {}", side.object_ptr_type()))
+                        }
+                        Type::NewId => {
+                            arg.interface
+                                .as_ref()
+                                .map(|s| format!("super::{}::{}", s, snake_to_camel(s)))
+                                .unwrap_or("(&str, u32)".into())
+                        }
+                        _ => arg.typ.rust_type().into(),
+                    }
+                },
+                if arg.allow_null { ">" } else { "" }
+            )?;
         }
         writeln!(out, ") {{}}")?;
     }
     // hidden method for internal machinery
     writeln!(out, "#[doc(hidden)]")?;
-    writeln!(out,
-             "unsafe fn __message(&mut self, evq: &mut {}, {} proxy: &{}, opcode: u32, args: *const wl_argument) -> Result<(),()> {{",
-             side.handle_type(),
-             if side == Side::Server {
-                 "client: &Client,"
-             } else {
-                 ""
-             },
-             snake_to_camel(iname))?;
+    writeln!(
+        out,
+        "unsafe fn __message(&mut self, evq: &mut {}, {} proxy: &{}, opcode: u32, args: *const wl_argument) -> Result<(),()> {{",
+        side.handle_type(),
+        if side == Side::Server {
+            "client: &Client,"
+        } else {
+            ""
+        },
+        snake_to_camel(iname)
+    )?;
     writeln!(out, "match opcode {{")?;
     for (op, msg) in messages.iter().enumerate() {
         writeln!(out, "{} => {{", op)?;
@@ -412,61 +479,79 @@ fn write_handler_trait<O: Write>(messages: &[Message], out: &mut O, side: Side, 
             if arg.allow_null {
                 match arg.typ {
                     Type::Uint | Type::Int | Type::Fixed | Type::NewId => {
-                        panic!("Argument {} for message {}.{} cannot be null given its type!",
-                               i,
-                               iname,
-                               msg.name)
+                        panic!(
+                            "Argument {} for message {}.{} cannot be null given its type!",
+                            i,
+                            iname,
+                            msg.name
+                        )
                     }
                     _ => {}
                 }
-                write!(out,
-                       "if (*(args.offset({}) as *const *const c_void)).is_null() {{ Option::None }} else {{ Some({{",
-                       i)?;
+                write!(
+                    out,
+                    "if (*(args.offset({}) as *const *const c_void)).is_null() {{ Option::None }} else {{ Some({{",
+                    i
+                )?;
             }
             if let Some(ref name) = arg.enum_ {
-                write!(out,
-                       "match {}::from_raw(*(args.offset({}) as *const u32)) {{ Some(v) => v, Option::None => return Err(()) }}",
-                       dotted_to_relname(name),
-                       i)?;
+                write!(
+                    out,
+                    "match {}::from_raw(*(args.offset({}) as *const u32)) {{ Some(v) => v, Option::None => return Err(()) }}",
+                    dotted_to_relname(name),
+                    i
+                )?;
             } else {
                 match arg.typ {
                     Type::Uint => write!(out, "*(args.offset({}) as *const u32)", i)?,
                     Type::Int | Type::Fd => write!(out, "*(args.offset({}) as *const i32)", i)?,
                     Type::Fixed => {
-                        write!(out,
-                               "wl_fixed_to_double(*(args.offset({}) as *const i32))",
-                               i)?
+                        write!(
+                            out,
+                            "wl_fixed_to_double(*(args.offset({}) as *const i32))",
+                            i
+                        )?
                     }
                     Type::Object => {
-                        write!(out,
-                               "{}::from_ptr_initialized(*(args.offset({}) as *const *mut {}))",
-                               side.object_trait(),
-                               i,
-                               side.object_ptr_type())?
+                        write!(
+                            out,
+                            "{}::from_ptr_initialized(*(args.offset({}) as *const *mut {}))",
+                            side.object_trait(),
+                            i,
+                            side.object_ptr_type()
+                        )?
                     }
                     Type::String => {
-                        write!(out,
-                               "String::from_utf8_lossy(CStr::from_ptr(*(args.offset({}) as *const *const _)).to_bytes()).into_owned()",
-                               i)?
+                        write!(
+                            out,
+                            "String::from_utf8_lossy(CStr::from_ptr(*(args.offset({}) as *const *const _)).to_bytes()).into_owned()",
+                            i
+                        )?
                     }
                     Type::Array => {
-                        write!(out,
-                               "let array = *(args.offset({}) as *const *mut wl_array); ::std::slice::from_raw_parts((*array).data as *const u8, (*array).size as usize).to_owned()",
-                               i)?
+                        write!(
+                            out,
+                            "let array = *(args.offset({}) as *const *mut wl_array); ::std::slice::from_raw_parts((*array).data as *const u8, (*array).size as usize).to_owned()",
+                            i
+                        )?
                     }
                     Type::NewId => {
                         match side {
                             Side::Client => {
-                                write!(out,
-                                       "Proxy::from_ptr_new(*(args.offset({}) as *const *mut wl_proxy))",
-                                       i)?
+                                write!(
+                                    out,
+                                    "Proxy::from_ptr_new(*(args.offset({}) as *const *mut wl_proxy))",
+                                    i
+                                )?
                             }
                             Side::Server => {
-                                write!(out,
-                                       "Resource::from_ptr_new(ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_create, client.ptr(), <super::{}::{} as Resource>::interface_ptr(), proxy.version(), *(args.offset({}) as *const u32)))",
-                                       arg.interface.as_ref().unwrap(),
-                                       snake_to_camel(arg.interface.as_ref().unwrap()),
-                                       i)?
+                                write!(
+                                    out,
+                                    "Resource::from_ptr_new(ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_create, client.ptr(), <super::{}::{} as Resource>::interface_ptr(), proxy.version(), *(args.offset({}) as *const u32)))",
+                                    arg.interface.as_ref().unwrap(),
+                                    snake_to_camel(arg.interface.as_ref().unwrap()),
+                                    i
+                                )?
                             }
                         }
                     }
@@ -480,22 +565,26 @@ fn write_handler_trait<O: Write>(messages: &[Message], out: &mut O, side: Side, 
         }
 
         if let Some(Type::Destructor) = msg.typ {
-            writeln!(out,
-                     r#"
+            writeln!(
+                out,
+                r#"
                 if let Some(ref data) = proxy.data {{
                     data.0.store(false, ::std::sync::atomic::Ordering::SeqCst);
                 }}
                 ffi_dispatch!({0}, {1}_destroy, proxy.ptr());
                 "#,
-                     side.handle(),
-                     side.object_ptr_type())?;
+                side.handle(),
+                side.object_ptr_type()
+            )?;
         }
 
-        write!(out,
-               "self.{}{}(evq, {} proxy",
-               msg.name,
-               if is_keyword(&msg.name) { "_" } else { "" },
-               if side == Side::Server { "client," } else { "" })?;
+        write!(
+            out,
+            "self.{}{}(evq, {} proxy",
+            msg.name,
+            if is_keyword(&msg.name) { "_" } else { "" },
+            if side == Side::Server { "client," } else { "" }
+        )?;
         for arg in &msg.args {
             match arg.typ {
                 Type::Object => {
@@ -531,12 +620,14 @@ fn write_impl<O: Write>(messages: &[Message], out: &mut O, iname: &str, side: Si
             write_doc(Some(short), long, false, out)?;
         }
         if let Some(Type::Destructor) = msg.typ {
-            writeln!(out,
-                     "///\n/// This is a destructor, you cannot send {} to this object once this method is called.",
-                     match side {
-                         Side::Server => "events",
-                         Side::Client => "requests",
-                     })?;
+            writeln!(
+                out,
+                "///\n/// This is a destructor, you cannot send {} to this object once this method is called.",
+                match side {
+                    Side::Server => "events",
+                    Side::Client => "requests",
+                }
+            )?;
         }
 
         // detect new_id
@@ -545,9 +636,11 @@ fn write_impl<O: Write>(messages: &[Message], out: &mut O, iname: &str, side: Si
             match arg.typ {
                 Type::NewId => {
                     if newid.is_some() {
-                        panic!("Request {}.{} returns more than one new_id",
-                               iname,
-                               msg.name);
+                        panic!(
+                            "Request {}.{} returns more than one new_id",
+                            iname,
+                            msg.name
+                        );
                     } else {
                         newid = Some(arg);
                     }
@@ -559,52 +652,58 @@ fn write_impl<O: Write>(messages: &[Message], out: &mut O, iname: &str, side: Si
         // method start
         match newid {
             Some(arg) if arg.interface.is_none() && side == Side::Client => {
-                write!(out,
-                       "pub fn {}{}<T: {}>(&self, version: u32",
-                       if is_keyword(&msg.name) { "_" } else { "" },
-                       msg.name,
-                       side.object_trait())?;
+                write!(
+                    out,
+                    "pub fn {}{}<T: {}>(&self, version: u32",
+                    if is_keyword(&msg.name) { "_" } else { "" },
+                    msg.name,
+                    side.object_trait()
+                )?;
             }
             _ => {
-                write!(out,
-                       "pub fn {}{}(&self",
-                       if is_keyword(&msg.name) { "_" } else { "" },
-                       msg.name)?;
+                write!(
+                    out,
+                    "pub fn {}{}(&self",
+                    if is_keyword(&msg.name) { "_" } else { "" },
+                    msg.name
+                )?;
             }
         }
 
         // print args
         for arg in &msg.args {
-            write!(out,
-                   ", {}{}: {}{}{}",
-                   if is_keyword(&arg.name) { "_" } else { "" },
-                   arg.name,
-                   if arg.allow_null { "Option<" } else { "" },
-                   if let Some(ref name) = arg.enum_ {
-                       dotted_to_relname(name)
-                   } else {
-                       match arg.typ {
-                           Type::Object => {
-                               arg.interface
-                                   .as_ref()
-                                   .map(|s| format!("&super::{}::{}", s, snake_to_camel(s)))
-                                   .unwrap_or(format!("*mut {}", side.object_ptr_type()))
-                           }
-                           Type::NewId => {
-                               if side == Side::Server {
-                                   arg.interface
-                                       .as_ref()
-                                       .map(|s| format!("&super::{}::{}", s, snake_to_camel(s)))
-                                       .unwrap_or(format!("*mut {}", side.object_ptr_type()))
-                               } else {
-                                   // client-side, the return-type handles that
-                                   continue;
-                               }
-                           }
-                           _ => arg.typ.rust_type().into(),
-                       }
-                   },
-                   if arg.allow_null { ">" } else { "" })?;
+            write!(
+                out,
+                ", {}{}: {}{}{}",
+                if is_keyword(&arg.name) { "_" } else { "" },
+                arg.name,
+                if arg.allow_null { "Option<" } else { "" },
+                if let Some(ref name) = arg.enum_ {
+                    dotted_to_relname(name)
+                } else {
+                    match arg.typ {
+                        Type::Object => {
+                            arg.interface
+                                .as_ref()
+                                .map(|s| format!("&super::{}::{}", s, snake_to_camel(s)))
+                                .unwrap_or(format!("*mut {}", side.object_ptr_type()))
+                        }
+                        Type::NewId => {
+                            if side == Side::Server {
+                                arg.interface
+                                    .as_ref()
+                                    .map(|s| format!("&super::{}::{}", s, snake_to_camel(s)))
+                                    .unwrap_or(format!("*mut {}", side.object_ptr_type()))
+                            } else {
+                                // client-side, the return-type handles that
+                                continue;
+                            }
+                        }
+                        _ => arg.typ.rust_type().into(),
+                    }
+                },
+                if arg.allow_null { ">" } else { "" }
+            )?;
         }
         write!(out, ") ->")?;
 
@@ -612,16 +711,18 @@ fn write_impl<O: Write>(messages: &[Message], out: &mut O, iname: &str, side: Si
         if destroyable {
             write!(out, "{}<", side.result_type())?;
         }
-        write!(out,
-               "{}",
-               if let (Some(arg), Side::Client) = (newid, side) {
-                   arg.interface
-                       .as_ref()
-                       .map(|s| format!("super::{}::{}", s, snake_to_camel(s)))
-                       .unwrap_or("T".into())
-               } else {
-                   "()".into()
-               })?;
+        write!(
+            out,
+            "{}",
+            if let (Some(arg), Side::Client) = (newid, side) {
+                arg.interface
+                    .as_ref()
+                    .map(|s| format!("super::{}::{}", s, snake_to_camel(s)))
+                    .unwrap_or("T".into())
+            } else {
+                "()".into()
+            }
+        )?;
         if destroyable {
             write!(out, ">")?;
         }
@@ -629,9 +730,11 @@ fn write_impl<O: Write>(messages: &[Message], out: &mut O, iname: &str, side: Si
 
         // check liveness
         if destroyable {
-            writeln!(out,
-                     "if self.status() == Liveness::Dead {{ return {}::Destroyed }}",
-                     side.result_type())?;
+            writeln!(
+                out,
+                "if self.status() == Liveness::Dead {{ return {}::Destroyed }}",
+                side.result_type()
+            )?;
         }
 
         // arg translation for some types
@@ -642,30 +745,38 @@ fn write_impl<O: Write>(messages: &[Message], out: &mut O, iname: &str, side: Si
                 }
                 Type::Array => {
                     if arg.allow_null {
-                        writeln!(out,
-                                 "let {0} = {0}.as_ref().map(|v|
+                        writeln!(
+                            out,
+                            "let {0} = {0}.as_ref().map(|v|
     wl_array {{ size: v.len(), alloc: v.capacity(), data: v.as_ptr() as *mut _ }}
 );",
-                                 arg.name)?;
+                            arg.name
+                        )?;
                     } else {
-                        writeln!(out,
-                                 "let {0} = wl_array {{ size: {0}.len(), alloc: {0}.capacity(), data: {0}.as_ptr() as *mut _ }};",
-                                 arg.name)?;
+                        writeln!(
+                            out,
+                            "let {0} = wl_array {{ size: {0}.len(), alloc: {0}.capacity(), data: {0}.as_ptr() as *mut _ }};",
+                            arg.name
+                        )?;
                     }
                 }
                 Type::String => {
                     if arg.allow_null {
-                        writeln!(out,
-                                 "let {0} = {0}.map(|s| CString::new(s).unwrap_or_else(|_| panic!(\"Got a String with interior null in {1}.{2}:{0}\")));",
-                                 arg.name,
-                                 iname,
-                                 msg.name)?;
+                        writeln!(
+                            out,
+                            "let {0} = {0}.map(|s| CString::new(s).unwrap_or_else(|_| panic!(\"Got a String with interior null in {1}.{2}:{0}\")));",
+                            arg.name,
+                            iname,
+                            msg.name
+                        )?;
                     } else {
-                        writeln!(out,
-                                 "let {0} = CString::new({0}).unwrap_or_else(|_| panic!(\"Got a String with interior null in {1}.{2}:{0}\"));",
-                                 arg.name,
-                                 iname,
-                                 msg.name)?;
+                        writeln!(
+                            out,
+                            "let {0} = CString::new({0}).unwrap_or_else(|_| panic!(\"Got a String with interior null in {1}.{2}:{0}\"));",
+                            arg.name,
+                            iname,
+                            msg.name
+                        )?;
                     }
                 }
                 _ => (),
@@ -677,15 +788,19 @@ fn write_impl<O: Write>(messages: &[Message], out: &mut O, iname: &str, side: Si
             if let Some(arg) = newid {
                 if let Some(ref iface) = arg.interface {
                     // FIXME: figure if argument order is really correct in the general case
-                    write!(out,
-                           "let ptr = unsafe {{ ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_proxy_marshal_constructor, self.ptr(), {}_{}, &{}_interface",
-                           snake_to_screaming(iname),
-                           snake_to_screaming(&msg.name),
-                           iface)?;
+                    write!(
+                        out,
+                        "let ptr = unsafe {{ ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_proxy_marshal_constructor, self.ptr(), {}_{}, &{}_interface",
+                        snake_to_screaming(iname),
+                        snake_to_screaming(&msg.name),
+                        iface
+                    )?;
                 } else {
                     writeln!(out, "if version > <T as Proxy>::supported_version() {{")?;
-                    writeln!(out,
-                             "    panic!(\"Tried to bind interface {{}} with version {{}} while it is only supported up to {{}}.\", <T as Proxy>::interface_name(), version, <T as Proxy>::supported_version())")?;
+                    writeln!(
+                        out,
+                        "    panic!(\"Tried to bind interface {{}} with version {{}} while it is only supported up to {{}}.\", <T as Proxy>::interface_name(), version, <T as Proxy>::supported_version())"
+                    )?;
                     writeln!(out, "}}")?;
                     try!(write!(out,
                         "let ptr = unsafe {{ ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_proxy_marshal_constructor_versioned, self.ptr(), {}_{}, <T as Proxy>::interface_ptr(), version",
@@ -694,16 +809,20 @@ fn write_impl<O: Write>(messages: &[Message], out: &mut O, iname: &str, side: Si
                     ));
                 }
             } else {
-                write!(out,
-                       "unsafe {{ ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_proxy_marshal, self.ptr(), {}_{}",
-                       snake_to_screaming(iname),
-                       snake_to_screaming(&msg.name))?;
+                write!(
+                    out,
+                    "unsafe {{ ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_proxy_marshal, self.ptr(), {}_{}",
+                    snake_to_screaming(iname),
+                    snake_to_screaming(&msg.name)
+                )?;
             }
         } else {
-            write!(out,
-                   "unsafe {{ ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_post_event, self.ptr(), {}_{}",
-                   snake_to_screaming(iname),
-                   snake_to_screaming(&msg.name))?;
+            write!(
+                out,
+                "unsafe {{ ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_post_event, self.ptr(), {}_{}",
+                snake_to_screaming(iname),
+                snake_to_screaming(&msg.name)
+            )?;
         }
 
         // write actual args
@@ -717,28 +836,34 @@ fn write_impl<O: Write>(messages: &[Message], out: &mut O, iname: &str, side: Si
                 }
                 Type::String => {
                     if arg.allow_null {
-                        write!(out,
-                               ", {}.as_ref().map(|s| s.as_ptr()).unwrap_or(ptr::null())",
-                               arg.name)?;
+                        write!(
+                            out,
+                            ", {}.as_ref().map(|s| s.as_ptr()).unwrap_or(ptr::null())",
+                            arg.name
+                        )?;
                     } else {
                         write!(out, ", {}.as_ptr()", arg.name)?;
                     }
                 }
                 Type::Array => {
                     if arg.allow_null {
-                        write!(out,
-                               ", {}.as_ref().map(|a| a as *const wl_array).unwrap_or(ptr::null())",
-                               arg.name)?;
+                        write!(
+                            out,
+                            ", {}.as_ref().map(|a| a as *const wl_array).unwrap_or(ptr::null())",
+                            arg.name
+                        )?;
                     } else {
                         write!(out, ", &{} as *const wl_array", arg.name)?;
                     }
                 }
                 Type::Object => {
                     if arg.allow_null {
-                        write!(out,
-                               ", {}.map({}::ptr).unwrap_or(ptr::null_mut())",
-                               arg.name,
-                               side.object_trait())?;
+                        write!(
+                            out,
+                            ", {}.map({}::ptr).unwrap_or(ptr::null_mut())",
+                            arg.name,
+                            side.object_trait()
+                        )?;
                     } else {
                         write!(out, ", {}.ptr()", arg.name)?;
                     }
@@ -756,15 +881,17 @@ fn write_impl<O: Write>(messages: &[Message], out: &mut O, iname: &str, side: Si
         writeln!(out, ") }};")?;
 
         if let Some(Type::Destructor) = msg.typ {
-            writeln!(out,
-                     r#"
+            writeln!(
+                out,
+                r#"
                 if let Some(ref data) = self.data {{
                     data.0.store(false, ::std::sync::atomic::Ordering::SeqCst);
                 }}
                 unsafe {{ ffi_dispatch!({0}, {1}_destroy, self.ptr()); }}
                 "#,
-                     side.handle(),
-                     side.object_ptr_type())?;
+                side.handle(),
+                side.object_ptr_type()
+            )?;
         }
 
         if newid.is_some() && side == Side::Client {

--- a/wayland-scanner/src/interface_gen.rs
+++ b/wayland-scanner/src/interface_gen.rs
@@ -16,9 +16,10 @@ macro_rules! for_requests_and_events_of_interface(
 );
 
 pub fn generate_interfaces<O: Write>(protocol: Protocol, out: &mut O) {
-    writeln!(out,
-             "//\n// This file was auto-generated, do not edit directly\n//\n")
-            .unwrap();
+    writeln!(
+        out,
+        "//\n// This file was auto-generated, do not edit directly\n//\n"
+    ).unwrap();
 
     if let Some(text) = protocol.copyright {
         writeln!(out, "/*\n{}\n*/\n", text).unwrap();
@@ -30,35 +31,32 @@ pub fn generate_interfaces<O: Write>(protocol: Protocol, out: &mut O) {
     // null types array
     //
 
-    let longest_nulls = protocol
-        .interfaces
-        .iter()
-        .fold(0, |max, interface| {
-            let request_longest_null = interface
-                .requests
-                .iter()
-                .fold(0, |max, request| if request.all_null() {
-                    cmp::max(request.args.len(), max)
-                } else {
-                    max
-                });
-            let events_longest_null = interface
-                .events
-                .iter()
-                .fold(0, |max, event| if event.all_null() {
-                    cmp::max(event.args.len(), max)
-                } else {
-                    max
-                });
-            cmp::max(max, cmp::max(request_longest_null, events_longest_null))
+    let longest_nulls = protocol.interfaces.iter().fold(0, |max, interface| {
+        let request_longest_null = interface.requests.iter().fold(0, |max, request| {
+            if request.all_null() {
+                cmp::max(request.args.len(), max)
+            } else {
+                max
+            }
         });
+        let events_longest_null = interface.events.iter().fold(
+            0,
+            |max, event| if event.all_null() {
+                cmp::max(event.args.len(), max)
+            } else {
+                max
+            },
+        );
+        cmp::max(max, cmp::max(request_longest_null, events_longest_null))
+    });
 
     writeln!(out, "const NULLPTR : *const c_void = 0 as *const c_void;\n").unwrap();
 
-    writeln!(out,
-             "static mut types_null: [*const wl_interface; {}] = [",
-             longest_nulls)
-            .unwrap();
+    writeln!(
+        out,
+        "static mut types_null: [*const wl_interface; {}] = [",
+        longest_nulls
+    ).unwrap();
     for _ in 0..longest_nulls {
         writeln!(out, "    NULLPTR as *const wl_interface,").unwrap();
     }
@@ -130,30 +128,34 @@ pub fn generate_interfaces<O: Write>(protocol: Protocol, out: &mut O) {
         emit_messages!(interface, requests);
         emit_messages!(interface, events);
 
-        writeln!(out,
-                 "\npub static mut {}_interface: wl_interface = wl_interface {{",
-                 interface.name)
-                .unwrap();
-        writeln!(out,
-                 "    name: b\"{}\\0\" as *const u8  as *const c_char,",
-                 interface.name)
-                .unwrap();
+        writeln!(
+            out,
+            "\npub static mut {}_interface: wl_interface = wl_interface {{",
+            interface.name
+        ).unwrap();
+        writeln!(
+            out,
+            "    name: b\"{}\\0\" as *const u8  as *const c_char,",
+            interface.name
+        ).unwrap();
         writeln!(out, "    version: {},", interface.version).unwrap();
         writeln!(out, "    request_count: {},", interface.requests.len()).unwrap();
         if interface.requests.len() > 0 {
-            writeln!(out,
-                     "    requests: unsafe {{ &{}_requests as *const _ }},",
-                     interface.name)
-                    .unwrap();
+            writeln!(
+                out,
+                "    requests: unsafe {{ &{}_requests as *const _ }},",
+                interface.name
+            ).unwrap();
         } else {
             writeln!(out, "    requests: NULLPTR as *const wl_message,").unwrap();
         }
         writeln!(out, "    event_count: {},", interface.events.len()).unwrap();
         if interface.events.len() > 0 {
-            writeln!(out,
-                     "    events: unsafe {{ &{}_events as *const _ }},",
-                     interface.name)
-                    .unwrap();
+            writeln!(
+                out,
+                "    events: unsafe {{ &{}_events as *const _ }},",
+                interface.name
+            ).unwrap();
         } else {
             writeln!(out, "    events: NULLPTR as *const wl_message,").unwrap();
         }

--- a/wayland-scanner/src/parse.rs
+++ b/wayland-scanner/src/parse.rs
@@ -50,7 +50,8 @@ pub fn parse_stream<S: Read>(stream: S) -> Protocol {
 }
 
 fn parse_protocol<'a, S: Read + 'a>(mut iter: Events<S>) -> Protocol {
-    let mut protocol = extract_from!(
+    let mut protocol =
+        extract_from!(
         iter => XmlEvent::StartElement { name, attributes, .. } => {
             assert!(name.local_name == "protocol", "Missing protocol toplevel tag");
             assert!(attributes[0].name.local_name == "name", "Protocol must have a name");
@@ -69,24 +70,28 @@ fn parse_protocol<'a, S: Read + 'a>(mut iter: Events<S>) -> Protocol {
                         protocol.copyright = Some(copyright);
                     }
                     "interface" => {
-                        protocol
-                            .interfaces
-                            .push(parse_interface(&mut iter, attributes));
+                        protocol.interfaces.push(
+                            parse_interface(&mut iter, attributes),
+                        );
                     }
                     "description" => {
                         protocol.description = Some(parse_description(&mut iter, attributes));
                     }
                     _ => {
-                        panic!("Ill-formed protocol file: unexpected token `{}` in protocol {}",
-                               name.local_name,
-                               protocol.name)
+                        panic!(
+                            "Ill-formed protocol file: unexpected token `{}` in protocol {}",
+                            name.local_name,
+                            protocol.name
+                        )
                     }
                 }
             }
             Some(Ok(XmlEvent::EndElement { name })) => {
-                assert!(name.local_name == "protocol",
-                        "Unexpected closing token `{}`",
-                        name.local_name);
+                assert!(
+                    name.local_name == "protocol",
+                    "Unexpected closing token `{}`",
+                    name.local_name
+                );
                 break;
             }
             e => panic!("Ill-formed protocol file: {:?}", e),

--- a/wayland-scanner/src/protocol.rs
+++ b/wayland-scanner/src/protocol.rs
@@ -47,18 +47,26 @@ impl Interface {
                 if let Some(Type::Destructor) = req.typ {
                     // all is good
                 } else {
-                    return Err(format!("Request '{}.destroy' is not a destructor.", self.name));
+                    return Err(format!(
+                        "Request '{}.destroy' is not a destructor.",
+                        self.name
+                    ));
                 }
             }
             if let Some(Type::Destructor) = req.typ {
                 // sanity checks
                 if req.args.len() > 0 {
-                    return Err(format!("Destructor request '{}.{}' cannot take arguments.",
-                                       self.name,
-                                       req.name));
+                    return Err(format!(
+                        "Destructor request '{}.{}' cannot take arguments.",
+                        self.name,
+                        req.name
+                    ));
                 }
                 if found_destructor {
-                    return Err(format!("Interface {} has more than one destructor.", self.name));
+                    return Err(format!(
+                        "Interface {} has more than one destructor.",
+                        self.name
+                    ));
                 }
                 found_destructor = true
             }
@@ -90,9 +98,9 @@ impl Message {
     }
 
     pub fn all_null(&self) -> bool {
-        self.args
-            .iter()
-            .all(|a| !((a.typ == Type::Object || a.typ == Type::NewId) && a.interface.is_some()))
+        self.args.iter().all(|a| {
+            !((a.typ == Type::Object || a.typ == Type::NewId) && a.interface.is_some())
+        })
     }
 }
 
@@ -163,7 +171,7 @@ impl Entry {
     }
 }
 
-#[derive(Debug,PartialEq,Eq,Copy,Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum Type {
     Int,
     Uint,

--- a/wayland-scanner/src/side.rs
+++ b/wayland-scanner/src/side.rs
@@ -4,7 +4,7 @@ use self::Side::{Client, Server};
 ///
 /// This enum represents the two possible sides of
 /// the protocol API that can be generated.
-#[derive(Copy,Clone,PartialEq,Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum Side {
     /// wayland client applications
     Client,

--- a/wayland-scanner/src/util.rs
+++ b/wayland-scanner/src/util.rs
@@ -17,13 +17,12 @@ pub fn snake_to_camel(input: &str) -> String {
         .split('_')
         .flat_map(|s| {
             let mut first = true;
-            s.chars()
-                .map(move |c| if first {
-                         first = false;
-                         c.to_ascii_uppercase()
-                     } else {
-                         c
-                     })
+            s.chars().map(move |c| if first {
+                first = false;
+                c.to_ascii_uppercase()
+            } else {
+                c
+            })
         })
         .collect()
 }

--- a/wayland-server/src/event_loop.rs
+++ b/wayland-server/src/event_loop.rs
@@ -117,8 +117,9 @@ impl EventLoopHandle {
     /// Returns an error and does nothing if this resource is dead or already managed by
     /// something else than this library.
     pub fn register<R, H>(&mut self, resource: &R, handler_id: usize) -> RegisterStatus
-        where R: Resource,
-              H: Handler<R> + Any + Send + 'static
+    where
+        R: Resource,
+        H: Handler<R> + Any + Send + 'static,
     {
         self.register_with_destructor::<R, H, NoopDestroy>(resource, handler_id)
     }
@@ -135,35 +136,39 @@ impl EventLoopHandle {
     /// Returns an error and does nothing if this resource is dead or already managed by
     /// something else than this library.
     pub fn register_with_destructor<R, H, D>(&mut self, resource: &R, handler_id: usize) -> RegisterStatus
-        where R: Resource,
-              H: Handler<R> + Any + Send + 'static,
-              D: Destroy<R> + 'static
+    where
+        R: Resource,
+        H: Handler<R> + Any + Send + 'static,
+        D: Destroy<R> + 'static,
     {
-        let h = self.handlers[handler_id]
-            .downcast_ref::<H>()
-            .expect("Handler type do not match.");
+        let h = self.handlers[handler_id].downcast_ref::<H>().expect(
+            "Handler type do not match.",
+        );
         match resource.status() {
             ::Liveness::Dead => return RegisterStatus::Dead,
             ::Liveness::Unmanaged => return RegisterStatus::Unmanaged,
             ::Liveness::Alive => { /* ok, we can continue */ }
         }
         unsafe {
-            let data: *mut ResourceUserData = ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                                                            wl_resource_get_user_data,
-                                                            resource.ptr()) as
-                                              *mut _;
+            let data: *mut ResourceUserData = ffi_dispatch!(
+                WAYLAND_SERVER_HANDLE,
+                wl_resource_get_user_data,
+                resource.ptr()
+            ) as *mut _;
             // This cast from *const to *mut is legit because we enforce that a Handler
             // can only be assigned to a single EventQueue.
             // (this is actually the whole point of the design of this lib)
             (&mut *data).0 = self as *const _ as *mut _;
             (&mut *data).1 = h as *const _ as *mut c_void;
-            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                          wl_resource_set_dispatcher,
-                          resource.ptr(),
-                          dispatch_func::<R, H>,
-                          &RUST_MANAGED as *const _ as *const _,
-                          data as *mut c_void,
-                          Some(resource_destroy::<R, D>));
+            ffi_dispatch!(
+                WAYLAND_SERVER_HANDLE,
+                wl_resource_set_dispatcher,
+                resource.ptr(),
+                dispatch_func::<R, H>,
+                &RUST_MANAGED as *const _ as *const _,
+                data as *mut c_void,
+                Some(resource_destroy::<R, D>)
+            );
         }
         RegisterStatus::Registered
     }
@@ -214,24 +219,27 @@ impl EventLoopHandle {
 /// Returns `false` if the resource is dead, even if it was registered to this
 /// handler while alive.
 pub fn resource_is_registered<R, H>(resource: &R, handler_id: usize) -> bool
-    where R: Resource,
-          H: Handler<R> + Any + Send + 'static
+where
+    R: Resource,
+    H: Handler<R> + Any + Send + 'static,
 {
     if resource.status() != ::Liveness::Alive {
         return false;
     }
     let resource_data = unsafe {
-        &*(ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                         wl_resource_get_user_data,
-                         resource.ptr()) as *mut ResourceUserData)
+        &*(ffi_dispatch!(
+            WAYLAND_SERVER_HANDLE,
+            wl_resource_get_user_data,
+            resource.ptr()
+        ) as *mut ResourceUserData)
     };
     if resource_data.0.is_null() {
         return false;
     }
     let evlh = unsafe { &*(resource_data.0) };
-    let h = evlh.handlers[handler_id]
-        .downcast_ref::<H>()
-        .expect("Handler type do not match.");
+    let h = evlh.handlers[handler_id].downcast_ref::<H>().expect(
+        "Handler type do not match.",
+    );
     (&*resource_data).1 == h as *const _ as *mut c_void
 }
 
@@ -277,9 +285,9 @@ pub unsafe fn create_event_loop(ptr: *mut wl_event_loop, display: Option<*mut wl
         ptr: ptr,
         display: display,
         handle: Box::new(EventLoopHandle {
-                             handlers: Vec::new(),
-                             keep_going: false,
-                         }),
+            handlers: Vec::new(),
+            keep_going: false,
+        }),
     }
 }
 
@@ -296,7 +304,8 @@ impl EventLoop {
     /// event sources.
     pub fn new() -> EventLoop {
         unsafe {
-            let ptr = ffi_dispatch!(
+            let ptr =
+                ffi_dispatch!(
                 WAYLAND_SERVER_HANDLE,
                 wl_event_loop_create,
             );
@@ -318,10 +327,12 @@ impl EventLoop {
             Some(v) => (v as i32),
         };
         let ret = unsafe {
-            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                          wl_event_loop_dispatch,
-                          self.ptr,
-                          timeout)
+            ffi_dispatch!(
+                WAYLAND_SERVER_HANDLE,
+                wl_event_loop_dispatch,
+                self.ptr,
+                timeout
+            )
         };
         if ret >= 0 {
             Ok(ret as u32)
@@ -369,21 +380,25 @@ impl EventLoop {
         let h = self.handle.handlers[handler_id]
             .downcast_ref::<H>()
             .expect("Handler type do not match.");
-        let display =
-            self.display
-                .expect("Globals can only be registered on an event loop associated with a display.");
+        let display = self.display.expect(
+            "Globals can only be registered on an event loop associated with a display.",
+        );
 
-        let data = Box::new((h as *const _ as *mut c_void,
-                             &*self.handle as *const _ as *mut EventLoopHandle));
+        let data = Box::new((
+            h as *const _ as *mut c_void,
+            &*self.handle as *const _ as *mut EventLoopHandle,
+        ));
 
         let ptr = unsafe {
-            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                          wl_global_create,
-                          display,
-                          R::interface_ptr(),
-                          version,
-                          &*data as *const (*mut c_void, *mut EventLoopHandle) as *mut _,
-                          global_bind::<R, H>)
+            ffi_dispatch!(
+                WAYLAND_SERVER_HANDLE,
+                wl_global_create,
+                display,
+                R::interface_ptr(),
+                version,
+                &*data as *const (*mut c_void, *mut EventLoopHandle) as *mut _,
+                global_bind::<R, H>
+            )
         };
 
         Global {
@@ -410,22 +425,27 @@ impl EventLoop {
     pub fn add_fd_event_source<H>(&mut self, fd: RawFd, handler_id: usize,
                                   interest: ::event_sources::FdInterest)
                                   -> IoResult<::event_sources::FdEventSource>
-        where H: ::event_sources::FdEventSourceHandler + 'static
+    where
+        H: ::event_sources::FdEventSourceHandler + 'static,
     {
-        let h = self.handlers[handler_id]
-            .downcast_ref::<H>()
-            .expect("Handler type do not match.");
-        let data = Box::new((h as *const _ as *mut c_void,
-                             &*self.handle as *const _ as *mut EventLoopHandle));
+        let h = self.handlers[handler_id].downcast_ref::<H>().expect(
+            "Handler type do not match.",
+        );
+        let data = Box::new((
+            h as *const _ as *mut c_void,
+            &*self.handle as *const _ as *mut EventLoopHandle,
+        ));
 
         let ret = unsafe {
-            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                          wl_event_loop_add_fd,
-                          self.ptr,
-                          fd,
-                          interest.bits(),
-                          ::event_sources::event_source_fd_dispatcher::<H>,
-                          &*data as *const _ as *mut c_void)
+            ffi_dispatch!(
+                WAYLAND_SERVER_HANDLE,
+                wl_event_loop_add_fd,
+                self.ptr,
+                fd,
+                interest.bits(),
+                ::event_sources::event_source_fd_dispatcher::<H>,
+                &*data as *const _ as *mut c_void
+            )
         };
         if ret.is_null() {
             Err(IoError::last_os_error())
@@ -442,20 +462,25 @@ impl EventLoop {
     /// this event loop.
     pub fn add_timer_event_source<H>(&mut self, handler_id: usize)
                                      -> IoResult<::event_sources::TimerEventSource>
-        where H: ::event_sources::TimerEventSourceHandler + 'static
+    where
+        H: ::event_sources::TimerEventSourceHandler + 'static,
     {
-        let h = self.handlers[handler_id]
-            .downcast_ref::<H>()
-            .expect("Handler type do not match.");
-        let data = Box::new((h as *const _ as *mut c_void,
-                             &*self.handle as *const _ as *mut EventLoopHandle));
+        let h = self.handlers[handler_id].downcast_ref::<H>().expect(
+            "Handler type do not match.",
+        );
+        let data = Box::new((
+            h as *const _ as *mut c_void,
+            &*self.handle as *const _ as *mut EventLoopHandle,
+        ));
 
         let ret = unsafe {
-            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                          wl_event_loop_add_timer,
-                          self.ptr,
-                          ::event_sources::event_source_timer_dispatcher::<H>,
-                          &*data as *const _ as *mut c_void)
+            ffi_dispatch!(
+                WAYLAND_SERVER_HANDLE,
+                wl_event_loop_add_timer,
+                self.ptr,
+                ::event_sources::event_source_timer_dispatcher::<H>,
+                &*data as *const _ as *mut c_void
+            )
         };
         if ret.is_null() {
             Err(IoError::last_os_error())
@@ -472,21 +497,26 @@ impl EventLoop {
     /// dispatching of this event loop.
     pub fn add_signal_event_source<H>(&mut self, signal: ::nix::sys::signal::Signal, handler_id: usize)
                                       -> IoResult<::event_sources::SignalEventSource>
-        where H: ::event_sources::SignalEventSourceHandler + 'static
+    where
+        H: ::event_sources::SignalEventSourceHandler + 'static,
     {
-        let h = self.handlers[handler_id]
-            .downcast_ref::<H>()
-            .expect("Handler type do not match.");
-        let data = Box::new((h as *const _ as *mut c_void,
-                             &*self.handle as *const _ as *mut EventLoopHandle));
+        let h = self.handlers[handler_id].downcast_ref::<H>().expect(
+            "Handler type do not match.",
+        );
+        let data = Box::new((
+            h as *const _ as *mut c_void,
+            &*self.handle as *const _ as *mut EventLoopHandle,
+        ));
 
         let ret = unsafe {
-            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                          wl_event_loop_add_signal,
-                          self.ptr,
-                          signal as c_int,
-                          ::event_sources::event_source_signal_dispatcher::<H>,
-                          &*data as *const _ as *mut c_void)
+            ffi_dispatch!(
+                WAYLAND_SERVER_HANDLE,
+                wl_event_loop_add_signal,
+                self.ptr,
+                signal as c_int,
+                ::event_sources::event_source_signal_dispatcher::<H>,
+                &*data as *const _ as *mut c_void
+            )
         };
         if ret.is_null() {
             Err(IoError::last_os_error())
@@ -529,8 +559,10 @@ unsafe extern "C" fn dispatch_func<R: Resource, H: Handler<R>>(_impl: *const c_v
                                                                -> c_int {
     // sanity check, if it triggers, it is a bug
     if _impl != &RUST_MANAGED as *const _ as *const _ {
-        let _ = write!(::std::io::stderr(),
-                       "[wayland-client error] Dispatcher got called for a message on a non-managed object.");
+        let _ = write!(
+            ::std::io::stderr(),
+            "[wayland-client error] Dispatcher got called for a message on a non-managed object."
+        );
         ::libc::abort();
     }
     // We don't need to worry about panic-safeness, because if there is a panic,
@@ -540,14 +572,18 @@ unsafe extern "C" fn dispatch_func<R: Resource, H: Handler<R>>(_impl: *const c_v
         // can only be assigned to a single EventQueue.
         // (this is actually the whole point of the design of this lib)
         let resource = R::from_ptr_initialized(resource as *mut wl_resource);
-        let data = &mut *(ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                                        wl_resource_get_user_data,
-                                        resource.ptr()) as *mut ResourceUserData);
+        let data = &mut *(ffi_dispatch!(
+            WAYLAND_SERVER_HANDLE,
+            wl_resource_get_user_data,
+            resource.ptr()
+        ) as *mut ResourceUserData);
         let evqhandle = &mut *data.0;
         let handler = &mut *(data.1 as *mut H);
-        let client = Client::from_ptr(ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                                                    wl_resource_get_client,
-                                                    resource.ptr()));
+        let client = Client::from_ptr(ffi_dispatch!(
+            WAYLAND_SERVER_HANDLE,
+            wl_resource_get_client,
+            resource.ptr()
+        ));
         handler.message(evqhandle, &client, &resource, opcode, args)
     });
     match ret {
@@ -563,9 +599,11 @@ unsafe extern "C" fn dispatch_func<R: Resource, H: Handler<R>>(_impl: *const c_v
         }
         Err(_) => {
             // a panic occured
-            let _ = write!(::std::io::stderr(),
-                           "[wayland-server error] A handler for {} panicked, aborting.",
-                           R::interface_name());
+            let _ = write!(
+                ::std::io::stderr(),
+                "[wayland-server error] A handler for {} panicked, aborting.",
+                R::interface_name()
+            );
             ::libc::abort();
         }
     }
@@ -579,12 +617,14 @@ unsafe extern "C" fn global_bind<R: Resource, H: GlobalHandler<R>>(client: *mut 
         let handler = &mut *data.0;
         let evqhandle = &mut *data.1;
         let client = Client::from_ptr(client);
-        let ptr = ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                                wl_resource_create,
-                                client.ptr(),
-                                R::interface_ptr(),
-                                version as i32, // wayland already checks the validity of the version
-                                id);
+        let ptr = ffi_dispatch!(
+            WAYLAND_SERVER_HANDLE,
+            wl_resource_create,
+            client.ptr(),
+            R::interface_ptr(),
+            version as i32, // wayland already checks the validity of the version
+            id
+        );
         let resource = R::from_ptr_new(ptr as *mut wl_resource);
         handler.bind(evqhandle, &client, resource)
     });
@@ -592,9 +632,11 @@ unsafe extern "C" fn global_bind<R: Resource, H: GlobalHandler<R>>(client: *mut 
         Ok(()) => (),   // all went well
         Err(_) => {
             // a panic occured
-            let _ = write!(::std::io::stderr(),
-                           "[wayland-server error] A global handler for {} panicked, aborting.",
-                           R::interface_name());
+            let _ = write!(
+                ::std::io::stderr(),
+                "[wayland-server error] A global handler for {} panicked, aborting.",
+                R::interface_name()
+            );
             ::libc::abort();
         }
     }
@@ -610,12 +652,15 @@ unsafe extern "C" fn resource_destroy<R: Resource, D: Destroy<R>>(resource: *mut
     let resource = R::from_ptr_initialized(resource as *mut wl_resource);
     if resource.status() == ::Liveness::Alive {
         // mark the resource as dead
-        let data = &mut *(ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                                        wl_resource_get_user_data,
-                                        resource.ptr()) as *mut ResourceUserData);
-        (data.2)
-            .0
-            .store(false, ::std::sync::atomic::Ordering::SeqCst);
+        let data = &mut *(ffi_dispatch!(
+            WAYLAND_SERVER_HANDLE,
+            wl_resource_get_user_data,
+            resource.ptr()
+        ) as *mut ResourceUserData);
+        (data.2).0.store(
+            false,
+            ::std::sync::atomic::Ordering::SeqCst,
+        );
     }
     D::destroy(&resource);
 }

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -200,10 +200,9 @@ mod event_sources;
 
 pub mod sources {
     //! Secondary event sources
-    //!
-    //! This module contains the types & traits to work with
-    //! different kind of event sources that can be registered to and
-    //! event loop, other than the wayland protocol sockets.
+    // This module contains the types & traits to work with
+    // different kind of event sources that can be registered to and
+    // event loop, other than the wayland protocol sockets.
 
     pub use event_sources::{FdEventSource, FdEventSourceHandler};
     pub use event_sources::{FdInterest, READ, WRITE};
@@ -277,11 +276,13 @@ pub trait Resource {
         // be truncated at this point.
         unsafe {
             let cstring = ::std::ffi::CString::from_vec_unchecked(msg.into());
-            ffi_dispatch!(WAYLAND_SERVER_HANDLE,
-                          wl_resource_post_error,
-                          self.ptr(),
-                          error_code,
-                          cstring.as_ptr())
+            ffi_dispatch!(
+                WAYLAND_SERVER_HANDLE,
+                wl_resource_post_error,
+                self.ptr(),
+                error_code,
+                cstring.as_ptr()
+            )
         }
     }
     /// Clone this resource handle
@@ -289,7 +290,8 @@ pub trait Resource {
     /// Will only succeed if the resource is managed by this library and
     /// is still alive.
     fn clone(&self) -> Option<Self>
-        where Self: Sized
+    where
+        Self: Sized,
     {
         if self.status() == Liveness::Alive {
             Some(unsafe { self.clone_unchecked() })
@@ -304,7 +306,8 @@ pub trait Resource {
     /// has no knowledge of its lifetime, and cannot ensure that the new handle
     /// will not outlive the object.
     unsafe fn clone_unchecked(&self) -> Self
-        where Self: Sized
+    where
+        Self: Sized,
     {
         // TODO: this can be more optimized with codegen help, but would be a
         // breaking change, so do it at next breaking release
@@ -353,7 +356,7 @@ pub unsafe trait Handler<T: Resource> {
 }
 
 /// Represents the state of liveness of a wayland object
-#[derive(Copy,Clone,PartialEq,Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum Liveness {
     /// This object is alive and events can be sent to it
     Alive,
@@ -372,21 +375,19 @@ mod generated {
 
     pub mod interfaces {
         //! Interfaces for the core protocol
-        //!
-        //! You might need them for the bindings generated for protocol extensions
+        // You might need them for the bindings generated for protocol extensions
         include!(concat!(env!("OUT_DIR"), "/wayland_interfaces.rs"));
     }
 
     pub mod server {
         //! The wayland core protocol
-        //!
-        //! This module contains all objects of the core wayland protocol.
-        //!
-        //! It has been generated from the `wayland.xml` protocol file
-        //! using `wayland_scanner`.
-        //! Imports that need to be available to submodules
-        //! but should not be in public API.
-        //! Will be fixable with pub(restricted).
+        // This module contains all objects of the core wayland protocol.
+        //
+        // It has been generated from the `wayland.xml` protocol file
+        // using `wayland_scanner`.
+        // Imports that need to be available to submodules
+        // but should not be in public API.
+        // Will be fixable with pub(restricted).
 
         #[doc(hidden)]
         pub use super::interfaces;

--- a/wayland-sys/src/client.rs
+++ b/wayland-sys/src/client.rs
@@ -85,7 +85,11 @@ lazy_static!(
             Ok(h) => Some(h),
             Err(::dlib::DlError::NotFound) => None,
             Err(::dlib::DlError::MissingSymbol(s)) => {
-                panic!("Found library libwayland-client.so but symbol {} is missing.", s);
+                use std::io::Write;
+                let _ = write!(::std::io::stderr(),
+                               "[wayland-client] Found library libwayland-client.so cannot be used: symbol {} is missing.",
+                               s);
+                None
             }
         }
     };

--- a/wayland-sys/src/server.rs
+++ b/wayland-sys/src/server.rs
@@ -129,7 +129,11 @@ lazy_static!(
             Ok(h) => Some(h),
             Err(::dlib::DlError::NotFound) => None,
             Err(::dlib::DlError::MissingSymbol(s)) => {
-                panic!("Found library libwayland-server.so but symbol {} is missing.", s);
+                use std::io::Write;
+                let _ = write!(::std::io::stderr(),
+                               "[wayland-server] Found library libwayland-server.so cannot be used: symbol {} is missing.",
+                               s);
+                None
             }
         }
     };


### PR DESCRIPTION
- `cargo test --all` in travis
- Fixes #118 
- Add the ability to use `declare_handler!()` macro and its friends on types with type parameters to make generic implementations (this will help remove some cryptic unsafe impls from downstream crates)