### PR TITLE
Add a notify to EnvHandler & externalize state to token_store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [client] Add `EnvHandler::init_with_notify()` to still be notified about
   global events when using `EnvHandler`.
+- [client/server] Externalise state logic to crate `token_store`
 
 ## 0.11.0 - 2017-10-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- [client] Add `EnvHandler::init_with_notify()` to still be notified about
+  global events when using `EnvHandler`.
+
 ## 0.11.0 - 2017-10-09
 
 - **Breaking change**: Update bitflags dependency to 1.0. Generated code for

--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -17,6 +17,7 @@ travis-ci = { repository = "smithay/wayland-rs" }
 wayland-sys = { version = "0.11.0", features = ["client"], path = "../wayland-sys" }
 libc = "0.2"
 bitflags = "1.0"
+token_store = "0.1"
 
 [build-dependencies]
 wayland-scanner = { version = "0.11.0", path = "../wayland-scanner" }

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -98,7 +98,7 @@ pub mod egl;
 pub mod cursor;
 
 pub use display::{connect_to, default_connect, ConnectError, FatalError};
-pub use env::{EnvHandler, EnvHandlerInner};
+pub use env::{EnvHandler, EnvHandlerInner, EnvNotify};
 pub use event_queue::{EventQueue, EventQueueHandle, ReadEventsGuard, RegisterStatus, State, StateToken};
 
 /// Common routines for wayland proxy objects.

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -79,6 +79,7 @@
 #[macro_use]
 extern crate bitflags;
 extern crate libc;
+extern crate token_store;
 #[macro_use]
 extern crate wayland_sys;
 

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -18,6 +18,7 @@ wayland-sys = { version = "0.11.0", features = ["server"], path = "../wayland-sy
 libc = "0.2"
 nix = "0.9"
 bitflags = "1.0"
+token_store = "0.1"
 
 [build-dependencies]
 wayland-scanner = { version = "0.11.0", path = "../wayland-scanner" }

--- a/wayland-server/src/event_loop.rs
+++ b/wayland-server/src/event_loop.rs
@@ -1,15 +1,13 @@
 use {Client, Implementable, Resource};
 use std::any::Any;
-use std::cell::Cell;
 use std::io::{Error as IoError, Result as IoResult};
 use std::io::Write;
-use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::os::raw::{c_int, c_void};
 use std::os::unix::io::RawFd;
-use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicPtr};
+pub use token_store::{Store as State, Token as StateToken};
 use wayland_sys::RUST_MANAGED;
 use wayland_sys::common::{wl_argument, wl_message};
 use wayland_sys::server::*;
@@ -29,102 +27,6 @@ pub enum RegisterStatus {
     Unmanaged,
     /// The resource was not registered because it is already destroyed.
     Dead,
-}
-
-/// A state store
-///
-/// This struct allows you to store various values in a special
-/// storage that will be made available to your proxy implementations.
-pub struct State {
-    values: Vec<Option<(Box<Any>, Rc<Cell<bool>>)>>,
-}
-
-/// A token for accessing the state store contents
-pub struct StateToken<V> {
-    id: usize,
-    live: Rc<Cell<bool>>,
-    _type: PhantomData<V>,
-}
-
-impl<V> Clone for StateToken<V> {
-    fn clone(&self) -> StateToken<V> {
-        StateToken {
-            id: self.id,
-            live: self.live.clone(),
-            _type: PhantomData,
-        }
-    }
-}
-
-impl State {
-    /// Insert a new value in this state store
-    ///
-    /// Returns a clonable token that you can later use to access this
-    /// value.
-    pub fn insert<V: Any + 'static>(&mut self, value: V) -> StateToken<V> {
-        let boxed = Box::new(value) as Box<Any>;
-        let live = Rc::new(Cell::new(true));
-        {
-            // artificial scope to make the borrow checker happy
-            let empty_slot = self.values
-                .iter_mut()
-                .enumerate()
-                .find(|&(_, ref s)| s.is_none());
-            if let Some((id, slot)) = empty_slot {
-                *slot = Some((boxed, live.clone()));
-                return StateToken {
-                    id: id,
-                    live: live,
-                    _type: PhantomData,
-                };
-            }
-        }
-        self.values.push(Some((boxed, live.clone())));
-        StateToken {
-            id: self.values.len() - 1,
-            live: live,
-            _type: PhantomData,
-        }
-    }
-
-    /// Access value previously inserted in this state store
-    ///
-    /// Panics if the provided token corresponds to a value that was removed.
-    pub fn get<V: Any + 'static>(&self, token: &StateToken<V>) -> &V {
-        if !token.live.get() {
-            panic!("Attempted to access a state value that was already removed!");
-        }
-        self.values[token.id]
-            .as_ref()
-            .and_then(|t| t.0.downcast_ref::<V>())
-            .unwrap()
-    }
-
-    /// Mutably access value previously inserted in this state store
-    ///
-    /// Panics if the provided token corresponds to a value that was removed.
-    pub fn get_mut<V: Any + 'static>(&mut self, token: &StateToken<V>) -> &mut V {
-        if !token.live.get() {
-            panic!("Attempted to access a state value that was already removed!");
-        }
-        self.values[token.id]
-            .as_mut()
-            .and_then(|t| t.0.downcast_mut::<V>())
-            .unwrap()
-    }
-
-    /// Remove a value previously inserted in this state store
-    ///
-    /// Panics if the provided token corresponds to a value that was already
-    /// removed.
-    pub fn remove<V: Any + 'static>(&mut self, token: StateToken<V>) -> V {
-        if !token.live.get() {
-            panic!("Attempted to remove a state value that was already removed!");
-        }
-        let (boxed, live) = self.values[token.id].take().unwrap();
-        live.set(false);
-        *boxed.downcast().unwrap()
-    }
 }
 
 /// A handle to a global object
@@ -376,7 +278,7 @@ pub unsafe fn create_event_loop(ptr: *mut wl_event_loop, display: Option<*mut wl
     EventLoop {
         display: display,
         handle: Box::new(EventLoopHandle {
-            state: State { values: Vec::new() },
+            state: State::new(),
             keep_going: false,
             ptr: ptr,
         }),

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -99,9 +99,9 @@
 extern crate bitflags;
 extern crate libc;
 extern crate nix;
+extern crate token_store;
 #[macro_use]
 extern crate wayland_sys;
-
 
 pub use client::Client;
 pub use display::{create_display, Display};


### PR DESCRIPTION
- [client] Add `EnvHandler::init_with_notify()` to still be notified about global events when using `EnvHandler`.
- [client/server] Externalise state logic to crate `token_store`