### PR TITLE
Added as_ptr to Display and EventQueue

### DIFF
--- a/wayland-client/src/display.rs
+++ b/wayland-client/src/display.rs
@@ -95,6 +95,12 @@ impl Display {
     }
 
     #[cfg(feature = "native_lib")]
+    /// Gets the raw wl_display pointer.
+    pub fn as_ptr(&self) -> *mut wl_display {
+        self.inner.display
+    }
+
+    #[cfg(feature = "native_lib")]
     /// Create a Display and Event Queue from an external display
     ///
     /// This allows you to interface with an already-existing wayland connection,

--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -72,6 +72,12 @@ impl EventQueue {
         }
     }
 
+    #[cfg(feature = "native_lib")]
+    /// Gets the raw wl_event_queue pointer.
+    pub fn as_ptr(&self) -> *mut wl_event_queue {
+        self.inner.wlevq.unwrap_or_else(|| ptr::null_mut())
+    }
+
     /// Dispatches events from the internal buffer.
     ///
     /// Dispatches all events to their appropriaters.


### PR DESCRIPTION
This is necessary in Way Cooler to set up the client event queue to respond after the glib main loop runs (this glue code is currently written in C, thus the need for the raw pointers).