### PR TITLE
[breaking] Update deps & fix documentation of enum/bitflags variants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
   - sudo apt-get install -y libwayland-dev
 
 rust:
+  - 1.20.0
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -30,3 +30,6 @@ The documentation for the releases can be found on [docs.rs](https://docs.rs/):
  - [wayland-scanner](https://docs.rs/wayland-scanner/)
  - [wayland-sys](https://docs.rs/wayland-sys/)
 
+## Requirements
+
+Requires at least rust 1.20 to be used (using bitflags 1.0 for associated constants).

--- a/tests/scanner_assets/client_code.rs
+++ b/tests/scanner_assets/client_code.rs
@@ -137,8 +137,11 @@ pub mod wl_foo {
     #[repr(u32)]
     #[derive(Copy,Clone,Debug,PartialEq)]
     pub enum CakeKind {
+        /// mild cake without much flavor
         Basic = 0,
+        /// spicy cake to burn your tongue
         Spicy = 1,
+        /// fruity cake to get vitamins
         Fruity = 2,
     }
     impl CakeKind {
@@ -155,14 +158,18 @@ pub mod wl_foo {
         }
     }
 
-    bitflags! { #[doc = r#"possible delivery modes
-
-"#]
-    pub struct DeliveryKind: u32 {
-        const PickUp = 1;
-        const Drone = 2;
-        const Catapult = 4;
-    } }
+    bitflags! {
+        /// possible delivery modes
+        ///
+        pub struct DeliveryKind: u32 {
+            /// pick your cake up yourself
+            const PickUp = 1;
+            /// flying drone delivery
+            const Drone = 2;
+            /// because we fear nothing
+            const Catapult = 4;
+        }
+    }
 
     impl DeliveryKind {
         pub fn from_raw(n: u32) -> Option<DeliveryKind> {

--- a/tests/scanner_assets/protocol.xml
+++ b/tests/scanner_assets/protocol.xml
@@ -35,7 +35,7 @@
         List of the possible kind of cake supported by the protocol.
       </description>
       <entry name="basic" value="0" summary="mild cake without much flavor" />
-      <entry name="spicy" value="1" summary="spicy cake to brun your tongue" />
+      <entry name="spicy" value="1" summary="spicy cake to burn your tongue" />
       <entry name="fruity" value="2" summary="fruity cake to get vitamins" since="3" />
     </enum>
 

--- a/tests/scanner_assets/server_code.rs
+++ b/tests/scanner_assets/server_code.rs
@@ -146,8 +146,11 @@ pub mod wl_foo {
     #[repr(u32)]
     #[derive(Copy,Clone,Debug,PartialEq)]
     pub enum CakeKind {
+        /// mild cake without much flavor
         Basic = 0,
+        /// spicy cake to burn your tongue
         Spicy = 1,
+        /// fruity cake to get vitamins
         Fruity = 2,
     }
     impl CakeKind {
@@ -164,14 +167,18 @@ pub mod wl_foo {
         }
     }
 
-    bitflags! { #[doc = r#"possible delivery modes
-
-"#]
-    pub struct DeliveryKind: u32 {
-        const PickUp = 1;
-        const Drone = 2;
-        const Catapult = 4;
-    } }
+    bitflags! {
+        /// possible delivery modes
+        ///
+        pub struct DeliveryKind: u32 {
+            /// pick your cake up yourself
+            const PickUp = 1;
+            /// flying drone delivery
+            const Drone = 2;
+            /// because we fear nothing
+            const Catapult = 4;
+        }
+    }
     impl DeliveryKind {
         pub fn from_raw(n: u32) -> Option<DeliveryKind> {
             Some(DeliveryKind::from_bits_truncate(n))

--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "smithay/wayland-rs" }
 [dependencies]
 wayland-sys = { version = "0.10.3", features = ["client"], path = "../wayland-sys" }
 libc = "0.2"
-bitflags = "0.9"
+bitflags = "1.0"
 
 [build-dependencies]
 wayland-scanner = { version = "0.10.3", path = "../wayland-scanner" }

--- a/wayland-protocols/Cargo.toml
+++ b/wayland-protocols/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "smithay/wayland-rs" }
 wayland-sys = { version = "0.10.3", path = "../wayland-sys" }
 wayland-client = { version = "0.10.3", path = "../wayland-client", optional = true, default-features = false }
 wayland-server = { version = "0.10.3", path = "../wayland-server", optional = true }
-bitflags = "0.9"
+bitflags = "1.0"
 
 [build-dependencies]
 wayland-scanner = { version = "0.10.3", path = "../wayland-scanner" }

--- a/wayland-scanner/src/parse.rs
+++ b/wayland-scanner/src/parse.rs
@@ -250,7 +250,7 @@ fn parse_arg<'a, S: Read + 'a>(iter: &mut Events<S>, attrs: Vec<OwnedAttribute>)
         match &attr.name.local_name[..] {
             "name" => arg.name = attr.value,
             "type" => arg.typ = parse_type(&attr.value),
-            "summary" => arg.summary = Some(attr.value),
+            "summary" => arg.summary = Some(attr.value.split_whitespace().collect::<Vec<_>>().join(" ")),
             "interface" => arg.interface = Some(attr.value),
             "allow-null" => if attr.value == "true" {
                 arg.allow_null = true
@@ -300,7 +300,7 @@ fn parse_entry<'a, S: Read + 'a>(iter: &mut Events<S>, attrs: Vec<OwnedAttribute
             "name" => entry.name = attr.value,
             "value" => entry.value = attr.value,
             "since" => entry.since = attr.value.parse().unwrap(),
-            "summary" => entry.summary = Some(attr.value),
+            "summary" => entry.summary = Some(attr.value.split_whitespace().collect::<Vec<_>>().join(" ")),
             _ => {}
         }
     }

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "smithay/wayland-rs" }
 wayland-sys = { version = "0.10.3", features = ["server"], path = "../wayland-sys" }
 libc = "0.2"
 nix = "0.9"
-bitflags = "0.9"
+bitflags = "1.0"
 
 [build-dependencies]
 wayland-scanner = { version = "0.10.3", path = "../wayland-scanner" }

--- a/wayland-server/src/event_sources.rs
+++ b/wayland-server/src/event_sources.rs
@@ -110,10 +110,10 @@ where
         } else {
             let mut bits = FdInterest::empty();
             if mask & 0x02 > 0 {
-                bits = bits | WRITE;
+                bits = bits | FdInterest::WRITE;
             }
             if mask & 0x01 > 0 {
-                bits = bits | READ;
+                bits = bits | FdInterest::READ;
             }
             (implem.ready)(evlh, idata, fd, bits)
         }

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -123,8 +123,7 @@ pub mod sources {
     // different kind of event sources that can be registered to and
     // event loop, other than the wayland protocol sockets.
 
-    pub use event_sources::{FdEventSource, FdEventSourceImpl};
-    pub use event_sources::{FdInterest, READ, WRITE};
+    pub use event_sources::{FdEventSource, FdEventSourceImpl, FdInterest};
     pub use event_sources::{SignalEventSource, SignalEventSourceImpl};
     pub use event_sources::{TimerEventSource, TimerEventSourceImpl};
 }

--- a/wayland-sys/Cargo.toml
+++ b/wayland-sys/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["external-ffi-bindings"]
 travis-ci = { repository = "smithay/wayland-rs" }
 
 [dependencies]
-dlib = "0.3"
+dlib = "0.4"
 libc = { version = "0.2", optional = true }
 lazy_static = { version = "0.2", optional = true }
 


### PR DESCRIPTION
Updates dependencies:

- dlib -> 0.4
- bitflags -> 1.0 [breaking change]

And correct documentation for enum & bitflags variants that were not always properly generated.

Also, document that the last supported rust version is 1.20 and CI-test it.