### PR TITLE
Fixed incorrect print statement.

### DIFF
--- a/wayland-sys/src/client.rs
+++ b/wayland-sys/src/client.rs
@@ -96,7 +96,7 @@ lazy_static!(
                 Err(::dlib::DlError::MissingSymbol(s)) => {
                     if ::std::env::var_os("WAYLAND_RS_DEBUG").is_some() {
                         // only print debug messages if WAYLAND_RS_DEBUG is set
-                        eprintln!("[wayland-client] Found library {} cannot be used: symbol {} is missing.", ver, s);
+                        println!("[wayland-client] Found library {} cannot be used: symbol {} is missing.", ver, s);
                     }
                     return None;
                 }


### PR DESCRIPTION
Hey, I have very limited knowledge about wayland-sys, however I found this quite obvious bug today, when trying to compile your lib.

```
error: cannot find macro `eprintln!` in this scope
  --> /home/pgolab/.cargo/registry/src/github.com-1ecc6299db9ec823/wayland-sys-0.9.10/src/client.rs:99:25
   |
99 |                         eprintln!("[wayland-client] Found library {} cannot be used: symbol {} is missing.", ver, s);
   |                         ^^^^^^^^
   |
   = help: did you mean `println!`?

error: aborting due to previous error

```

 Wayland-rs was a dependency to the piston_window = "0.70.0" and it prevented me from compiling it. 

Could you please take look at this and review?

