### PR TITLE
scanner: Fix '*mut_' typo (add space)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [scanner] Fixed `*mut_` typo when generating code for nullable array arguments
+
 # 0.20.10 - 2018-06-04
 
 - [client] Fix regression from previous release where `Display` was no longer

--- a/wayland-scanner/src/c_code_gen.rs
+++ b/wayland-scanner/src/c_code_gen.rs
@@ -325,7 +325,7 @@ pub fn write_messagegroup_impl<O: Write>(
                     }
                     Type::Array => {
                         if a.allow_null {
-                            writeln!(out, "let _arg_{} = {}.as_ref().map(|vec| wl_array {{ size: vec.len(), alloc: vec.capacity(), data: vec.as_ptr() as *mut_ }});", j, a.name)?;
+                            writeln!(out, "let _arg_{} = {}.as_ref().map(|vec| wl_array {{ size: vec.len(), alloc: vec.capacity(), data: vec.as_ptr() as *mut _ }});", j, a.name)?;
                             write!(out, "                    ")?;
                             writeln!(out, "_args_array[{}].a = _arg_{}.as_ref().map(|a| a as *const wl_array).unwrap_or(::std::ptr::null());", j, j)?;
                         } else {


### PR DESCRIPTION
Was erroring with "expected mut or const in raw pointer type"