### PR TITLE
sys: hide debug messages behind env variable

### DIFF
--- a/wayland-sys/src/client.rs
+++ b/wayland-sys/src/client.rs
@@ -85,10 +85,10 @@ lazy_static!(
             Ok(h) => Some(h),
             Err(::dlib::DlError::NotFound) => None,
             Err(::dlib::DlError::MissingSymbol(s)) => {
-                use std::io::Write;
-                let _ = write!(::std::io::stderr(),
-                               "[wayland-client] Found library libwayland-client.so cannot be used: symbol {} is missing.",
-                               s);
+                if ::std::env::var_os("WAYLAND_RS_DEBUG").is_some() {
+                    // only print debug messages if WAYLAND_RS_DEBUG is set
+                    eprintln!("[wayland-client] Found library libwayland-client.so cannot be used: symbol {} is missing.", s);
+                }
                 None
             }
         }

--- a/wayland-sys/src/server.rs
+++ b/wayland-sys/src/server.rs
@@ -139,10 +139,10 @@ lazy_static!(
             Ok(h) => Some(h),
             Err(::dlib::DlError::NotFound) => None,
             Err(::dlib::DlError::MissingSymbol(s)) => {
-                use std::io::Write;
-                let _ = write!(::std::io::stderr(),
-                               "[wayland-server] Found library libwayland-server.so cannot be used: symbol {} is missing.",
-                               s);
+                if ::std::env::var_os("WAYLAND_RS_DEBUG").is_some() {
+                    // only print debug messages if WAYLAND_RS_DEBUG is set
+                    eprintln!("[wayland-server] Found library libwayland-server.so cannot be used: symbol {} is missing.", s);
+                }
                 None
             }
         }


### PR DESCRIPTION
Debug messages about missing symbols will now only be
displayed if the env variable WAYLAND_RS_DEBUG is set.

(the actual value does not matter)

Fixes #127