### PR TITLE
Added a workaround when using dlopen on Ubuntu 17.04

### DIFF
--- a/wayland-sys/src/client.rs
+++ b/wayland-sys/src/client.rs
@@ -90,21 +90,20 @@ lazy_static!(
         let versions = ["libwayland-client.so",
                         "libwayland-client.so.0",
                         "libwayland-client.so.0.3.0"];
-        let mut ret = None;
         for ver in &versions {
             match WaylandClient::open(ver) {
-                Ok(h) => ret = Some(h),
+                Ok(h) => return Some(h),
                 Err(::dlib::DlError::NotFound) => continue,
                 Err(::dlib::DlError::MissingSymbol(s)) => {
                     if ::std::env::var_os("WAYLAND_RS_DEBUG").is_some() {
                         // only print debug messages if WAYLAND_RS_DEBUG is set
                         eprintln!("[wayland-client] Found library {} cannot be used: symbol {} is missing.", ver, s);
                     }
+                    return None;
                 }
             }
-            break;
         }
-        ret
+        None
     };
     pub static ref WAYLAND_CLIENT_HANDLE: &'static WaylandClient = {
         WAYLAND_CLIENT_OPTION.as_ref().expect("Library libwayland-client.so could not be loaded.")

--- a/wayland-sys/src/client.rs
+++ b/wayland-sys/src/client.rs
@@ -88,8 +88,7 @@ lazy_static!(
         // We could do some trickery with str slices but that is more trouble
         // than its worth
         let versions = ["libwayland-client.so",
-                        "libwayland-client.so.0",
-                        "libwayland-client.so.0.3.0"];
+                        "libwayland-client.so.0"];
         for ver in &versions {
             match WaylandClient::open(ver) {
                 Ok(h) => return Some(h),

--- a/wayland-sys/src/server.rs
+++ b/wayland-sys/src/server.rs
@@ -142,8 +142,7 @@ lazy_static!(
         // We could do some trickery with str slices but that is more trouble
         // than its worth
         let versions = ["libwayland-server.so",
-                        "libwayland-server.so.0",
-                        "libwayland-server.so.0.1.0"];
+                        "libwayland-server.so.0"];
         for ver in &versions {
             match WaylandServer::open(ver) {
                 Ok(h) => return Some(h),

--- a/wayland-sys/src/server.rs
+++ b/wayland-sys/src/server.rs
@@ -144,21 +144,20 @@ lazy_static!(
         let versions = ["libwayland-server.so",
                         "libwayland-server.so.0",
                         "libwayland-server.so.0.1.0"];
-        let mut ret = None;
         for ver in &versions {
             match WaylandServer::open(ver) {
-                Ok(h) => ret = Some(h),
+                Ok(h) => return Some(h),
                 Err(::dlib::DlError::NotFound) => continue,
                 Err(::dlib::DlError::MissingSymbol(s)) => {
                     if ::std::env::var_os("WAYLAND_RS_DEBUG").is_some() {
                         // only print debug messages if WAYLAND_RS_DEBUG is set
                         eprintln!("[wayland-server] Found library {} cannot be used: symbol {} is missing.", ver, s);
                     }
+                    return None;
                 }
             }
-            break;
         }
-        ret
+        None
     };
     pub static ref WAYLAND_SERVER_HANDLE: &'static WaylandServer = {
         WAYLAND_SERVER_OPTION.as_ref().expect("Library libwayland-server.so could not be loaded.")


### PR DESCRIPTION
This adds a maintenance overhead of making sure the listed
`libwayland-{client, server}.so` versions are correct for our current
target unfortunately but should also be completely backwards compatible
as it will still try the "bare" version first and only try the others if
it can not find that one.

Fixes #139