### PR TITLE
client: make make_display public

### DIFF
--- a/wayland-client/src/display.rs
+++ b/wayland-client/src/display.rs
@@ -70,7 +70,11 @@ pub struct Display {
 
 impl Display {
     #[cfg(feature = "native_lib")]
-    unsafe fn make_display(ptr: *mut wl_display) -> Result<(Display, EventQueue), ConnectError> {
+    /// Wrap an existing wayland connection (e.g. from a UI toolkit) into Rust wrappers.
+    ///
+    /// On success, you are given the `Display` object as well as the main `EventQueue` hosting
+    /// the `WlDisplay` wayland object.
+    pub unsafe fn make_display(ptr: *mut wl_display) -> Result<(Display, EventQueue), ConnectError> {
         if ptr.is_null() {
             return Err(ConnectError::NoCompositorListening);
         }


### PR DESCRIPTION
To allow using wayland-rs with `wl_display` objects received from e.g. UI toolkits.

(My use case: setting up a GTK window with a custom shell protocol instead of xdg-shell.)