### PR TITLE
Proxy::equals -> PartialEq::eq, impl Eq for Proxy

### DIFF
--- a/wayland-client/src/proxy.rs
+++ b/wayland-client/src/proxy.rs
@@ -50,20 +50,8 @@ unsafe impl<I: Interface> Send for Proxy<I> {}
 unsafe impl<I: Interface> Sync for Proxy<I> {}
 
 impl <I: Interface> PartialEq for Proxy<I> {
-    /// Check if the other proxy refers to the same underlying wayland object
     fn eq(&self, other: &Proxy<I>) -> bool {
-        #[cfg(not(feature = "native_lib"))]
-        {
-            unimplemented!()
-        }
-        #[cfg(feature = "native_lib")]
-        {
-            match (&self.internal, &other.internal) {
-                (&Some(ref my_inner), &Some(ref other_inner)) => Arc::ptr_eq(my_inner, other_inner),
-                (&None, &None) => self.ptr == other.ptr,
-                _ => false,
-            }
-        }
+        self.equals(other)
     }
 }
 
@@ -205,6 +193,22 @@ impl<I: Interface> Proxy<I> {
     /// See `from_c_ptr` for details.
     pub fn is_external(&self) -> bool {
         self.internal.is_none()
+    }
+
+    /// Check if the other proxy refers to the same underlying wayland object
+    pub fn equals(&self, other: &Proxy<I>) -> bool {
+        #[cfg(not(feature = "native_lib"))]
+        {
+            unimplemented!()
+        }
+        #[cfg(feature = "native_lib")]
+        {
+            match (&self.internal, &other.internal) {
+                (&Some(ref my_inner), &Some(ref other_inner)) => Arc::ptr_eq(my_inner, other_inner),
+                (&None, &None) => self.ptr == other.ptr,
+                _ => false,
+            }
+        }
     }
 
     #[cfg(feature = "native_lib")]

--- a/wayland-client/src/proxy.rs
+++ b/wayland-client/src/proxy.rs
@@ -49,6 +49,26 @@ pub struct Proxy<I: Interface> {
 unsafe impl<I: Interface> Send for Proxy<I> {}
 unsafe impl<I: Interface> Sync for Proxy<I> {}
 
+impl <I: Interface> PartialEq for Proxy<I> {
+    /// Check if the other proxy refers to the same underlying wayland object
+    fn eq(&self, other: &Proxy<I>) -> bool {
+        #[cfg(not(feature = "native_lib"))]
+        {
+            unimplemented!()
+        }
+        #[cfg(feature = "native_lib")]
+        {
+            match (&self.internal, &other.internal) {
+                (&Some(ref my_inner), &Some(ref other_inner)) => Arc::ptr_eq(my_inner, other_inner),
+                (&None, &None) => self.ptr == other.ptr,
+                _ => false,
+            }
+        }
+    }
+}
+
+impl <I: Interface> Eq for Proxy<I> {}
+
 impl<I: Interface> Proxy<I> {
     /// Send a request through this object
     ///
@@ -185,22 +205,6 @@ impl<I: Interface> Proxy<I> {
     /// See `from_c_ptr` for details.
     pub fn is_external(&self) -> bool {
         self.internal.is_none()
-    }
-
-    /// Check if the other proxy refers to the same underlying wayland object
-    pub fn equals(&self, other: &Proxy<I>) -> bool {
-        #[cfg(not(feature = "native_lib"))]
-        {
-            unimplemented!()
-        }
-        #[cfg(feature = "native_lib")]
-        {
-            match (&self.internal, &other.internal) {
-                (&Some(ref my_inner), &Some(ref other_inner)) => Arc::ptr_eq(my_inner, other_inner),
-                (&None, &None) => self.ptr == other.ptr,
-                _ => false,
-            }
-        }
     }
 
     #[cfg(feature = "native_lib")]


### PR DESCRIPTION
This allows you to use functions which depend on the PartialEq and Eq trait being defined.

Fixes #181 