### PR TITLE
[breaking] Event loop rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 *.rs.bk
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ branches:
 
 before_script:
   - export PATH=$HOME/.local/bin:$HOME/.cargo/bin:$PATH
-  - which rustfmt || cargo install rustfmt
   - which mdbook || cargo install mdbook
   - which cargo-tarpaulin || cargo install cargo-tarpaulin
   - which cargo-install-update || cargo install cargo-update
@@ -35,12 +34,13 @@ before_script:
   - pip install 'travis-cargo<0.2' --user
   - mkdir $(pwd)/socket
   - export XDG_RUNTIME_DIR="$(pwd)/socket"
+  - travis-cargo --only nightly install rustfmt-nightly -- --force
 
 os:
   - linux
 
 script:
-  - cargo fmt --all -- --write-mode=diff
+  - travis-cargo --only nightly fmt -- --all -- --write-mode=diff
   - cargo build --all --all-features
   - cargo test
   - cargo doc --all --no-deps --all-features

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ after_success:
 
 env:
   global:
+    - TRAVIS_CARGO_NIGHTLY_FEATURE=""
     - secure: A/zuPuIu03Z+rqnDS/NNNjbXrg8Nc9lEGKzcBdpHgnyd23z37zreEEAKzFhjJKMx0np0ntDo5LVeLgT6d7fGaDFsJrBZHej3pxuG81MAJdLEmJNaCLCc1eCbwDHgJkEJ5HsblHTrYK0RjBvNL5I8+URuzEqXkwVr7UHJv5px1ZA=
 
 notifications:

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -12,9 +12,9 @@ pub struct TestServer {
 impl TestServer {
     pub fn new() -> TestServer {
         let (mut display, event_loop) = ::ways::create_display();
-        let socket_name = display.add_socket_auto().expect(
-            "Failed to create a server socket.",
-        );
+        let socket_name = display
+            .add_socket_auto()
+            .expect("Failed to create a server socket.");
 
         TestServer {
             display: display,

--- a/tests/scanner.rs
+++ b/tests/scanner.rs
@@ -1,11 +1,10 @@
-extern crate wayland_scanner;
 extern crate difference;
+extern crate wayland_scanner;
 
 
 use difference::{Changeset, Difference};
 use std::io::Cursor;
 use std::str::from_utf8;
-
 use wayland_scanner::Side;
 
 const PROTOCOL: &'static str = include_str!("./scanner_assets/protocol.xml");
@@ -20,21 +19,15 @@ fn print_diff(diffs: &[Difference]) {
     println!("");
     for d in diffs {
         match *d {
-            Difference::Same(ref x) => {
-                for l in x.lines() {
-                    println!("   {}", l);
-                }
-            }
-            Difference::Add(ref x) => {
-                for l in x.lines() {
-                    println!("\x1b[92m + {}\x1b[0m", l);
-                }
-            }
-            Difference::Rem(ref x) => {
-                for l in x.lines() {
-                    println!("\x1b[91m - {}\x1b[0m", l);
-                }
-            }
+            Difference::Same(ref x) => for l in x.lines() {
+                println!("   {}", l);
+            },
+            Difference::Add(ref x) => for l in x.lines() {
+                println!("\x1b[92m + {}\x1b[0m", l);
+            },
+            Difference::Rem(ref x) => for l in x.lines() {
+                println!("\x1b[91m - {}\x1b[0m", l);
+            },
         }
     }
 }
@@ -42,8 +35,7 @@ fn print_diff(diffs: &[Difference]) {
 fn only_newlines_err(diffs: &[Difference]) -> bool {
     for d in diffs {
         match *d {
-            Difference::Add(_) |
-            Difference::Rem(_) => return false,
+            Difference::Add(_) | Difference::Rem(_) => return false,
             _ => {}
         }
     }

--- a/tests/scanner_assets/server_code.rs
+++ b/tests/scanner_assets/server_code.rs
@@ -17,7 +17,7 @@ pub mod wl_foo {
     use super::EventLoopHandle;
     use super::Resource;
     use super::EventResult;
-    use super::Liveness;
+    use super::{Liveness, Implementable};
     use super::interfaces::*;
     use wayland_sys::common::*;
     use std::any::Any;
@@ -37,13 +37,13 @@ pub mod wl_foo {
     unsafe impl Send for WlFoo {}
     unsafe impl Sync for WlFoo {}
 
-    impl Resource for WlFoo {
+    unsafe impl Resource for WlFoo {
         fn ptr(&self) -> *mut wl_resource { self.ptr }
 
         unsafe fn from_ptr_new(ptr: *mut wl_resource) -> WlFoo {
             let data = Box::into_raw(Box::new((
                 ptr::null_mut::<c_void>(),
-                ptr::null_mut::<c_void>(),
+                Option::None::<Box<Any>>,
                 Arc::new((AtomicBool::new(true), AtomicPtr::new(ptr::null_mut())))
             )));
             ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_set_user_data, ptr, data as *mut c_void);
@@ -57,7 +57,7 @@ pub mod wl_foo {
 
 
             if rust_managed {
-                let data = ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_get_user_data, ptr) as *mut (*mut c_void, *mut c_void, Arc<(AtomicBool, AtomicPtr<()>)>);
+                let data = ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_get_user_data, ptr) as *mut (*mut c_void, Option<Box<Any>>, Arc<(AtomicBool, AtomicPtr<()>)>);
                 WlFoo { ptr: ptr, data: Some((&*data).2.clone()) }
             } else {
                 WlFoo { ptr: ptr, data: Option::None }
@@ -95,6 +95,47 @@ pub mod wl_foo {
             } else {
                 ::std::ptr::null_mut()
             }
+        }
+        unsafe fn clone_unchecked(&self) -> WlFoo {
+            WlFoo {
+                ptr: self.ptr,
+                data: self.data.clone()
+            }
+        }
+    }
+    unsafe impl<ID: 'static> Implementable<ID> for WlFoo {
+        type Implementation = Implementation<ID>;
+        #[allow(unused_mut,unused_assignments)]
+        unsafe fn __dispatch_msg(&self, client: &Client, opcode: u32, args: *const wl_argument) -> Result<(),()> {
+
+        let data: &mut (*mut EventLoopHandle, Option<Box<Any>>, Arc<(AtomicBool, AtomicPtr<()>)>) =
+            &mut *(ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_resource_get_user_data, self.ptr()) as *mut _);
+        let evq = &mut *(data.0);
+        let mut kill = false;
+        {
+            let &mut (ref implementation, ref mut idata) = data.1.as_mut().unwrap().downcast_mut::<(Implementation<ID>, ID)>().unwrap();
+            match opcode {
+                0 => {
+                    let number = {*(args.offset(0) as *const i32)};
+                    let unumber = {*(args.offset(1) as *const u32)};
+                    let text = {String::from_utf8_lossy(CStr::from_ptr(*(args.offset(2) as *const *const _)).to_bytes()).into_owned()};
+                    let float = {wl_fixed_to_double(*(args.offset(3) as *const i32))};
+                    let file = {*(args.offset(4) as *const i32)};
+                    (implementation.foo_it)(evq, idata, client, self, number, unumber, text, float, file);
+                },
+                1 => {
+                    let id = {Resource::from_ptr_new(ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_create, client.ptr(), <super::wl_bar::WlBar as Resource>::interface_ptr(), self.version(), *(args.offset(0) as *const u32)))};
+                    (implementation.create_bar)(evq, idata, client, self, id);
+                },
+                _ => return Err(())
+            }
+        }
+
+        if kill {
+            let _impl = data.1.take();
+            ::std::mem::drop(_impl);
+        }
+            Ok(())
         }
     }
 
@@ -139,35 +180,33 @@ pub mod wl_foo {
         }
     }
 
-    pub trait Handler {
+    pub struct Implementation<ID> {
         /// do some foo
         ///
         /// This will do some foo with its args.
-        fn foo_it(&mut self, evqh: &mut EventLoopHandle, client: &Client,  resource: &WlFoo, number: i32, unumber: u32, text: String, float: f64, file: ::std::os::unix::io::RawFd) {}
-
+        ///
+        /// **Arguments:** event_queue_handle, interface_data, wl_foo, number, unumber, text, float, file
+        pub foo_it: fn(evqh: &mut EventLoopHandle, data: &mut ID, client: &Client,  wl_foo: &WlFoo, number: i32, unumber: u32, text: String, float: f64, file: ::std::os::unix::io::RawFd),
         /// create a bar
         ///
         /// Create a bar which will do its bar job.
-        fn create_bar(&mut self, evqh: &mut EventLoopHandle, client: &Client,  resource: &WlFoo, id: super::wl_bar::WlBar) {}
+        ///
+        /// **Arguments:** event_queue_handle, interface_data, wl_foo, id
+        pub create_bar: fn(evqh: &mut EventLoopHandle, data: &mut ID, client: &Client,  wl_foo: &WlFoo, id: super::wl_bar::WlBar),
+    }
+    impl<ID> Copy for Implementation<ID> {}
+    impl<ID> Clone for Implementation<ID> {
+        fn clone(&self) -> Implementation<ID> {
+            *self
+        }
+    }
 
-        #[doc(hidden)]
-        unsafe fn __message(&mut self, evq: &mut EventLoopHandle, client: &Client, proxy: &WlFoo, opcode: u32, args: *const wl_argument) -> Result<(),()> {
-            match opcode {
-                0 => {
-                    let number = {*(args.offset(0) as *const i32)};
-                    let unumber = {*(args.offset(1) as *const u32)};
-                    let text = {String::from_utf8_lossy(CStr::from_ptr(*(args.offset(2) as *const *const _)).to_bytes()).into_owned()};
-                    let float = {wl_fixed_to_double(*(args.offset(3) as *const i32))};
-                    let file = {*(args.offset(4) as *const i32)};
-                    self.foo_it(evq, client, proxy, number, unumber, text, float, file);
-                },
-                1 => {
-                    let id = {Resource::from_ptr_new(ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_create, client.ptr(), <super::wl_bar::WlBar as Resource>::interface_ptr(), proxy.version(), *(args.offset(0) as *const u32)))};
-                    self.create_bar(evq, client, proxy, id);
-                },
-                _ => return Err(())
-            }
-            Ok(())
+    impl<ID> PartialEq for Implementation<ID> {
+        fn eq(&self, other: &Implementation<ID>) -> bool {
+            true
+            && (self.foo_it as usize == other.foo_it as usize)
+            && (self.create_bar as usize == other.create_bar as usize)
+
         }
     }
 
@@ -196,7 +235,7 @@ pub mod wl_bar {
     use super::Resource;
     use super::EventResult;
 
-    use super::Liveness;
+    use super::{Liveness, Implementable};
     use super::interfaces::*;
     use wayland_sys::common::*;
     use std::any::Any;
@@ -216,13 +255,13 @@ pub mod wl_bar {
     unsafe impl Send for WlBar {}
     unsafe impl Sync for WlBar {}
 
-    impl Resource for WlBar {
+    unsafe impl Resource for WlBar {
         fn ptr(&self) -> *mut wl_resource { self.ptr }
 
         unsafe fn from_ptr_new(ptr: *mut wl_resource) -> WlBar {
             let data = Box::into_raw(Box::new((
                 ptr::null_mut::<c_void>(),
-                ptr::null_mut::<c_void>(),
+                Option::None::<Box<Any>>,
                 Arc::new((AtomicBool::new(true), AtomicPtr::new(ptr::null_mut())))
             )));
             ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_set_user_data, ptr, data as *mut c_void);
@@ -236,7 +275,7 @@ pub mod wl_bar {
 
 
             if rust_managed {
-                let data = ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_get_user_data, ptr) as *mut (*mut c_void, *mut c_void, Arc<(AtomicBool, AtomicPtr<()>)>);
+                let data = ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_get_user_data, ptr) as *mut (*mut c_void, Option<Box<Any>>, Arc<(AtomicBool, AtomicPtr<()>)>);
                 WlBar { ptr: ptr, data: Some((&*data).2.clone()) }
             } else {
                 WlBar { ptr: ptr, data: Option::None }
@@ -275,45 +314,84 @@ pub mod wl_bar {
                 ::std::ptr::null_mut()
             }
         }
+        unsafe fn clone_unchecked(&self) -> WlBar {
+            WlBar {
+                ptr: self.ptr,
+                data: self.data.clone()
+            }
+        }
     }
 
-    pub trait Handler {
-        /// ask for a bar delivery
-        ///
-        /// Proceed to a bar delivery of given foo.
-        ///
-        /// This event only exists since version 2 of the interface
-        fn bar_delivery(&mut self, evqh: &mut EventLoopHandle, client: &Client,  resource: &WlBar, kind: super::wl_foo::DeliveryKind, target: &super::wl_foo::WlFoo, metadata: Vec<u8>) {}
+    unsafe impl<ID: 'static> Implementable<ID> for WlBar {
+        type Implementation = Implementation<ID>;
+        #[allow(unused_mut,unused_assignments)]
+        unsafe fn __dispatch_msg(&self, client: &Client, opcode: u32, args: *const wl_argument) -> Result<(),()> {
 
-        /// release this bar
-        ///
-        /// Notify the compositor that you have finished using this bar.
-        ///
-        /// This is a destructor, you cannot send events to this object once this method is called.
-        fn release(&mut self, evqh: &mut EventLoopHandle, client: &Client,  resource: &WlBar) {}
-
-        #[doc(hidden)]
-        unsafe fn __message(&mut self, evq: &mut EventLoopHandle, client: &Client, proxy: &WlBar, opcode: u32, args: *const wl_argument) -> Result<(),()> {
+        let data: &mut (*mut EventLoopHandle, Option<Box<Any>>, Arc<(AtomicBool, AtomicPtr<()>)>) =
+            &mut *(ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_resource_get_user_data, self.ptr()) as *mut _);
+        let evq = &mut *(data.0);
+        let mut kill = false;
+        {
+            let &mut (ref implementation, ref mut idata) = data.1.as_mut().unwrap().downcast_mut::<(Implementation<ID>, ID)>().unwrap();
             match opcode {
                 0 => {
                     let kind = {match super::wl_foo::DeliveryKind::from_raw(*(args.offset(0) as *const u32)) { Some(v) => v, Option::None => return Err(()) }};
                     let target = {Resource::from_ptr_initialized(*(args.offset(1) as *const *mut wl_resource))};
                     let metadata = {let array = *(args.offset(2) as *const *mut wl_array); ::std::slice::from_raw_parts((*array).data as *const u8, (*array).size as usize).to_owned()};
-                    self.bar_delivery(evq, client, proxy, kind, &target, metadata);
+                    (implementation.bar_delivery)(evq, idata, client, self, kind, &target, metadata);
                 },
                 1 => {
 
-                if let Some(ref data) = proxy.data {
-                    data.0.store(false, ::std::sync::atomic::Ordering::SeqCst);
-                }
-                ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_destroy, proxy.ptr());
-                    self.release(evq, client, proxy);
+                (data.2).0.store(false, ::std::sync::atomic::Ordering::SeqCst);
+                kill = true;
+                ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_destroy, self.ptr());
+                    (implementation.release)(evq, idata, client, self);
                 },
                 _ => return Err(())
             }
-            Ok(())
         }
 
+        if kill {
+            let _impl = data.1.take();
+            ::std::mem::drop(_impl);
+        }
+            Ok(())
+        }
+    }
+
+    pub struct Implementation<ID> {
+        /// ask for a bar delivery
+        ///
+        /// Proceed to a bar delivery of given foo.
+        ///
+        /// **Arguments:** event_queue_handle, interface_data, wl_bar, kind, target, metadata
+        ///
+        /// This event only exists since version 2 of the interface
+        pub bar_delivery: fn(evqh: &mut EventLoopHandle, data: &mut ID, client: &Client,  wl_bar: &WlBar, kind: super::wl_foo::DeliveryKind, target: &super::wl_foo::WlFoo, metadata: Vec<u8>),
+        /// release this bar
+        ///
+        /// Notify the compositor that you have finished using this bar.
+        ///
+        /// **Arguments:** event_queue_handle, interface_data, wl_bar
+        ///
+        /// This is a destructor, you cannot send events to this object once this method is called.
+        pub release: fn(evqh: &mut EventLoopHandle, data: &mut ID, client: &Client,  wl_bar: &WlBar),
+    }
+
+    impl<ID> Copy for Implementation<ID> {}
+    impl<ID> Clone for Implementation<ID> {
+        fn clone(&self) -> Implementation<ID> {
+            *self
+        }
+    }
+
+    impl<ID> PartialEq for Implementation<ID> {
+        fn eq(&self, other: &Implementation<ID>) -> bool {
+            true
+            && (self.bar_delivery as usize == other.bar_delivery as usize)
+            && (self.release as usize == other.release as usize)
+
+        }
     }
 
     impl WlBar {
@@ -328,7 +406,7 @@ pub mod wl_callback {
     use super::EventLoopHandle;
     use super::Resource;
     use super::EventResult;
-    use super::Liveness;
+    use super::{Liveness, Implementable};
     use super::interfaces::*;
     use wayland_sys::common::*;
     use std::any::Any;
@@ -347,13 +425,13 @@ pub mod wl_callback {
 
     unsafe impl Send for WlCallback {}
     unsafe impl Sync for WlCallback {}
-    impl Resource for WlCallback {
+    unsafe impl Resource for WlCallback {
         fn ptr(&self) -> *mut wl_resource { self.ptr }
 
         unsafe fn from_ptr_new(ptr: *mut wl_resource) -> WlCallback {
             let data = Box::into_raw(Box::new((
                 ptr::null_mut::<c_void>(),
-                ptr::null_mut::<c_void>(),
+                Option::None::<Box<Any>>,
                 Arc::new((AtomicBool::new(true), AtomicPtr::new(ptr::null_mut())))
             )));
             ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_set_user_data, ptr, data as *mut c_void);
@@ -366,7 +444,7 @@ pub mod wl_callback {
             ) != 0;
 
             if rust_managed {
-                let data = ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_get_user_data, ptr) as *mut (*mut c_void, *mut c_void, Arc<(AtomicBool, AtomicPtr<()>)>);
+                let data = ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_get_user_data, ptr) as *mut (*mut c_void, Option<Box<Any>>, Arc<(AtomicBool, AtomicPtr<()>)>);
                 WlCallback { ptr: ptr, data: Some((&*data).2.clone()) }
             } else {
                 WlCallback { ptr: ptr, data: Option::None }
@@ -404,6 +482,12 @@ pub mod wl_callback {
                 data.1.load(Ordering::SeqCst)
             } else {
                 ::std::ptr::null_mut()
+            }
+        }
+        unsafe fn clone_unchecked(&self) -> WlCallback {
+            WlCallback {
+                ptr: self.ptr,
+                data: self.data.clone()
             }
         }
     }

--- a/tests/scanner_assets/server_code.rs
+++ b/tests/scanner_assets/server_code.rs
@@ -109,7 +109,7 @@ pub mod wl_foo {
         unsafe fn __dispatch_msg(&self, client: &Client, opcode: u32, args: *const wl_argument) -> Result<(),()> {
 
         let data: &mut (*mut EventLoopHandle, Option<Box<Any>>, Arc<(AtomicBool, AtomicPtr<()>)>) =
-            &mut *(ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_resource_get_user_data, self.ptr()) as *mut _);
+            &mut *(ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_get_user_data, self.ptr()) as *mut _);
         let evq = &mut *(data.0);
         let mut kill = false;
         {
@@ -328,7 +328,7 @@ pub mod wl_bar {
         unsafe fn __dispatch_msg(&self, client: &Client, opcode: u32, args: *const wl_argument) -> Result<(),()> {
 
         let data: &mut (*mut EventLoopHandle, Option<Box<Any>>, Arc<(AtomicBool, AtomicPtr<()>)>) =
-            &mut *(ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_resource_get_user_data, self.ptr()) as *mut _);
+            &mut *(ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_get_user_data, self.ptr()) as *mut _);
         let evq = &mut *(data.0);
         let mut kill = false;
         {

--- a/tests/skel.rs
+++ b/tests/skel.rs
@@ -3,7 +3,7 @@ extern crate wayland_server as ways;
 
 mod helpers;
 
-use helpers::{TestClient, TestServer, roundtrip};
+use helpers::{roundtrip, TestClient, TestServer};
 
 #[test]
 fn skel() {

--- a/wayland-client/build.rs
+++ b/wayland-client/build.rs
@@ -2,8 +2,7 @@ extern crate wayland_scanner;
 
 use std::env::var;
 use std::path::Path;
-
-use wayland_scanner::{Side, generate_code, generate_interfaces};
+use wayland_scanner::{generate_code, generate_interfaces, Side};
 
 fn main() {
     let protocol_file = "./wayland.xml";

--- a/wayland-client/examples/simple_client.rs
+++ b/wayland-client/examples/simple_client.rs
@@ -11,16 +11,15 @@ fn main() {
         Err(e) => panic!("Cannot connect to wayland server: {:?}", e),
     };
 
-    event_queue.add_handler(EnvHandler::<WaylandEnv>::new());
-
     let registry = display.get_registry();
-    event_queue.register::<_, EnvHandler<WaylandEnv>>(&registry, 0);
+
+    let env_token = EnvHandler::<WaylandEnv>::init(&mut event_queue, &registry);
 
     event_queue.sync_roundtrip().unwrap();
 
     let state = event_queue.state();
 
-    let env = state.get_handler::<EnvHandler<WaylandEnv>>(0);
+    let env = state.get(&env_token);
 
     println!("Globals advertised by server:");
     for &(name, ref interface, version) in env.globals() {

--- a/wayland-client/src/cursor.rs
+++ b/wayland-client/src/cursor.rs
@@ -23,7 +23,6 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::os::raw::c_int;
 use std::ptr;
-
 use wayland_sys::cursor::*;
 
 /// Checks if the wayland-cursor lib is available and can be used

--- a/wayland-client/src/display.rs
+++ b/wayland-client/src/display.rs
@@ -1,12 +1,9 @@
 use Proxy;
-
-use event_queue::{EventQueue, create_event_queue};
+use event_queue::{create_event_queue, EventQueue};
 use generated::client::wl_display::WlDisplay;
 use std::ffi::{CStr, CString, OsStr};
-
 use std::io;
 use std::os::unix::ffi::OsStrExt;
-
 use wayland_sys::client::*;
 
 /// Enum representing the possible reasons why connecting to the wayland server failed
@@ -80,9 +77,7 @@ pub fn connect_to(name: &OsStr) -> Result<(WlDisplay, EventQueue), ConnectError>
     }
     // Only possible error is interior null, and in this case, no compositor will be listening to a socket
     // with null in its name.
-    let name = CString::new(name.as_bytes().to_owned()).map_err(|_| {
-        ConnectError::NoCompositorListening
-    })?;
+    let name = CString::new(name.as_bytes().to_owned()).map_err(|_| ConnectError::NoCompositorListening)?;
     let ptr = unsafe { ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_display_connect, name.as_ptr()) };
     if ptr.is_null() {
         Err(ConnectError::NoCompositorListening)

--- a/wayland-client/src/egl.rs
+++ b/wayland-client/src/egl.rs
@@ -11,7 +11,6 @@ use Proxy;
 use protocol::wl_surface::WlSurface;
 use std::os::raw::c_void;
 use wayland_sys::client::wl_proxy;
-
 use wayland_sys::egl::*;
 
 /// Checks if the wayland-egl lib is available and can be used

--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -1,17 +1,23 @@
-use {Handler, Proxy};
+use {Implementable, Proxy};
 use std::any::Any;
+use std::cell::Cell;
 use std::io::{Error as IoError, Result as IoResult};
 use std::io::Write;
+use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::os::raw::{c_int, c_void};
+use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicPtr};
 use wayland_sys::RUST_MANAGED;
-
 use wayland_sys::client::*;
 use wayland_sys::common::*;
 
-type ProxyUserData = (*mut EventQueueHandle, *mut c_void, Arc<(AtomicBool, AtomicPtr<()>)>);
+type ProxyUserData = (
+    *mut EventQueueHandle,
+    Option<Box<Any>>,
+    Arc<(AtomicBool, AtomicPtr<()>)>,
+);
 
 /// Status of a registration attempt of a proxy.
 pub enum RegisterStatus {
@@ -23,6 +29,102 @@ pub enum RegisterStatus {
     Dead,
 }
 
+/// A state store
+///
+/// This struct allows you to store various values in a special
+/// storage that will be made available to your proxy implementations.
+pub struct State {
+    values: Vec<Option<(Box<Any>, Rc<Cell<bool>>)>>,
+}
+
+/// A token for accessing the state store contents
+pub struct StateToken<V> {
+    id: usize,
+    live: Rc<Cell<bool>>,
+    _type: PhantomData<V>,
+}
+
+impl<V> Clone for StateToken<V> {
+    fn clone(&self) -> StateToken<V> {
+        StateToken {
+            id: self.id,
+            live: self.live.clone(),
+            _type: PhantomData,
+        }
+    }
+}
+
+impl State {
+    /// Insert a new value in this state store
+    ///
+    /// Returns a clonable token that you can later use to access this
+    /// value.
+    pub fn insert<V: Any + 'static>(&mut self, value: V) -> StateToken<V> {
+        let boxed = Box::new(value) as Box<Any>;
+        let live = Rc::new(Cell::new(true));
+        {
+            // artificial scope to make the borrow checker happy
+            let empty_slot = self.values
+                .iter_mut()
+                .enumerate()
+                .find(|&(_, ref s)| s.is_none());
+            if let Some((id, slot)) = empty_slot {
+                *slot = Some((boxed, live.clone()));
+                return StateToken {
+                    id: id,
+                    live: live,
+                    _type: PhantomData,
+                };
+            }
+        }
+        self.values.push(Some((boxed, live.clone())));
+        StateToken {
+            id: self.values.len() - 1,
+            live: live,
+            _type: PhantomData,
+        }
+    }
+
+    /// Access value previously inserted in this state store
+    ///
+    /// Panics if the provided token corresponds to a value that was removed.
+    pub fn get<V: Any + 'static>(&self, token: &StateToken<V>) -> &V {
+        if !token.live.get() {
+            panic!("Attempted to access a state value that was already removed!");
+        }
+        self.values[token.id]
+            .as_ref()
+            .and_then(|t| t.0.downcast_ref::<V>())
+            .unwrap()
+    }
+
+    /// Mutably access value previously inserted in this state store
+    ///
+    /// Panics if the provided token corresponds to a value that was removed.
+    pub fn get_mut<V: Any + 'static>(&mut self, token: &StateToken<V>) -> &mut V {
+        if !token.live.get() {
+            panic!("Attempted to access a state value that was already removed!");
+        }
+        self.values[token.id]
+            .as_mut()
+            .and_then(|t| t.0.downcast_mut::<V>())
+            .unwrap()
+    }
+
+    /// Remove a value previously inserted in this state store
+    ///
+    /// Panics if the provided token corresponds to a value that was already
+    /// removed.
+    pub fn remove<V: Any + 'static>(&mut self, token: StateToken<V>) -> V {
+        if !token.live.get() {
+            panic!("Attempted to remove a state value that was already removed!");
+        }
+        let (boxed, live) = self.values[token.id].take().unwrap();
+        live.set(false);
+        *boxed.downcast().unwrap()
+    }
+}
+
 /// Handle to an event queue
 ///
 /// This handle gives you access to methods on an event queue
@@ -30,42 +132,31 @@ pub enum RegisterStatus {
 ///
 /// They are also available on an `EventQueue` object via `Deref`.
 pub struct EventQueueHandle {
-    handlers: Vec<Option<Box<Any + Send>>>,
+    state: State,
     wlevq: Option<*mut wl_event_queue>,
 }
 
-/// A trait to initialize handlers after they've been inserted in an event queue
-///
-/// Works with the `add_handler_with_init` method of `EventQueueHandle`.
-pub trait Init {
-    /// Init the handler
-    ///
-    /// `index` is the current index of the handler in the event queue (you can
-    /// use it to register objects to it)
-    fn init(&mut self, evqh: &mut EventQueueHandle, index: usize);
-}
-
 impl EventQueueHandle {
-    /// Register a proxy to a handler of this event queue.
+    /// Register a proxy to this event queue.
     ///
-    /// The H type must be provided and match the type of the targetted Handler, or
-    /// it will panic.
+    /// You are required to provide a valid implementation for this proxy
+    /// as well as some associated implementation data. This implementation
+    /// is expected to be a `static` struct holding the various relevant
+    /// function pointers.
     ///
-    /// This overwrites any precedently set Handler for this proxy.
+    /// This implementation data can typically contain indexes to state value
+    /// that the implementation will need to work on.
+    ///
+    /// This overwrites any precedently set implementation for this proxy.
     ///
     /// Returns appropriately and does nothing if this proxy is dead or already managed by
     /// something else than this library.
-    pub fn register<P, H>(&mut self, proxy: &P, handler_id: usize) -> RegisterStatus
+    pub fn register<P, ID>(&mut self, proxy: &P, implementation: P::Implementation, idata: ID)
+                           -> RegisterStatus
     where
-        P: Proxy,
-        H: Handler<P> + Any + Send + 'static,
+        P: Proxy + Implementable<ID>,
+        ID: 'static,
     {
-        let h = self.handlers[handler_id]
-            .as_ref()
-            .expect("Handler has already been removed.")
-            .downcast_ref::<H>()
-            .expect("Handler type do not match.");
-
         match proxy.status() {
             ::Liveness::Dead => return RegisterStatus::Dead,
             ::Liveness::Unmanaged => return RegisterStatus::Unmanaged,
@@ -75,17 +166,17 @@ impl EventQueueHandle {
         unsafe {
             let data: *mut ProxyUserData =
                 ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_proxy_get_user_data, proxy.ptr()) as *mut _;
-            // This cast from *const to *mut is legit because we enforce that a Handler
+            // This cast from *const to *mut is legit because we enforce that a proxy
             // can only be assigned to a single EventQueue.
             // (this is actually the whole point of the design of this lib)
             (&mut *data).0 = self as *const _ as *mut _;
-            (&mut *data).1 = h as *const _ as *mut c_void;
-            // even if this call fails, we updated the user_data, so the new handler is in place.
+            (&mut *data).1 = Some(Box::new((implementation, idata)) as Box<Any>);
+            // even if this call fails, we updated the user_data, so the new implementation is in place.
             ffi_dispatch!(
                 WAYLAND_CLIENT_HANDLE,
                 wl_proxy_add_dispatcher,
                 proxy.ptr(),
-                dispatch_func::<P, H>,
+                dispatch_func::<P, ID>,
                 &RUST_MANAGED as *const _ as *const _,
                 data as *mut c_void
             );
@@ -102,149 +193,33 @@ impl EventQueueHandle {
         RegisterStatus::Registered
     }
 
-    fn insert_handler(&mut self, h: Box<Any + Send>) -> usize {
-        {
-            // artificial scope to make the borrow checker happy
-            let empty_slot = self.handlers.iter_mut().enumerate().find(|&(_, ref s)| {
-                s.is_none()
-            });
-            if let Some((id, slot)) = empty_slot {
-                *slot = Some(h);
-                return id;
-            }
-        }
-        self.handlers.push(Some(h));
-        self.handlers.len() - 1
-    }
-
-    /// Insert a new handler to this event queue
+    /// Get a handle to the internal state
     ///
-    /// Returns the index of this handler in the internal array, which is needed
-    /// to register proxies to it.
-    pub fn add_handler<H: Any + Send + 'static>(&mut self, handler: H) -> usize {
-        self.insert_handler(Box::new(handler) as Box<Any + Send>)
-    }
-
-    /// Insert a new handler with init
-    ///
-    /// Allows you to insert handlers that require some interaction with the
-    /// event loop in their initialization, like registering some objects to it.
-    ///
-    /// The handler must implement the `Init` trait, and its init method will
-    /// be called after its insertion.
-    pub fn add_handler_with_init<H: Init + Any + Send + 'static>(&mut self, handler: H) -> usize {
-        let mut box_ = Box::new(handler);
-        // this little juggling is to avoid the double-borrow, which is actually safe,
-        // as handlers cannot be mutably accessed outside of an event-dispatch,
-        // and this new handler cannot receive any events before the return
-        // of this function
-        let h = &mut *box_ as *mut H;
-        let index = self.insert_handler(box_ as Box<Any + Send>);
-        unsafe { (&mut *h).init(self, index) };
-        index
-    }
-
-    /// Remove a handler previously inserted in this event loop and returns it.
-    ///
-    /// Panics if the requested type does not match the type of the stored handler
-    /// or if the specified index was already removed.
-    ///
-    /// **Unsafety** This function is unsafe because removing a handler while some wayland
-    /// objects are still registered to it can lead to access freed memory. Also, the index
-    /// of this handler will be reused at next handler insertion.
-    pub unsafe fn remove_handler<H: Any + Send + 'static>(&mut self, idx: usize) -> H {
-        let is_type = self.handlers[idx]
-            .as_ref()
-            .expect("Handler has already been removed.")
-            .is::<H>();
-        assert!(is_type, "Handler type do not match.");
-        *(self.handlers[idx].take().unwrap().downcast().unwrap())
-    }
-}
-
-/// Guard to access internal state of an event queue
-///
-/// This guard allows you to get references to the handlers you
-/// previously stored inside an event queue.
-///
-/// It borrows the event queue, so no event dispatching is possible
-/// as long as the guard is in scope, for safety reasons.
-pub struct StateGuard<'evq> {
-    evq: &'evq mut EventQueue,
-}
-
-impl<'evq> StateGuard<'evq> {
-    /// Get a reference to a handler
-    ///
-    /// Provides a reference to a handler stored in this event loop.
-    ///
-    /// The H type must be provided and match the type of the targetted Handler, or
-    /// it will panic.
-    pub fn get_handler<H: Any + 'static>(&self, handler_id: usize) -> &H {
-        self.evq.handle.handlers[handler_id]
-            .as_ref()
-            .expect("Handler has already been removed")
-            .downcast_ref::<H>()
-            .expect("Handler type do not match.")
-    }
-
-    /// Get a mutable reference to a handler
-    ///
-    /// Provides a reference to a handler stored in this event loop.
-    ///
-    /// The H type must be provided and match the type of the targetted Handler, or
-    /// it will panic.
-    pub fn get_mut_handler<H: Any + 'static>(&mut self, handler_id: usize) -> &mut H {
-        self.evq.handle.handlers[handler_id]
-            .as_mut()
-            .expect("Handler has already been removed")
-            .downcast_mut::<H>()
-            .expect("Handler type do not match.")
+    /// The returned guard object allows you to get references
+    /// to the handler objects you previously inserted in this
+    /// event queue.
+    pub fn state(&mut self) -> &mut State {
+        &mut self.state
     }
 }
 
 /// An event queue managing wayland events
 ///
 /// Each wayland object can receive events from the server. To handle these events
-/// you must use a handler object: a struct (or enum) which you have implemented
-/// the appropriate `Handler` traits on it (each wayland interface defines a `Handler`
-/// trait in its module), and declared it using the `declare_handler!(..)` macro.
+/// you must associate to these objects an implementation: a struct defined in their
+/// respective module, in which you provide a set of functions that will handle each event.
 ///
-/// This handler contains the state all your handler methods will be able to access
-/// via the `&mut self` argument. You can then instantiate your type, and give ownership of
-/// the handler object to the event queue, via the `add_handler(..)` method. Then, each
-/// wayland object must be registered to a handler via the `register(..)` method (or its events
-/// will all be ignored).
+/// Your implementation can also access a shared state managed by the event queue. See
+/// the `State` struct and the `state()` method on `EventQueueHandle`. If you need this,
+/// the way to do it is:
+///
+/// - insert your state value in the event queue state store, your are then provided with a
+///   token to access it
+/// - provide this token (you can clone it) as implementation data to any wayland object
+///   that need to access this state in its event callbacks.
 ///
 /// The event queues also provides you control on the flow of the program, via the `dispatch()` and
 /// `dispatch_pending()` methods.
-///
-/// ## example of use
-///
-/// ```ignore
-/// struct MyHandler { /* ... */ }
-///
-/// impl wl_surface::Handler for MyHandler {
-///     // implementation of the handler methods
-/// }
-///
-/// declare_handler!(MyHandler, wl_surface::Handler, wl_surface::WlSurface);
-///
-/// fn main() {
-///     /* ... setup of your environment ... */
-///     let surface = compositor.create_surface().expect("Compositor cannot be destroyed.");
-///     let my_id = eventqueue.add_handler(MyHandler::new());
-///     eventqueue.register::<_, MyHandler>(&surface, my_id);
-///
-///     // main event loop
-///     loop {
-///         // flush requests to the server
-///         display.flush().unwrap();
-///         // dispatch events from the server, blocking if needed
-///         eventqueue.dispatch().unwrap();
-///     }
-/// }
-/// ```
 pub struct EventQueue {
     handle: Box<EventQueueHandle>,
     display: *mut wl_display,
@@ -316,7 +291,7 @@ impl EventQueue {
     /// Synchronous roundtrip
     ///
     /// This call will cause a synchonous roundtrip with the wayland server. It will block until all
-    /// pending requests of this queue are send to the server and it has processed all of them and
+    /// pending requests of this queue are sent to the server and it has processed all of them and
     /// send the appropriate events.
     ///
     /// Handlers are called as a consequence.
@@ -325,14 +300,12 @@ impl EventQueue {
     pub fn sync_roundtrip(&mut self) -> IoResult<i32> {
         let ret = unsafe {
             match self.handle.wlevq {
-                Some(evtq) => {
-                    ffi_dispatch!(
-                        WAYLAND_CLIENT_HANDLE,
-                        wl_display_roundtrip_queue,
-                        self.display,
-                        evtq
-                    )
-                }
+                Some(evtq) => ffi_dispatch!(
+                    WAYLAND_CLIENT_HANDLE,
+                    wl_display_roundtrip_queue,
+                    self.display,
+                    evtq
+                ),
                 None => ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_display_roundtrip, self.display),
             }
         };
@@ -341,15 +314,6 @@ impl EventQueue {
         } else {
             Err(IoError::last_os_error())
         }
-    }
-
-    /// Get a handle to the internal state
-    ///
-    /// The returned guard object allows you to get references
-    /// to the handler objects you previously inserted in this
-    /// event queue.
-    pub fn state(&mut self) -> StateGuard {
-        StateGuard { evq: self }
     }
 
     /// Prepare an conccurent read
@@ -374,26 +338,24 @@ impl EventQueue {
     pub fn prepare_read(&self) -> Option<ReadEventsGuard> {
         let ret = unsafe {
             match self.handle.wlevq {
-                Some(evtq) => {
-                    ffi_dispatch!(
-                        WAYLAND_CLIENT_HANDLE,
-                        wl_display_prepare_read_queue,
-                        self.display,
-                        evtq
-                    )
-                }
+                Some(evtq) => ffi_dispatch!(
+                    WAYLAND_CLIENT_HANDLE,
+                    wl_display_prepare_read_queue,
+                    self.display,
+                    evtq
+                ),
                 None => ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_display_prepare_read, self.display),
             }
         };
         if ret >= 0 {
-            Some(ReadEventsGuard { display: self.display })
+            Some(ReadEventsGuard {
+                display: self.display,
+            })
         } else {
             None
         }
     }
 }
-
-unsafe impl Send for EventQueue {}
 
 impl Deref for EventQueue {
     type Target = EventQueueHandle;
@@ -451,16 +413,19 @@ pub unsafe fn create_event_queue(display: *mut wl_display, evq: Option<*mut wl_e
     EventQueue {
         display: display,
         handle: Box::new(EventQueueHandle {
-            handlers: Vec::new(),
+            state: State { values: Vec::new() },
             wlevq: evq,
         }),
     }
 }
 
-unsafe extern "C" fn dispatch_func<P: Proxy, H: Handler<P>>(_impl: *const c_void, proxy: *mut c_void,
-                                                            opcode: u32, _msg: *const wl_message,
-                                                            args: *const wl_argument)
-                                                            -> c_int {
+unsafe extern "C" fn dispatch_func<P, ID>(_impl: *const c_void, proxy: *mut c_void, opcode: u32,
+                                          _msg: *const wl_message, args: *const wl_argument)
+                                          -> c_int
+where
+    P: Proxy + Implementable<ID>,
+    ID: 'static,
+{
     // sanity check, if it triggers, it is a bug
     if _impl != &RUST_MANAGED as *const _ as *const _ {
         let _ = write!(
@@ -473,20 +438,17 @@ unsafe extern "C" fn dispatch_func<P: Proxy, H: Handler<P>>(_impl: *const c_void
     // we'll abort the process, so no access to corrupted data is possible.
     let ret = ::std::panic::catch_unwind(move || {
         let proxy = P::from_ptr_initialized(proxy as *mut wl_proxy);
-        let data = &mut *(ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_proxy_get_user_data, proxy.ptr()) as
-                              *mut ProxyUserData);
-        let evqhandle = &mut *data.0;
-        let handler = &mut *(data.1 as *mut H);
-        handler.message(evqhandle, &proxy, opcode, args)
+        proxy.__dispatch_msg(opcode, args)
     });
     match ret {
-        Ok(Ok(())) => return 0,   // all went well
+        Ok(Ok(())) => return 0, // all went well
         Ok(Err(())) => {
             // an unknown opcode was dispatched, this is not normal
             let _ = write!(
                 ::std::io::stderr(),
                 "[wayland-client error] Attempted to dispatch unknown opcode {} for {}, aborting.",
-                opcode, P::interface_name()
+                opcode,
+                P::interface_name()
             );
             ::libc::abort();
         }
@@ -501,127 +463,3 @@ unsafe extern "C" fn dispatch_func<P: Proxy, H: Handler<P>>(_impl: *const c_void
         }
     }
 }
-
-/// Synonym of the declare_handler! macro
-///
-/// This more distinctive can be used for projects that need to use
-/// both the client-side and server-side macros.
-#[macro_export]
-macro_rules! client_declare_handler(
-    ($handler_struct: ident <$($tyarg:ident : [$($trait: ident $(<$($traitarg:ty),*>)*),*]),*>, $handler_trait: path, $handled_type: ty) => {
-        unsafe impl<$($tyarg : $($trait $(<$($traitarg),*>)* +)* 'static),*> $crate::Handler<$handled_type> for $handler_struct<$($tyarg),*> {
-            unsafe fn message(&mut self,
-                              evq: &mut $crate::EventQueueHandle,
-                              proxy: &$handled_type,
-                              opcode: u32,
-                              args: *const $crate::sys::wl_argument
-                             ) -> ::std::result::Result<(),()> {
-                <$handler_trait>::__message(self, evq, proxy, opcode, args)
-            }
-        }
-    };
-    ($handler_struct: ident, $handler_trait: path, $handled_type: ty) => {
-        unsafe impl $crate::Handler<$handled_type> for $handler_struct {
-            unsafe fn message(&mut self,
-                              evq: &mut $crate::EventQueueHandle,
-                              proxy: &$handled_type,
-                              opcode: u32,
-                              args: *const $crate::sys::wl_argument
-                             ) -> ::std::result::Result<(),()> {
-                <$handler_trait>::__message(self, evq, proxy, opcode, args)
-            }
-        }
-    };
-);
-
-
-/// Registers a handler type so it can be used in event queue
-///
-/// After having implemented the appropriate Handler trait for your type,
-/// declare it via this macro, like this:
-///
-/// ```ignore
-/// struct MyHandler;
-///
-/// impl wl_foo::Handler for MyHandler {
-///     ...
-/// }
-///
-/// declare_handler!(MyHandler, wl_foo::Handler, wl_foo::WlFoo);
-/// ```
-///
-/// If your type has type arguments, they must be specified using this special
-/// syntax to describe constraints on them:
-///
-/// ```ignore
-/// // Note that even if there are no constraints on U, there is a need to put this "empty list"
-/// declare_handler!(MyHandler<T: [Trait1, Trait2], U: []>, wl_foo::Handler, wl_foo::WlFoo);
-/// ```
-#[macro_export]
-macro_rules! declare_handler(
-    ($handler_struct: ident <$($tyarg:ident : [$($trait: ident $(<$($traitarg:ty),*>)*),*]),*>, $handler_trait: path, $handled_type: ty) => {
-        client_declare_handler!($handler_struct<$($tyarg: [$($trait $(<$($traitarg),*>)*),*]),*>, $handler_trait, $handled_type);
-    };
-    ($handler_struct: ident, $handler_trait: path, $handled_type: ty) => {
-        client_declare_handler!($handler_struct, $handler_trait, $handled_type);
-    };
-);
-
-/// Synonym of the declare_delegating_handler! macro
-///
-/// This more distinctive can be used for projects that need to use
-/// both the client-side and server-side macros.
-#[macro_export]
-macro_rules! client_declare_delegating_handler(
-    ($handler_struct: ident <$($tyarg:ident : [$($trait: ident $(<$($traitarg:ty),*>)*),*]),*>, $($handler_field: ident).+ , $handler_trait: path, $handled_type: ty) => {
-        unsafe impl<$($tyarg : $($trait $(<$($traitarg),*>)* +)* 'static),*> $crate::Handler<$handled_type> for $handler_struct<$($tyarg),*> {
-            unsafe fn message(&mut self,
-                              evq: &mut $crate::EventQueueHandle,
-                              proxy: &$handled_type,
-                              opcode: u32,
-                              args: *const $crate::sys::wl_argument
-                             ) -> ::std::result::Result<(),()> {
-                <$handler_trait>::__message(&mut self.$($handler_field).+, evq, proxy, opcode, args)
-            }
-        }
-    };
-    ($handler_struct: ident, $($handler_field: ident).+ , $handler_trait: path, $handled_type: ty) => {
-        unsafe impl $crate::Handler<$handled_type> for $handler_struct {
-            unsafe fn message(&mut self,
-                              evq: &mut $crate::EventQueueHandle,
-                              proxy: &$handled_type,
-                              opcode: u32,
-                              args: *const $crate::sys::wl_argument
-                             ) -> ::std::result::Result<(),()> {
-                <$handler_trait>::__message(&mut self.$($handler_field).+, evq, proxy, opcode, args)
-            }
-        }
-    };
-);
-
-/// Registers a handler type so it as delegating to one of its fields
-///
-/// This allows to declare your type as a handler, by delegating the impl
-/// to one of its fields (or subfields).
-///
-/// ```ignore
-/// // MySubHandler is a proper handler for wl_foo events
-/// struct MySubHandler;
-///
-/// struct MyHandler {
-///     sub: MySubHandler
-/// }
-///
-/// declare_delegating_handler!(MySubHandler, sub, wl_foo::Handler, wl_foo::WlFoo);
-/// ```
-///
-/// The syntax to use if your type has type arguments is the same as for `declare_handler!()`.
-#[macro_export]
-macro_rules! declare_delegating_handler(
-    ($handler_struct: ident <$($tyarg:ident : [$($trait: ident $(<$($traitarg:ty),*>)*),*]),*>, $($handler_field: ident).+ , $handler_trait: path, $handled_type: ty) => {
-        client_declare_delegating_handler!($handler_struct<$($tyarg: [$($trait $(<$($traitarg),*>)*),*]),*>, $($handler_field).+, $handler_trait, $handled_type);
-    };
-    ($handler_struct: ident, $($handler_field: ident).+ , $handler_trait: path, $handled_type: ty) => {
-        client_declare_delegating_handler!($handler_struct, $($handler_field).+, $handler_trait, $handled_type);
-    };
-);

--- a/wayland-protocols/build.rs
+++ b/wayland-protocols/build.rs
@@ -2,49 +2,45 @@ extern crate wayland_scanner;
 
 use std::env::var;
 use std::path::Path;
-
-use wayland_scanner::{Side, generate_code, generate_interfaces};
+use wayland_scanner::{generate_code, generate_interfaces, Side};
 
 static BASE_PROTOCOL_DIR: &'static str = "./protocols/";
 
-static STABLE_PROTOCOLS: &'static [(&'static str, &'static str)] =
-    &[
-        (
-            "presentation-time",
-            "presentation-time/presentation-time.xml",
-        ),
-        ("viewporter", "viewporter/viewporter.xml"),
-    ];
+static STABLE_PROTOCOLS: &'static [(&'static str, &'static str)] = &[
+    (
+        "presentation-time",
+        "presentation-time/presentation-time.xml",
+    ),
+    ("viewporter", "viewporter/viewporter.xml"),
+];
 
-static UNSTABLE_PROTOCOLS: &'static [(&'static str, &'static str)] =
-    &[
-        (
-            "fullscreen-shell",
-            "fullscreen-shell/fullscreen-shell-unstable-v1.xml",
-        ),
-        ("idle-inhibit", "idle-inhibit/idle-inhibit-unstable-v1.xml"),
-        ("input-method", "input-method/input-method-unstable-v1.xml"),
-        ("linux-dmabuf", "linux-dmabuf/linux-dmabuf-unstable-v1.xml"),
-        (
-            "pointer-constraints",
-            "pointer-constraints/pointer-constraints-unstable-v1.xml",
-        ),
-        (
-            "pointer-gestures",
-            "pointer-gestures/pointer-gestures-unstable-v1.xml",
-        ),
-        (
-            "relative-pointer",
-            "relative-pointer/relative-pointer-unstable-v1.xml",
-        ),
-        ("tablet", "tablet/tablet-unstable-v2.xml"),
-        ("text-input", "text-input/text-input-unstable-v1.xml"),
-        ("xdg-foreign", "xdg-foreign/xdg-foreign-unstable-v1.xml"),
-        ("xdg-shell", "xdg-shell/xdg-shell-unstable-v6.xml"),
-    ];
+static UNSTABLE_PROTOCOLS: &'static [(&'static str, &'static str)] = &[
+    (
+        "fullscreen-shell",
+        "fullscreen-shell/fullscreen-shell-unstable-v1.xml",
+    ),
+    ("idle-inhibit", "idle-inhibit/idle-inhibit-unstable-v1.xml"),
+    ("input-method", "input-method/input-method-unstable-v1.xml"),
+    ("linux-dmabuf", "linux-dmabuf/linux-dmabuf-unstable-v1.xml"),
+    (
+        "pointer-constraints",
+        "pointer-constraints/pointer-constraints-unstable-v1.xml",
+    ),
+    (
+        "pointer-gestures",
+        "pointer-gestures/pointer-gestures-unstable-v1.xml",
+    ),
+    (
+        "relative-pointer",
+        "relative-pointer/relative-pointer-unstable-v1.xml",
+    ),
+    ("tablet", "tablet/tablet-unstable-v2.xml"),
+    ("text-input", "text-input/text-input-unstable-v1.xml"),
+    ("xdg-foreign", "xdg-foreign/xdg-foreign-unstable-v1.xml"),
+    ("xdg-shell", "xdg-shell/xdg-shell-unstable-v6.xml"),
+];
 
 fn generate_protocol(name: &str, file: &Path, out_dir: &Path, client: bool, server: bool) {
-
     let protocol_file = Path::new(BASE_PROTOCOL_DIR).join(file);
 
     generate_interfaces(

--- a/wayland-protocols/src/protocol_macro.rs
+++ b/wayland-protocols/src/protocol_macro.rs
@@ -23,7 +23,7 @@ macro_rules! wayland_protocol(
                     // Imports that need to be available to submodules
                     // but should not be in public API.
                     // Will be fixable with pub(restricted).
-                    #[doc(hidden)] pub use wayland_client::{Proxy, Handler, RequestResult, EventQueueHandle, Liveness};
+                    #[doc(hidden)] pub use wayland_client::{Proxy, Implementable, RequestResult, EventQueueHandle, Liveness};
                     #[doc(hidden)] pub use super::interfaces;
                     #[doc(hidden)] pub use wayland_client::protocol::{$($import),*};
                     include!(concat!(env!("OUT_DIR"), "/", $name, "_client_api.rs"));
@@ -41,7 +41,7 @@ macro_rules! wayland_protocol(
                     // Imports that need to be available to submodules
                     // but should not be in public API.
                     // Will be fixable with pub(restricted).
-                    #[doc(hidden)] pub use wayland_server::{Resource, Handler, EventResult, Client, EventLoopHandle, Liveness};
+                    #[doc(hidden)] pub use wayland_server::{Resource, Implementable, EventResult, Client, EventLoopHandle, Liveness};
                     #[doc(hidden)] pub use super::interfaces;
                     #[doc(hidden)] pub use wayland_server::protocol::{$($import),*};
                     include!(concat!(env!("OUT_DIR"), "/", $name, "_server_api.rs"));

--- a/wayland-scanner/src/code_gen.rs
+++ b/wayland-scanner/src/code_gen.rs
@@ -438,12 +438,13 @@ fn write_dispatch_func<O: Write>(messages: &[Message], out: &mut O, side: Side, 
     )?;
     writeln!(out, r#"
         let data: &mut (*mut {}, Option<Box<Any>>, Arc<(AtomicBool, AtomicPtr<()>)>) =
-            &mut *(ffi_dispatch!(WAYLAND_CLIENT_HANDLE, {}_get_user_data, self.ptr()) as *mut _);
+            &mut *(ffi_dispatch!({}, {}_get_user_data, self.ptr()) as *mut _);
         let evq = &mut *(data.0);
         let mut kill = false;
         {{
             let &mut (ref implementation, ref mut idata) = data.1.as_mut().unwrap().downcast_mut::<(Implementation<ID>, ID)>().unwrap();"#,
     side.handle_type(),
+    side.handle(),
     side.object_ptr_type()
     )?;
     writeln!(out, "            match opcode {{")?;

--- a/wayland-scanner/src/interface_gen.rs
+++ b/wayland-scanner/src/interface_gen.rs
@@ -21,21 +21,22 @@ pub fn generate_interfaces<O: Write>(protocol: Protocol, out: &mut O) {
     //
 
     let longest_nulls = protocol.interfaces.iter().fold(0, |max, interface| {
-        let request_longest_null = interface.requests.iter().fold(0, |max, request| {
-            if request.all_null() {
+        let request_longest_null = interface
+            .requests
+            .iter()
+            .fold(0, |max, request| if request.all_null() {
                 cmp::max(request.args.len(), max)
             } else {
                 max
-            }
-        });
-        let events_longest_null = interface.events.iter().fold(
-            0,
-            |max, event| if event.all_null() {
+            });
+        let events_longest_null = interface
+            .events
+            .iter()
+            .fold(0, |max, event| if event.all_null() {
                 cmp::max(event.args.len(), max)
             } else {
                 max
-            },
-        );
+            });
         cmp::max(max, cmp::max(request_longest_null, events_longest_null))
     });
 
@@ -111,7 +112,6 @@ pub fn generate_interfaces<O: Write>(protocol: Protocol, out: &mut O) {
     );
 
     for interface in &protocol.interfaces {
-
         writeln!(out, "// {}\n", interface.name).unwrap();
 
         emit_messages!(interface, requests);

--- a/wayland-scanner/src/parse.rs
+++ b/wayland-scanner/src/parse.rs
@@ -2,7 +2,6 @@
 
 use protocol::*;
 use std::io::Read;
-
 use xml::EventReader;
 use xml::attribute::OwnedAttribute;
 use xml::reader::Events;
@@ -50,8 +49,7 @@ pub fn parse_stream<S: Read>(stream: S) -> Protocol {
 }
 
 fn parse_protocol<'a, S: Read + 'a>(mut iter: Events<S>) -> Protocol {
-    let mut protocol =
-        extract_from!(
+    let mut protocol = extract_from!(
         iter => XmlEvent::StartElement { name, attributes, .. } => {
             assert!(name.local_name == "protocol", "Missing protocol toplevel tag");
             assert!(attributes[0].name.local_name == "name", "Protocol must have a name");
@@ -61,7 +59,11 @@ fn parse_protocol<'a, S: Read + 'a>(mut iter: Events<S>) -> Protocol {
 
     loop {
         match iter.next() {
-            Some(Ok(XmlEvent::StartElement { name, attributes, .. })) => {
+            Some(
+                Ok(XmlEvent::StartElement {
+                    name, attributes, ..
+                }),
+            ) => {
                 match &name.local_name[..] {
                     "copyright" => {
                         // parse the copyright
@@ -70,20 +72,18 @@ fn parse_protocol<'a, S: Read + 'a>(mut iter: Events<S>) -> Protocol {
                         protocol.copyright = Some(copyright);
                     }
                     "interface" => {
-                        protocol.interfaces.push(
-                            parse_interface(&mut iter, attributes),
-                        );
+                        protocol
+                            .interfaces
+                            .push(parse_interface(&mut iter, attributes));
                     }
                     "description" => {
                         protocol.description = Some(parse_description(&mut iter, attributes));
                     }
-                    _ => {
-                        panic!(
-                            "Ill-formed protocol file: unexpected token `{}` in protocol {}",
-                            name.local_name,
-                            protocol.name
-                        )
-                    }
+                    _ => panic!(
+                        "Ill-formed protocol file: unexpected token `{}` in protocol {}",
+                        name.local_name,
+                        protocol.name
+                    ),
                 }
             }
             Some(Ok(XmlEvent::EndElement { name })) => {
@@ -113,15 +113,17 @@ fn parse_interface<'a, S: Read + 'a>(iter: &mut Events<S>, attrs: Vec<OwnedAttri
 
     loop {
         match iter.next() {
-            Some(Ok(XmlEvent::StartElement { name, attributes, .. })) => {
-                match &name.local_name[..] {
-                    "description" => interface.description = Some(parse_description(iter, attributes)),
-                    "request" => interface.requests.push(parse_request(iter, attributes)),
-                    "event" => interface.events.push(parse_event(iter, attributes)),
-                    "enum" => interface.enums.push(parse_enum(iter, attributes)),
-                    _ => panic!("Unexpected tocken: `{}`", name.local_name),
-                }
-            }
+            Some(
+                Ok(XmlEvent::StartElement {
+                    name, attributes, ..
+                }),
+            ) => match &name.local_name[..] {
+                "description" => interface.description = Some(parse_description(iter, attributes)),
+                "request" => interface.requests.push(parse_request(iter, attributes)),
+                "event" => interface.events.push(parse_event(iter, attributes)),
+                "enum" => interface.enums.push(parse_enum(iter, attributes)),
+                _ => panic!("Unexpected tocken: `{}`", name.local_name),
+            },
             Some(Ok(XmlEvent::EndElement { ref name })) if name.local_name == "interface" => break,
             _ => {}
         }
@@ -164,13 +166,15 @@ fn parse_request<'a, S: Read + 'a>(iter: &mut Events<S>, attrs: Vec<OwnedAttribu
 
     loop {
         match iter.next() {
-            Some(Ok(XmlEvent::StartElement { name, attributes, .. })) => {
-                match &name.local_name[..] {
-                    "description" => request.description = Some(parse_description(iter, attributes)),
-                    "arg" => request.args.push(parse_arg(iter, attributes)),
-                    _ => panic!("Unexpected tocken: `{}`", name.local_name),
-                }
-            }
+            Some(
+                Ok(XmlEvent::StartElement {
+                    name, attributes, ..
+                }),
+            ) => match &name.local_name[..] {
+                "description" => request.description = Some(parse_description(iter, attributes)),
+                "arg" => request.args.push(parse_arg(iter, attributes)),
+                _ => panic!("Unexpected tocken: `{}`", name.local_name),
+            },
             Some(Ok(XmlEvent::EndElement { ref name })) if name.local_name == "request" => break,
             _ => {}
         }
@@ -185,24 +189,24 @@ fn parse_enum<'a, S: Read + 'a>(iter: &mut Events<S>, attrs: Vec<OwnedAttribute>
         match &attr.name.local_name[..] {
             "name" => enu.name = attr.value,
             "since" => enu.since = attr.value.parse().unwrap(),
-            "bitfield" => {
-                if &attr.value[..] == "true" {
-                    enu.bitfield = true
-                }
-            }
+            "bitfield" => if &attr.value[..] == "true" {
+                enu.bitfield = true
+            },
             _ => {}
         }
     }
 
     loop {
         match iter.next() {
-            Some(Ok(XmlEvent::StartElement { name, attributes, .. })) => {
-                match &name.local_name[..] {
-                    "description" => enu.description = Some(parse_description(iter, attributes)),
-                    "entry" => enu.entries.push(parse_entry(iter, attributes)),
-                    _ => panic!("Unexpected tocken: `{}`", name.local_name),
-                }
-            }
+            Some(
+                Ok(XmlEvent::StartElement {
+                    name, attributes, ..
+                }),
+            ) => match &name.local_name[..] {
+                "description" => enu.description = Some(parse_description(iter, attributes)),
+                "entry" => enu.entries.push(parse_entry(iter, attributes)),
+                _ => panic!("Unexpected tocken: `{}`", name.local_name),
+            },
             Some(Ok(XmlEvent::EndElement { ref name })) if name.local_name == "enum" => break,
             _ => {}
         }
@@ -223,13 +227,15 @@ fn parse_event<'a, S: Read + 'a>(iter: &mut Events<S>, attrs: Vec<OwnedAttribute
 
     loop {
         match iter.next() {
-            Some(Ok(XmlEvent::StartElement { name, attributes, .. })) => {
-                match &name.local_name[..] {
-                    "description" => event.description = Some(parse_description(iter, attributes)),
-                    "arg" => event.args.push(parse_arg(iter, attributes)),
-                    _ => panic!("Unexpected tocken: `{}`", name.local_name),
-                }
-            }
+            Some(
+                Ok(XmlEvent::StartElement {
+                    name, attributes, ..
+                }),
+            ) => match &name.local_name[..] {
+                "description" => event.description = Some(parse_description(iter, attributes)),
+                "arg" => event.args.push(parse_arg(iter, attributes)),
+                _ => panic!("Unexpected tocken: `{}`", name.local_name),
+            },
             Some(Ok(XmlEvent::EndElement { ref name })) if name.local_name == "event" => break,
             _ => {}
         }
@@ -246,11 +252,9 @@ fn parse_arg<'a, S: Read + 'a>(iter: &mut Events<S>, attrs: Vec<OwnedAttribute>)
             "type" => arg.typ = parse_type(&attr.value),
             "summary" => arg.summary = Some(attr.value),
             "interface" => arg.interface = Some(attr.value),
-            "allow-null" => {
-                if attr.value == "true" {
-                    arg.allow_null = true
-                }
-            }
+            "allow-null" => if attr.value == "true" {
+                arg.allow_null = true
+            },
             "enum" => arg.enum_ = Some(attr.value),
             _ => {}
         }
@@ -258,12 +262,14 @@ fn parse_arg<'a, S: Read + 'a>(iter: &mut Events<S>, attrs: Vec<OwnedAttribute>)
 
     loop {
         match iter.next() {
-            Some(Ok(XmlEvent::StartElement { name, attributes, .. })) => {
-                match &name.local_name[..] {
-                    "description" => arg.description = Some(parse_description(iter, attributes)),
-                    _ => panic!("Unexpected tocken: `{}`", name.local_name),
-                }
-            }
+            Some(
+                Ok(XmlEvent::StartElement {
+                    name, attributes, ..
+                }),
+            ) => match &name.local_name[..] {
+                "description" => arg.description = Some(parse_description(iter, attributes)),
+                _ => panic!("Unexpected tocken: `{}`", name.local_name),
+            },
             Some(Ok(XmlEvent::EndElement { ref name })) if name.local_name == "arg" => break,
             _ => {}
         }
@@ -301,12 +307,14 @@ fn parse_entry<'a, S: Read + 'a>(iter: &mut Events<S>, attrs: Vec<OwnedAttribute
 
     loop {
         match iter.next() {
-            Some(Ok(XmlEvent::StartElement { name, attributes, .. })) => {
-                match &name.local_name[..] {
-                    "description" => entry.description = Some(parse_description(iter, attributes)),
-                    _ => panic!("Unexpected tocken: `{}`", name.local_name),
-                }
-            }
+            Some(
+                Ok(XmlEvent::StartElement {
+                    name, attributes, ..
+                }),
+            ) => match &name.local_name[..] {
+                "description" => entry.description = Some(parse_description(iter, attributes)),
+                _ => panic!("Unexpected tocken: `{}`", name.local_name),
+            },
             Some(Ok(XmlEvent::EndElement { ref name })) if name.local_name == "entry" => break,
             _ => {}
         }

--- a/wayland-scanner/src/util.rs
+++ b/wayland-scanner/src/util.rs
@@ -2,12 +2,58 @@ use std::ascii::AsciiExt;
 
 pub fn is_keyword(txt: &str) -> bool {
     match txt {
-        "abstract" | "alignof" | "as" | "become" | "box" | "break" | "const" | "continue" | "crate" |
-        "do" | "else" | "enum" | "extern" | "false" | "final" | "fn" | "for" | "if" | "impl" | "in" |
-        "let" | "loop" | "macro" | "match" | "mod" | "move" | "mut" | "offsetof" | "override" | "priv" |
-        "proc" | "pub" | "pure" | "ref" | "return" | "Self" | "self" | "sizeof" | "static" | "struct" |
-        "super" | "trait" | "true" | "type" | "typeof" | "unsafe" | "unsized" | "use" | "virtual" |
-        "where" | "while" | "yield" => true,
+        "abstract" |
+        "alignof" |
+        "as" |
+        "become" |
+        "box" |
+        "break" |
+        "const" |
+        "continue" |
+        "crate" |
+        "do" |
+        "else" |
+        "enum" |
+        "extern" |
+        "false" |
+        "final" |
+        "fn" |
+        "for" |
+        "if" |
+        "impl" |
+        "in" |
+        "let" |
+        "loop" |
+        "macro" |
+        "match" |
+        "mod" |
+        "move" |
+        "mut" |
+        "offsetof" |
+        "override" |
+        "priv" |
+        "proc" |
+        "pub" |
+        "pure" |
+        "ref" |
+        "return" |
+        "Self" |
+        "self" |
+        "sizeof" |
+        "static" |
+        "struct" |
+        "super" |
+        "trait" |
+        "true" |
+        "type" |
+        "typeof" |
+        "unsafe" |
+        "unsized" |
+        "use" |
+        "virtual" |
+        "where" |
+        "while" |
+        "yield" => true,
         _ => false,
     }
 }

--- a/wayland-server/build.rs
+++ b/wayland-server/build.rs
@@ -2,8 +2,7 @@ extern crate wayland_scanner;
 
 use std::env::var;
 use std::path::Path;
-
-use wayland_scanner::{Side, generate_code, generate_interfaces};
+use wayland_scanner::{generate_code, generate_interfaces, Side};
 
 fn main() {
     let protocol_file = "./wayland.xml";

--- a/wayland-server/src/display.rs
+++ b/wayland-server/src/display.rs
@@ -1,6 +1,6 @@
 
 
-use event_loop::{EventLoop, create_event_loop};
+use event_loop::{create_event_loop, EventLoop};
 use std::env;
 use std::ffi::{CStr, CString, OsStr, OsString};
 use std::io::{Error as IoError, ErrorKind, Result as IoResult};
@@ -8,7 +8,6 @@ use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::io::{IntoRawFd, RawFd};
 use std::path::PathBuf;
 use std::ptr;
-
 use wayland_sys::server::*;
 
 /// A wayland socket
@@ -24,11 +23,7 @@ pub struct Display {
 /// using the `add_socket_*` methods.
 pub fn create_display() -> (Display, EventLoop) {
     unsafe {
-        let ptr =
-            ffi_dispatch!(
-            WAYLAND_SERVER_HANDLE,
-            wl_display_create,
-        );
+        let ptr = ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_display_create,);
         let el_ptr = ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_display_get_event_loop, ptr);
         (Display { ptr: ptr }, create_event_loop(el_ptr, Some(ptr)))
     }
@@ -79,10 +74,7 @@ impl Display {
             }
             Err(IoError::new(
                 ErrorKind::PermissionDenied,
-                format!(
-                    "could not bind socket {}",
-                    socket_name.to_string_lossy()
-                ),
+                format!("could not bind socket {}", socket_name.to_string_lossy()),
             ))
         } else {
             Ok(())
@@ -178,11 +170,9 @@ impl Drop for Display {
 fn get_runtime_dir() -> IoResult<PathBuf> {
     match env::var_os("XDG_RUNTIME_DIR") {
         Some(s) => Ok(s.into()),
-        None => {
-            Err(IoError::new(
-                ErrorKind::NotFound,
-                "XDG_RUNTIME_DIR env variable is not set",
-            ))
-        }
+        None => Err(IoError::new(
+            ErrorKind::NotFound,
+            "XDG_RUNTIME_DIR env variable is not set",
+        )),
     }
 }

--- a/wayland-sys/src/client.rs
+++ b/wayland-sys/src/client.rs
@@ -6,9 +6,9 @@
 use super::common::*;
 use std::os::raw::{c_char, c_int, c_void};
 
-pub enum wl_proxy { }
-pub enum wl_display { }
-pub enum wl_event_queue { }
+pub enum wl_proxy {}
+pub enum wl_display {}
+pub enum wl_event_queue {}
 
 external_library!(WaylandClient, "wayland-client",
     functions:

--- a/wayland-sys/src/common.rs
+++ b/wayland-sys/src/common.rs
@@ -58,10 +58,11 @@ pub struct wl_argument {
     _f: usize,
 }
 
-pub type wl_dispatcher_func_t = unsafe extern "C" fn(*const c_void,
-                                                     *mut c_void,
-                                                     u32,
-                                                     *const wl_message,
-                                                     *const wl_argument)
-                                                     -> c_int;
+pub type wl_dispatcher_func_t = unsafe extern "C" fn(
+                                 *const c_void,
+                                 *mut c_void,
+                                 u32,
+                                 *const wl_message,
+                                 *const wl_argument,
+) -> c_int;
 pub type wl_log_func_t = unsafe extern "C" fn(*const c_char, ...);

--- a/wayland-sys/src/cursor.rs
+++ b/wayland-sys/src/cursor.rs
@@ -5,7 +5,7 @@
 use client::wl_proxy;
 use std::os::raw::{c_char, c_int, c_uint};
 
-pub enum wl_cursor_theme { }
+pub enum wl_cursor_theme {}
 
 #[repr(C)]
 pub struct wl_cursor_image {

--- a/wayland-sys/src/egl.rs
+++ b/wayland-sys/src/egl.rs
@@ -7,7 +7,7 @@
 use client::wl_proxy;
 use std::os::raw::c_int;
 
-pub enum wl_egl_window { }
+pub enum wl_egl_window {}
 
 external_library!(WaylandEgl, "wayland-egl",
     functions:

--- a/wayland-sys/src/server.rs
+++ b/wayland-sys/src/server.rs
@@ -7,13 +7,13 @@ use super::common::*;
 use libc::{gid_t, pid_t, uid_t};
 use std::os::raw::{c_char, c_int, c_void};
 
-pub enum wl_client { }
-pub enum wl_display { }
-pub enum wl_event_loop { }
-pub enum wl_event_source { }
-pub enum wl_global { }
-pub enum wl_resource { }
-pub enum wl_shm_buffer { }
+pub enum wl_client {}
+pub enum wl_display {}
+pub enum wl_event_loop {}
+pub enum wl_event_source {}
+pub enum wl_global {}
+pub enum wl_resource {}
+pub enum wl_shm_buffer {}
 
 pub type wl_event_loop_fd_func_t = unsafe extern "C" fn(c_int, u32, *mut c_void) -> c_int;
 pub type wl_event_loop_timer_func_t = unsafe extern "C" fn(*mut c_void) -> c_int;


### PR DESCRIPTION
This breaks almost everything, largely changing the way the crates work.

We insert a clear boundary between "data" and "implementation" over the
event loop. Solving various "shared state access" issues.

Also, the event loops/event queues are no longer Send, and can store
non-Send data.