### PR TITLE
Update xml-rs to v0.7 and byteorder to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-## 0.11.3 - 2017-12-15
+- [scanner] Update xml-rs dependency to 0.7
+
+## 0.11.3 - 2017-10-15
 
 - [client] Add `EnvHandler::clone_inner()`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.11.4 - 2017-10-16
+
 - [client] Update byteorder dependency to v1
 - [scanner] Update xml-rs dependency to 0.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [client] Update byteorder dependency to v1
 - [scanner] Update xml-rs dependency to 0.7
 
 ## 0.11.3 - 2017-10-15

--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -23,7 +23,7 @@ token_store = "0.1.1"
 wayland-scanner = { version = "0.11.3", path = "../wayland-scanner" }
 
 [dev-dependencies]
-byteorder = "0.5"
+byteorder = "1"
 tempfile = "2"
 
 [features]

--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-client"
-version = "0.11.3"
+version = "0.11.4"
 documentation = "https://smithay.github.io/wayland-rs/wayland_client/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Victor Berger <victor.berger@m4x.org>"]
@@ -14,13 +14,13 @@ build = "build.rs"
 travis-ci = { repository = "smithay/wayland-rs" }
 
 [dependencies]
-wayland-sys = { version = "0.11.3", features = ["client"], path = "../wayland-sys" }
+wayland-sys = { version = "0.11.4", features = ["client"], path = "../wayland-sys" }
 libc = "0.2"
 bitflags = "1.0"
 token_store = "0.1.1"
 
 [build-dependencies]
-wayland-scanner = { version = "0.11.3", path = "../wayland-scanner" }
+wayland-scanner = { version = "0.11.4", path = "../wayland-scanner" }
 
 [dev-dependencies]
 byteorder = "1"

--- a/wayland-protocols/Cargo.toml
+++ b/wayland-protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-protocols"
-version = "0.11.3"
+version = "0.11.4"
 documentation = "https://smithay.github.io/wayland-rs/wayland_protocols/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Victor Berger <victor.berger@m4x.org>"]
@@ -14,13 +14,13 @@ categories = ["gui", "api-bindings"]
 travis-ci = { repository = "smithay/wayland-rs" }
 
 [dependencies]
-wayland-sys = { version = "0.11.3", path = "../wayland-sys" }
-wayland-client = { version = "0.11.3", path = "../wayland-client", optional = true, default-features = false }
-wayland-server = { version = "0.11.3", path = "../wayland-server", optional = true }
+wayland-sys = { version = "0.11.4", path = "../wayland-sys" }
+wayland-client = { version = "0.11.4", path = "../wayland-client", optional = true, default-features = false }
+wayland-server = { version = "0.11.4", path = "../wayland-server", optional = true }
 bitflags = "1.0"
 
 [build-dependencies]
-wayland-scanner = { version = "0.11.3", path = "../wayland-scanner" }
+wayland-scanner = { version = "0.11.4", path = "../wayland-scanner" }
 
 [features]
 client = ["wayland-client"]

--- a/wayland-scanner/Cargo.toml
+++ b/wayland-scanner/Cargo.toml
@@ -13,4 +13,4 @@ keywords = ["wayland", "codegen"]
 travis-ci = { repository = "smithay/wayland-rs" }
 
 [dependencies]
-xml-rs = "0.6"
+xml-rs = "0.7"

--- a/wayland-scanner/Cargo.toml
+++ b/wayland-scanner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-scanner"
-version = "0.11.3"
+version = "0.11.4"
 authors = ["Victor Berger <victor.berger@m4x.org>"]
 repository = "https://github.com/smithay/wayland-rs"
 documentation = "https://smithay.github.io/wayland-rs/wayland_scanner/"

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-server"
-version = "0.11.3"
+version = "0.11.4"
 documentation = "https://smithay.github.io/wayland-rs/wayland_server/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Victor Berger <victor.berger@m4x.org>"]
@@ -14,14 +14,14 @@ build = "build.rs"
 travis-ci = { repository = "smithay/wayland-rs" }
 
 [dependencies]
-wayland-sys = { version = "0.11.3", features = ["server"], path = "../wayland-sys" }
+wayland-sys = { version = "0.11.4", features = ["server"], path = "../wayland-sys" }
 libc = "0.2"
 nix = "0.9"
 bitflags = "1.0"
 token_store = "0.1.1"
 
 [build-dependencies]
-wayland-scanner = { version = "0.11.3", path = "../wayland-scanner" }
+wayland-scanner = { version = "0.11.4", path = "../wayland-scanner" }
 
 [features]
 dlopen = ["wayland-sys/dlopen"]

--- a/wayland-sys/Cargo.toml
+++ b/wayland-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-sys"
-version = "0.11.3"
+version = "0.11.4"
 repository = "https://github.com/smithay/wayland-rs"
 documentation = "https://smithay.github.io/wayland-rs/wayland_sys/"
 authors = ["Victor Berger <victor.berger@m4x.org>"]


### PR DESCRIPTION
Deduplicates bitflags dependency from xml-rs. Also corrected a typo in Changelog.md.

Edit: Looks like xml-rs is about to [drop bitflags](https://github.com/netvl/xml-rs/commit/bb39eee35b6a861d6a9c0a50dda6152a222e4a76), possibly undoing previous version break(?) Best not to merge yet.