### PR TITLE
Fuzzing

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,25 @@
+
+[package]
+name = "wayland-test-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.wayland-commons]
+path = "../wayland-commons/"
+
+[dependencies.wayland-test]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "message_parser"
+path = "fuzz_targets/message_parser.rs"

--- a/fuzz/fuzz_targets/message_parser.rs
+++ b/fuzz/fuzz_targets/message_parser.rs
@@ -1,0 +1,46 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate wayland_commons;
+
+use std::{mem, slice};
+use std::os::unix::io::RawFd;
+use wayland_commons::wire::{Message, ArgumentType};
+
+unsafe fn convert_slice<T: Sized>(data: &[u8]) -> &[T] {
+    let n = mem::size_of::<T>();
+    slice::from_raw_parts(
+        data.as_ptr() as *const T,
+        data.len()/n,
+    )
+}
+
+fn get_arg_types(data: &[u8]) -> [ArgumentType; 16] {
+    use ArgumentType::*;
+
+    let mut res = [Int; 16];
+    assert_eq!(data.len(), 16);
+    for i in 0..16 {
+        res[i] = match data[i] & 0b111 {
+            0 => Int,
+            1 => Uint,
+            2 => Fixed,
+            3 => Str,
+            4 => Object,
+            5 => NewId,
+            6 => Array,
+            7 => Fd,
+            _ => unreachable!(),
+        }
+    }
+    res
+}
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 32 { return; }
+    // 4 `RawFd`s
+    let fds: &[RawFd] = unsafe { convert_slice(&data[..16]) };
+    // 16 `ArgumentType`s
+    let args = get_arg_types(&data[16..32]);
+    let data: &[u32] = unsafe { convert_slice(&data[32..]) };
+    let _res = Message::from_raw(data, &args, fds);
+});

--- a/wayland-commons/src/wire.rs
+++ b/wayland-commons/src/wire.rs
@@ -232,7 +232,7 @@ impl Message {
         let opcode = (word_2 & 0x0000FFFF) as u16;
         let len = (word_2 >> 16) as usize / 4;
 
-        if len < 2 {
+        if len < 2 || len > raw.len() {
             return Err(MessageParseError::Malformed);
         }
 


### PR DESCRIPTION
Fuzzing with `cargo fuzz`. Closes #184.

To launch fuzzer use `cargo fuzz run message_parser` (you also can use `-j` option to increase number of workers). Currently it always passes 4 `RawFd`s and 16 `Argument`s, but I think it should be sufficient for testing.

It immediately found panic at `split_at` due to the insufficient length check. I will leave fuzzer for several hours, but looks like no other panics should happen.