### PR TITLE
client: check libs in `Display::connect_to_env`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [client] Check availability of library in `Display::connect_to_env`
+
 ## 0.20.2 - 2018-04-30
 
 - [server] Add methods for manual client management

--- a/wayland-client/src/display.rs
+++ b/wayland-client/src/display.rs
@@ -102,6 +102,10 @@ impl Display {
         }
         #[cfg(feature = "native_lib")]
         {
+            if !::wayland_sys::client::is_lib_available() {
+                return Err(ConnectError::NoWaylandLib);
+            }
+
             unsafe {
                 let display_ptr = ffi_dispatch!(
                     WAYLAND_CLIENT_HANDLE,


### PR DESCRIPTION
Check if the client libraries are available in
`Display::connect_to_env` before accessing `WAYLAND_CLIENT_HANDLE`.

This should help with https://github.com/tomaka/winit/issues/504.