### PR TITLE
Fixes #158 Can now parse KDE server dec protocol

### DIFF
--- a/wayland-scanner/src/parse.rs
+++ b/wayland-scanner/src/parse.rs
@@ -67,7 +67,12 @@ fn parse_protocol<'a, S: Read + 'a>(mut iter: Events<S>) -> Protocol {
                 match &name.local_name[..] {
                     "copyright" => {
                         // parse the copyright
-                        let copyright = extract_from!(iter => XmlEvent::Characters(copyright) => copyright);
+                        let copyright = match iter.next() {
+                            Some(Ok(XmlEvent::Characters(copyright))) |
+                            Some(Ok(XmlEvent::CData(copyright))) => copyright,
+                            e => panic!("Ill-formed protocol file: {:?}", e)
+                        };
+
                         extract_end_tag!(iter => "copyright");
                         protocol.copyright = Some(copyright);
                     }


### PR DESCRIPTION
Fixes an issue found while parsing the KDE client side decoration protocol where parsing the copyright clause would cause a panic if it contained a CDATA instead of a just the contents of the copyright notice.

This fixes this by properly unwrapping the string from the `CData`