### PR TITLE
Rework Proxy&Resource user_data mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [protocols] Remove support for wayland-wall, which has been discontinued.
 - [client] Add `Display::get_display_ptr()` to differentiate between the wrapper and the
   actual `wl_display`
+- [client] Rework user-data mechanism to introduce type-safety
 
 # 0.21.0-alpha1 - 2018-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [client] Add `Display::get_display_ptr()` to differentiate between the wrapper and the
   actual `wl_display`
 - [client] Rework user-data mechanism to introduce type-safety
+- [server] Rework `Resource` user-data mechanism to introduce type-safety
 
 # 0.21.0-alpha1 - 2018-07-18
 

--- a/tests/attach_to_surface.rs
+++ b/tests/attach_to_surface.rs
@@ -118,11 +118,11 @@ fn attach_null() {
 
     let compositor = manager
         .instantiate_exact::<wayc::protocol::wl_compositor::WlCompositor, _>(1, |comp| {
-            comp.implement(|_, _| {})
+            comp.implement(|_, _| {}, ())
         })
         .unwrap();
     let surface = compositor
-        .create_surface(|surface| surface.implement(|_, _| {}))
+        .create_surface(|surface| surface.implement(|_, _| {}, ()))
         .unwrap();
     surface.attach(None, 0, 0);
 
@@ -148,26 +148,26 @@ fn attach_buffer() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let shm = manager
-        .instantiate_exact::<wayc::protocol::wl_shm::WlShm, _>(1, |shm| shm.implement(|_, _| {}))
+        .instantiate_exact::<wayc::protocol::wl_shm::WlShm, _>(1, |shm| shm.implement(|_, _| {}, ()))
         .unwrap();
 
     let mut file = tempfile::tempfile().unwrap();
     write!(file, "I like trains!").unwrap();
     file.flush().unwrap();
     let pool = shm
-        .create_pool(file.as_raw_fd(), 42, |newp| newp.implement(|_, _| {}))
+        .create_pool(file.as_raw_fd(), 42, |newp| newp.implement(|_, _| {}, ()))
         .unwrap();
     let buffer = pool
-        .create_buffer(0, 0, 0, 0, Format::Argb8888, |newb| newb.implement(|_, _| {}))
+        .create_buffer(0, 0, 0, 0, Format::Argb8888, |newb| newb.implement(|_, _| {}, ()))
         .unwrap();
 
     let compositor = manager
         .instantiate_exact::<wayc::protocol::wl_compositor::WlCompositor, _>(1, |comp| {
-            comp.implement(|_, _| {})
+            comp.implement(|_, _| {}, ())
         })
         .unwrap();
     let surface = compositor
-        .create_surface(|surface| surface.implement(|_, _| {}))
+        .create_surface(|surface| surface.implement(|_, _| {}, ()))
         .unwrap();
     surface.attach(Some(&buffer), 0, 0);
 

--- a/tests/attach_to_surface.rs
+++ b/tests/attach_to_surface.rs
@@ -47,14 +47,14 @@ fn insert_compositor(server: &mut TestServer) -> Arc<Mutex<Option<Option<Resourc
                                 }
                             },
                             None::<fn(_, _)>,
-                            ()
+                            (),
                         );
                     } else {
                         panic!("Unexpected request on compositor!");
                     }
                 },
                 None::<fn(_, _)>,
-                ()
+                (),
             );
         },
     );
@@ -94,11 +94,11 @@ fn insert_shm(server: &mut TestServer) -> Arc<Mutex<Option<(RawFd, Option<Resour
                             }
                         },
                         None::<fn(_, _)>,
-                        ()
+                        (),
                     );
                 },
                 None::<fn(_, _)>,
-                ()
+                (),
             );
         });
 

--- a/tests/attach_to_surface.rs
+++ b/tests/attach_to_surface.rs
@@ -47,12 +47,14 @@ fn insert_compositor(server: &mut TestServer) -> Arc<Mutex<Option<Option<Resourc
                                 }
                             },
                             None::<fn(_, _)>,
+                            ()
                         );
                     } else {
                         panic!("Unexpected request on compositor!");
                     }
                 },
                 None::<fn(_, _)>,
+                ()
             );
         },
     );
@@ -86,15 +88,17 @@ fn insert_shm(server: &mut TestServer) -> Arc<Mutex<Option<(RawFd, Option<Resour
                                 let mut buffer_guard = pool_buffer.lock().unwrap();
                                 let buf = buffer_guard.as_mut().unwrap();
                                 assert!(buf.1.is_none());
-                                buf.1 = Some(id.implement(|_, _| {}, None::<fn(_, _)>));
+                                buf.1 = Some(id.implement(|_, _| {}, None::<fn(_, _)>, ()));
                             } else {
                                 panic!("Unexpected request on buffer!");
                             }
                         },
                         None::<fn(_, _)>,
+                        ()
                     );
                 },
                 None::<fn(_, _)>,
+                ()
             );
         });
 

--- a/tests/client_dispatch.rs
+++ b/tests/client_dispatch.rs
@@ -72,7 +72,7 @@ fn client_dispatch() {
     let token = client.event_queue.get_token();
     client
         .display
-        .sync(move |newcb| unsafe { newcb.implement_nonsend(move |_, _| done2.set(true), &token) })
+        .sync(move |newcb| unsafe { newcb.implement_nonsend(move |_, _| done2.set(true), (), &token) })
         .unwrap();
     while !done.get() {
         client.event_queue.dispatch().unwrap();

--- a/tests/client_proxies.rs
+++ b/tests/client_proxies.rs
@@ -35,11 +35,11 @@ fn proxy_equals() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let compositor1 = manager
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement(CompImpl1))
+        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement(CompImpl1, ()))
         .unwrap();
 
     let compositor2 = manager
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement(CompImpl1))
+        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement(CompImpl1, ()))
         .unwrap();
 
     let compositor3 = compositor1.clone();
@@ -63,22 +63,19 @@ fn proxy_user_data() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let compositor1 = manager
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement(CompImpl1))
+        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement(CompImpl1, 0xDEADBEEFusize))
         .unwrap();
-
-    compositor1.set_user_data(0xDEADBEEF as usize as *mut _);
 
     let compositor2 = manager
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement(CompImpl1))
+        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement(CompImpl1, 0xBADC0FFEusize))
         .unwrap();
-
-    compositor2.set_user_data(0xBADC0FFE as usize as *mut _);
 
     let compositor3 = compositor1.clone();
 
-    assert!(compositor1.get_user_data() as usize == 0xDEADBEEF);
-    assert!(compositor2.get_user_data() as usize == 0xBADC0FFE);
-    assert!(compositor3.get_user_data() as usize == 0xDEADBEEF);
+    assert!(compositor1.user_data::<usize>() == Some(&0xDEADBEEF));
+    assert!(compositor2.user_data::<usize>() == Some(&0xBADC0FFE));
+    assert!(compositor3.user_data::<usize>() == Some(&0xDEADBEEF));
+    assert!(compositor1.user_data::<u32>() == None);
 }
 
 #[test]
@@ -95,11 +92,11 @@ fn proxy_is_implemented() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let compositor1 = manager
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement(CompImpl1))
+        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement(CompImpl1, ()))
         .unwrap();
 
     let compositor2 = manager
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement(CompImpl2))
+        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement(CompImpl2, ()))
         .unwrap();
 
     let compositor3 = compositor1.clone();
@@ -151,7 +148,7 @@ fn dead_proxies() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let output = manager
-        .instantiate_auto::<wl_output::WlOutput, _>(|newp| newp.implement(|_, _| {}))
+        .instantiate_auto::<wl_output::WlOutput, _>(|newp| newp.implement(|_, _| {}, ()))
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();

--- a/tests/destructors.rs
+++ b/tests/destructors.rs
@@ -34,7 +34,7 @@ fn resource_destructor() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let output = manager
-        .instantiate_auto::<WlOutput, _>(|newp| newp.implement(|_, _| {}))
+        .instantiate_auto::<WlOutput, _>(|newp| newp.implement(|_, _| {}, ()))
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();
@@ -71,7 +71,7 @@ fn resource_destructor_cleanup() {
     roundtrip(&mut client, &mut server).unwrap();
 
     manager
-        .instantiate_auto::<WlOutput, _>(|newp| newp.implement(|_, _| {}))
+        .instantiate_auto::<WlOutput, _>(|newp| newp.implement(|_, _| {}, ()))
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();
@@ -110,7 +110,7 @@ fn client_destructor_cleanup() {
     roundtrip(&mut client, &mut server).unwrap();
 
     manager
-        .instantiate_auto::<WlOutput, _>(|newp| newp.implement(|_, _| {}))
+        .instantiate_auto::<WlOutput, _>(|newp| newp.implement(|_, _| {}, ()))
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();

--- a/tests/destructors.rs
+++ b/tests/destructors.rs
@@ -25,6 +25,7 @@ fn resource_destructor() {
                 Some(move |_, _| {
                     *destructor_called_resource.lock().unwrap() = true;
                 }),
+                ()
             );
         });
 
@@ -62,6 +63,7 @@ fn resource_destructor_cleanup() {
                 Some(move |_, _| {
                     *destructor_called_resource.lock().unwrap() = true;
                 }),
+                ()
             );
         });
 
@@ -95,7 +97,7 @@ fn client_destructor_cleanup() {
         .display
         .create_global::<ServerOutput, _>(&loop_token, 3, move |_, newo: NewResource<_>| {
             let destructor_called_resource = destructor_called_global.clone();
-            let output = newo.implement(|_, _| {}, None::<fn(_, _)>);
+            let output = newo.implement(|_, _| {}, None::<fn(_, _)>, ());
             let client = output.client().unwrap();
             client.set_user_data(Box::into_raw(Box::new(destructor_called_resource)) as *mut _);
             client.set_destructor(|data| {

--- a/tests/destructors.rs
+++ b/tests/destructors.rs
@@ -25,7 +25,7 @@ fn resource_destructor() {
                 Some(move |_, _| {
                     *destructor_called_resource.lock().unwrap() = true;
                 }),
-                ()
+                (),
             );
         });
 
@@ -63,7 +63,7 @@ fn resource_destructor_cleanup() {
                 Some(move |_, _| {
                     *destructor_called_resource.lock().unwrap() = true;
                 }),
-                ()
+                (),
             );
         });
 

--- a/tests/globals.rs
+++ b/tests/globals.rs
@@ -156,24 +156,24 @@ fn auto_instanciate() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let compositor = manager
-        .instantiate_auto::<WlCompositor, _>(|newp| newp.implement(|_, _| {}))
+        .instantiate_auto::<WlCompositor, _>(|newp| newp.implement(|_, _| {}, ()))
         .unwrap();
     assert!(compositor.version() == 4);
     let shell = manager
-        .instantiate_auto::<WlShell, _>(|newp| newp.implement(|_, _| {}))
+        .instantiate_auto::<WlShell, _>(|newp| newp.implement(|_, _| {}, ()))
         .unwrap();
     assert!(shell.version() == 1);
 
     assert!(
-        manager.instantiate_exact::<WlCompositor, _>(5, |newp| newp.implement(|_, _| {}))
+        manager.instantiate_exact::<WlCompositor, _>(5, |newp| newp.implement(|_, _| {}, ()))
             == Err(GlobalError::VersionTooLow(4))
     );
     assert!(
-        manager.instantiate_exact::<WlOutput, _>(5, |newp| newp.implement(|_, _| {}))
+        manager.instantiate_exact::<WlOutput, _>(5, |newp| newp.implement(|_, _| {}, ()))
             == Err(GlobalError::Missing)
     );
     assert!(
-        manager.instantiate_auto::<WlOutput, _>(|newp| newp.implement(|_, _| {}))
+        manager.instantiate_auto::<WlOutput, _>(|newp| newp.implement(|_, _| {}, ()))
             == Err(GlobalError::Missing)
     );
 }
@@ -204,14 +204,14 @@ fn wrong_global() {
     let mut client = TestClient::new(&server.socket_name);
     let registry = client
         .display
-        .get_registry(|newp| newp.implement(|_, _| {}))
+        .get_registry(|newp| newp.implement(|_, _| {}, ()))
         .unwrap();
 
     // instanciate a wrong global, this should kill the client
     // But currently does not fail on native_lib
 
     registry
-        .bind::<WlOutput, _>(1, 1, |newp| newp.implement(|_, _| {}))
+        .bind::<WlOutput, _>(1, 1, |newp| newp.implement(|_, _| {}, ()))
         .unwrap();
 
     assert!(roundtrip(&mut client, &mut server).is_err());
@@ -232,13 +232,13 @@ fn wrong_global_version() {
     let mut client = TestClient::new(&server.socket_name);
     let registry = client
         .display
-        .get_registry(|newp| newp.implement(|_, _| {}))
+        .get_registry(|newp| newp.implement(|_, _| {}, ()))
         .unwrap();
 
     // instanciate a global with wrong version, this shoudl kill the client
 
     registry
-        .bind::<WlCompositor, _>(2, 1, |newp| newp.implement(|_, _| {}))
+        .bind::<WlCompositor, _>(2, 1, |newp| newp.implement(|_, _| {}, ()))
         .unwrap();
 
     assert!(roundtrip(&mut client, &mut server).is_err());
@@ -259,13 +259,13 @@ fn invalid_global_version() {
     let mut client = TestClient::new(&server.socket_name);
     let registry = client
         .display
-        .get_registry(|newp| newp.implement(|_, _| {}))
+        .get_registry(|newp| newp.implement(|_, _| {}, ()))
         .unwrap();
 
     // instanciate a global with version 0, which is invalid this shoudl kill the client
 
     registry
-        .bind::<WlCompositor, _>(0, 1, |newp| newp.implement(|_, _| {}))
+        .bind::<WlCompositor, _>(0, 1, |newp| newp.implement(|_, _| {}, ()))
         .unwrap();
 
     assert!(roundtrip(&mut client, &mut server).is_err());
@@ -286,13 +286,13 @@ fn wrong_global_id() {
     let mut client = TestClient::new(&server.socket_name);
     let registry = client
         .display
-        .get_registry(|newp| newp.implement(|_, _| {}))
+        .get_registry(|newp| newp.implement(|_, _| {}, ()))
         .unwrap();
 
     // instanciate a global with wrong id, this should kill the client
 
     registry
-        .bind::<WlCompositor, _>(1, 3, |newp| newp.implement(|_, _| {}))
+        .bind::<WlCompositor, _>(1, 3, |newp| newp.implement(|_, _| {}, ()))
         .unwrap();
 
     assert!(roundtrip(&mut client, &mut server).is_err());

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -73,7 +73,7 @@ pub fn roundtrip(client: &mut TestClient, server: &mut TestServer) -> io::Result
     let token = client.event_queue.get_token();
     client
         .display
-        .sync(move |newcb| unsafe { newcb.implement_nonsend(move |_, _| done2.set(true), &token) })
+        .sync(move |newcb| unsafe { newcb.implement_nonsend(move |_, _| done2.set(true), (), &token) })
         .unwrap();
     while !done.get() {
         client.display.flush()?;

--- a/tests/server_created_object.rs
+++ b/tests/server_created_object.rs
@@ -29,19 +29,20 @@ fn data_offer() {
             new_resource.implement(
                 |request, _| match request {
                     SDDMReq::GetDataDevice { id, .. } => {
-                        let ddevice = id.implement(|_, _| {}, None::<fn(_, _)>);
+                        let ddevice = id.implement(|_, _| {}, None::<fn(_, _)>, ());
                         // create a data offer and send it
                         let offer = ddevice
                             .client()
                             .unwrap()
                             .create_resource::<ServerDO>(ddevice.version())
                             .unwrap()
-                            .implement(|_, _| {}, None::<fn(_, _)>);
+                            .implement(|_, _| {}, None::<fn(_, _)>, ());
                         ddevice.send(SDDEvt::DataOffer { id: offer })
                     }
                     _ => unimplemented!(),
                 },
                 None::<fn(_, _)>,
+                ()
             );
         },
     );

--- a/tests/server_created_object.rs
+++ b/tests/server_created_object.rs
@@ -52,10 +52,10 @@ fn data_offer() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let seat = manager
-        .instantiate_auto::<ClientSeat, _>(|newseat| newseat.implement(|_, _| {}))
+        .instantiate_auto::<ClientSeat, _>(|newseat| newseat.implement(|_, _| {}, ()))
         .unwrap();
     let ddmgr = manager
-        .instantiate_auto::<ClientDDMgr, _>(|newddmgr| newddmgr.implement(|_, _| {}))
+        .instantiate_auto::<ClientDDMgr, _>(|newddmgr| newddmgr.implement(|_, _| {}, ()))
         .unwrap();
 
     let received = Arc::new(Mutex::new(false));
@@ -63,14 +63,17 @@ fn data_offer() {
 
     ddmgr
         .get_data_device(&seat, move |newdd| {
-            newdd.implement(move |evt, _| match evt {
-                CDDEvt::DataOffer { id } => {
-                    let doffer = id.implement(|_, _| {});
-                    assert!(doffer.version() == 3);
-                    *received2.lock().unwrap() = true;
-                }
-                _ => unimplemented!(),
-            })
+            newdd.implement(
+                move |evt, _| match evt {
+                    CDDEvt::DataOffer { id } => {
+                        let doffer = id.implement(|_, _| {}, ());
+                        assert!(doffer.version() == 3);
+                        *received2.lock().unwrap() = true;
+                    }
+                    _ => unimplemented!(),
+                },
+                (),
+            )
         })
         .unwrap();
 

--- a/tests/server_created_object.rs
+++ b/tests/server_created_object.rs
@@ -42,7 +42,7 @@ fn data_offer() {
                     _ => unimplemented!(),
                 },
                 None::<fn(_, _)>,
-                ()
+                (),
             );
         },
     );

--- a/tests/server_resources.rs
+++ b/tests/server_resources.rs
@@ -35,7 +35,7 @@ fn resource_equals() {
             outputs2
                 .lock()
                 .unwrap()
-                .push(newo.implement(|_, _| {}, None::<fn(_, _)>));
+                .push(newo.implement(|_, _| {}, None::<fn(_, _)>, ()));
         });
 
     let mut client = TestClient::new(&server.socket_name);
@@ -75,8 +75,7 @@ fn resource_user_data() {
         .display
         .create_global::<wl_output::WlOutput, _>(&loop_token, 1, move |_, newo: NewResource<_>| {
             let mut guard = outputs2.lock().unwrap();
-            let output = newo.implement(|_, _| {}, None::<fn(_, _)>);
-            output.set_user_data((1000 + guard.len()) as *mut ());
+            let output = newo.implement(|_, _| {}, None::<fn(_, _)>, 1000 + guard.len());
             guard.push(output);
         });
 
@@ -96,12 +95,10 @@ fn resource_user_data() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let outputs_lock = outputs.lock().unwrap();
-    assert!(outputs_lock[0].get_user_data() as usize == 1000);
-    assert!(outputs_lock[1].get_user_data() as usize == 1001);
+    assert!(outputs_lock[0].user_data::<usize>() == Some(&1000));
+    assert!(outputs_lock[1].user_data::<usize>() == Some(&1001));
     let cloned = outputs_lock[0].clone();
-    assert!(cloned.get_user_data() as usize == 1000);
-    outputs_lock[0].set_user_data(4242usize as *mut ());
-    assert!(cloned.get_user_data() as usize == 4242);
+    assert!(cloned.user_data::<usize>() == Some(&1000));
 }
 
 #[test]
@@ -117,9 +114,9 @@ fn resource_is_implemented() {
         .create_global::<wl_output::WlOutput, _>(&loop_token, 1, move |_, newo: NewResource<_>| {
             let mut guard = outputs2.lock().unwrap();
             let output = if guard.len() == 0 {
-                newo.implement(Impl1, None::<fn(_, _)>)
+                newo.implement(Impl1, None::<fn(_, _)>, ())
             } else {
-                newo.implement(Impl2, None::<fn(_, _)>)
+                newo.implement(Impl2, None::<fn(_, _)>, ())
             };
             guard.push(output);
         });
@@ -164,7 +161,7 @@ fn dead_resources() {
             outputs2
                 .lock()
                 .unwrap()
-                .push(newo.implement(|_, _| {}, None::<fn(_, _)>));
+                .push(newo.implement(|_, _| {}, None::<fn(_, _)>, ()));
         });
 
     let mut client = TestClient::new(&server.socket_name);

--- a/tests/server_resources.rs
+++ b/tests/server_resources.rs
@@ -45,10 +45,10 @@ fn resource_equals() {
 
     // create two outputs
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}))
+        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}, ()))
         .unwrap();
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}))
+        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}, ()))
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();
@@ -87,10 +87,10 @@ fn resource_user_data() {
 
     // create two outputs
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}))
+        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}, ()))
         .unwrap();
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}))
+        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}, ()))
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();
@@ -131,10 +131,10 @@ fn resource_is_implemented() {
 
     // create two outputs
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}))
+        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}, ()))
         .unwrap();
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}))
+        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}, ()))
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();
@@ -173,10 +173,10 @@ fn dead_resources() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let client_output1 = manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}))
+        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}, ()))
         .unwrap();
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}))
+        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}, ()))
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();

--- a/wayland-client/examples/dynamic_globals.rs
+++ b/wayland-client/examples/dynamic_globals.rs
@@ -28,71 +28,77 @@ fn main() {
             [wl_seat::WlSeat, 1, |seat: NewProxy<_>| {
                 let mut seat_name = None;
                 let mut caps = None;
-                seat.implement(move |event, _| {
-                    use wayland_client::protocol::wl_seat::Event;
-                    match event {
-                        Event::Name { name } => {
-                            seat_name = Some(name);
+                seat.implement(
+                    move |event, _| {
+                        use wayland_client::protocol::wl_seat::Event;
+                        match event {
+                            Event::Name { name } => {
+                                seat_name = Some(name);
+                            }
+                            Event::Capabilities { capabilities } => {
+                                // We *should* have received the "name" event first
+                                caps = Some(capabilities);
+                            }
                         }
-                        Event::Capabilities { capabilities } => {
-                            // We *should* have received the "name" event first
-                            caps = Some(capabilities);
-                        }
-                    }
-                })
+                    },
+                    (),
+                )
             }],
             // Same thing with wl_output, but we require version 2
             [wl_output::WlOutput, 2, |output: NewProxy<_>| {
                 let mut name = "<unknown>".to_owned();
                 let mut modes = Vec::new();
                 let mut scale = 1;
-                output.implement(move |event, _| {
-                    use wayland_client::protocol::wl_output::Event;
-                    match event {
-                        Event::Geometry {
-                            x,
-                            y,
-                            physical_width,
-                            physical_height,
-                            subpixel,
-                            make,
-                            model,
-                            transform,
-                        } => {
-                            println!("New output: \"{} ({})\"", make, model);
-                            println!(" -> physical dimensions {}x{}", physical_width, physical_height);
-                            println!(" -> location in the compositor space: ({}, {})", x, y);
-                            println!(" -> transform: {:?}", transform);
-                            println!(" -> subpixel orientation: {:?}", subpixel);
-                            name = format!("{} ({})", make, model);
-                        }
-                        Event::Mode {
-                            flags,
-                            width,
-                            height,
-                            refresh,
-                        } => {
-                            modes.push((flags, width, height, refresh));
-                        }
-                        Event::Scale { factor } => {
-                            scale = factor;
-                        }
-                        Event::Done => {
-                            println!("Modesetting information for output \"{}\"", name);
-                            println!(" -> scaling factor: {}", scale);
-                            println!(" -> mode list:");
-                            for &(f, w, h, r) in &modes {
-                                println!(
-                                    "   -> {}x{} @{}Hz (flags: [ {:?} ])",
-                                    w,
-                                    h,
-                                    (r as f32) / 1000.0,
-                                    f
-                                );
+                output.implement(
+                    move |event, _| {
+                        use wayland_client::protocol::wl_output::Event;
+                        match event {
+                            Event::Geometry {
+                                x,
+                                y,
+                                physical_width,
+                                physical_height,
+                                subpixel,
+                                make,
+                                model,
+                                transform,
+                            } => {
+                                println!("New output: \"{} ({})\"", make, model);
+                                println!(" -> physical dimensions {}x{}", physical_width, physical_height);
+                                println!(" -> location in the compositor space: ({}, {})", x, y);
+                                println!(" -> transform: {:?}", transform);
+                                println!(" -> subpixel orientation: {:?}", subpixel);
+                                name = format!("{} ({})", make, model);
+                            }
+                            Event::Mode {
+                                flags,
+                                width,
+                                height,
+                                refresh,
+                            } => {
+                                modes.push((flags, width, height, refresh));
+                            }
+                            Event::Scale { factor } => {
+                                scale = factor;
+                            }
+                            Event::Done => {
+                                println!("Modesetting information for output \"{}\"", name);
+                                println!(" -> scaling factor: {}", scale);
+                                println!(" -> mode list:");
+                                for &(f, w, h, r) in &modes {
+                                    println!(
+                                        "   -> {}x{} @{}Hz (flags: [ {:?} ])",
+                                        w,
+                                        h,
+                                        (r as f32) / 1000.0,
+                                        f
+                                    );
+                                }
                             }
                         }
-                    }
-                })
+                    },
+                    (),
+                )
             }]
         ),
     );

--- a/wayland-client/examples/simple_window.rs
+++ b/wayland-client/examples/simple_window.rs
@@ -52,22 +52,22 @@ fn main() {
 
     // The compositor allows us to creates surfaces
     let compositor = globals
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|comp| comp.implement(|_, _| {}))
+        .instantiate_auto::<wl_compositor::WlCompositor, _>(|comp| comp.implement(|_, _| {}, ()))
         .unwrap();
     let surface = compositor
-        .create_surface(|surface| surface.implement(|_, _| {}))
+        .create_surface(|surface| surface.implement(|_, _| {}, ()))
         .unwrap();
 
     // The SHM allows us to share memory with the server, and create buffers
     // on this shared memory to paint our surfaces
     let shm = globals
-        .instantiate_auto::<wl_shm::WlShm, _>(|shm| shm.implement(|_, _| {}))
+        .instantiate_auto::<wl_shm::WlShm, _>(|shm| shm.implement(|_, _| {}, ()))
         .unwrap();
     let pool =
         shm.create_pool(
             tmp.as_raw_fd(),            // RawFd to the tempfile serving as shared memory
             (buf_x * buf_y * 4) as i32, // size in bytes of the shared memory (4 bytes per pixel)
-            |pool| pool.implement(|_, _| {}),
+            |pool| pool.implement(|_, _| {}, ()),
         ).unwrap();
     let buffer =
         pool.create_buffer(
@@ -76,7 +76,7 @@ fn main() {
             buf_y as i32,             // height of the buffer in pixels
             (buf_x * 4) as i32,       // number of bytes between the beginning of two consecutive lines
             wl_shm::Format::Argb8888, // chosen encoding for the data
-            |buffer| buffer.implement(|_, _| {}),
+            |buffer| buffer.implement(|_, _| {}, ()),
         ).unwrap();
 
     // The shell allows us to define our surface as a "toplevel", meaning the
@@ -85,18 +85,21 @@ fn main() {
     // NOTE: the wl_shell interface is actually deprecated in favour of the xdg_shell
     // protocol, available in wayland-protocols. But this will do for this example.
     let shell = globals
-        .instantiate_auto::<wl_shell::WlShell, _>(|shell| shell.implement(|_, _| {}))
+        .instantiate_auto::<wl_shell::WlShell, _>(|shell| shell.implement(|_, _| {}, ()))
         .unwrap();
     let shell_surface = shell
         .get_shell_surface(&surface, |shellsurface| {
-            shellsurface.implement(|event, shell_surface: Proxy<wl_shell_surface::WlShellSurface>| {
-                use wayland_client::protocol::wl_shell_surface::{Event, RequestsTrait};
-                // This ping/pong mechanism is used by the wayland server to detect
-                // unresponsive applications
-                if let Event::Ping { serial } = event {
-                    shell_surface.pong(serial);
-                }
-            })
+            shellsurface.implement(
+                |event, shell_surface: Proxy<wl_shell_surface::WlShellSurface>| {
+                    use wayland_client::protocol::wl_shell_surface::{Event, RequestsTrait};
+                    // This ping/pong mechanism is used by the wayland server to detect
+                    // unresponsive applications
+                    if let Event::Ping { serial } = event {
+                        shell_surface.pong(serial);
+                    }
+                },
+                (),
+            )
         })
         .unwrap();
 
@@ -112,43 +115,49 @@ fn main() {
     // seat, so we'll keep it simple here
     let mut pointer_created = false;
     globals.instantiate_auto::<wl_seat::WlSeat, _>(|seat| {
-        seat.implement(move |event, seat: Proxy<wl_seat::WlSeat>| {
-            // The capabilities of a seat are known at runtime and we retrieve
-            // them via an events. 3 capabilities exists: pointer, keyboard, and touch
-            // we are only interested in pointer here
-            use wayland_client::protocol::wl_pointer::Event as PointerEvent;
-            use wayland_client::protocol::wl_seat::{
-                Capability, Event as SeatEvent, RequestsTrait as SeatRequests,
-            };
+        seat.implement(
+            move |event, seat: Proxy<wl_seat::WlSeat>| {
+                // The capabilities of a seat are known at runtime and we retrieve
+                // them via an events. 3 capabilities exists: pointer, keyboard, and touch
+                // we are only interested in pointer here
+                use wayland_client::protocol::wl_pointer::Event as PointerEvent;
+                use wayland_client::protocol::wl_seat::{
+                    Capability, Event as SeatEvent, RequestsTrait as SeatRequests,
+                };
 
-            if let SeatEvent::Capabilities { capabilities } = event {
-                if !pointer_created && capabilities.contains(Capability::Pointer) {
-                    // create the pointer only once
-                    pointer_created = true;
-                    seat.get_pointer(|pointer| {
-                        pointer.implement(|event, _| match event {
-                            PointerEvent::Enter {
-                                surface_x, surface_y, ..
-                            } => {
-                                println!("Pointer entered at ({}, {}).", surface_x, surface_y);
-                            }
-                            PointerEvent::Leave { .. } => {
-                                println!("Pointer left.");
-                            }
-                            PointerEvent::Motion {
-                                surface_x, surface_y, ..
-                            } => {
-                                println!("Pointer moved to ({}, {}).", surface_x, surface_y);
-                            }
-                            PointerEvent::Button { button, state, .. } => {
-                                println!("Button {} was {:?}.", button, state);
-                            }
-                            _ => {}
-                        })
-                    });
+                if let SeatEvent::Capabilities { capabilities } = event {
+                    if !pointer_created && capabilities.contains(Capability::Pointer) {
+                        // create the pointer only once
+                        pointer_created = true;
+                        seat.get_pointer(|pointer| {
+                            pointer.implement(
+                                |event, _| match event {
+                                    PointerEvent::Enter {
+                                        surface_x, surface_y, ..
+                                    } => {
+                                        println!("Pointer entered at ({}, {}).", surface_x, surface_y);
+                                    }
+                                    PointerEvent::Leave { .. } => {
+                                        println!("Pointer left.");
+                                    }
+                                    PointerEvent::Motion {
+                                        surface_x, surface_y, ..
+                                    } => {
+                                        println!("Pointer moved to ({}, {}).", surface_x, surface_y);
+                                    }
+                                    PointerEvent::Button { button, state, .. } => {
+                                        println!("Button {} was {:?}.", button, state);
+                                    }
+                                    _ => {}
+                                },
+                                (),
+                            )
+                        });
+                    }
                 }
-            }
-        })
+            },
+            (),
+        )
     });
 
     loop {

--- a/wayland-client/src/native_lib/proxy.rs
+++ b/wayland-client/src/native_lib/proxy.rs
@@ -1,8 +1,8 @@
-use std::any::Any;
 use std::os::raw::{c_int, c_void};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use wayland_commons::utils::UserData;
 use wayland_commons::MessageGroup;
 use {Implementation, Interface, Proxy};
 
@@ -11,28 +11,16 @@ use super::EventQueueInner;
 use wayland_sys::client::*;
 use wayland_sys::common::*;
 
-struct UserData {
-    data: Box<Any + 'static>,
-}
-
-// similarly as for implementations, we need to be able to store non-Send
-// data in the UserData, but accessing it is `unsafe`, so the frontend is
-// responsible for ensuring threaded access is correct
-unsafe impl Send for UserData {}
-unsafe impl Sync for UserData {}
-
 pub struct ProxyInternal {
     alive: AtomicBool,
     user_data: UserData,
 }
 
 impl ProxyInternal {
-    pub fn new<UD: 'static>(user_data: UD) -> ProxyInternal {
+    pub fn new(user_data: UserData) -> ProxyInternal {
         ProxyInternal {
             alive: AtomicBool::new(true),
-            user_data: UserData {
-                data: Box::new(user_data),
-            },
+            user_data,
         }
     }
 }
@@ -73,9 +61,9 @@ impl ProxyInner {
         unsafe { ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_proxy_get_id, self.ptr) }
     }
 
-    pub(crate) unsafe fn get_user_data<UD: 'static>(&self) -> Option<&UD> {
+    pub(crate) fn get_user_data<UD: 'static>(&self) -> Option<&UD> {
         if let Some(ref inner) = self.internal {
-            inner.user_data.data.downcast_ref::<UD>()
+            inner.user_data.get::<UD>()
         } else {
             None
         }
@@ -170,7 +158,7 @@ impl ProxyInner {
             return ProxyInner {
                 internal: Some(Arc::new(ProxyInternal {
                     alive: AtomicBool::new(false),
-                    user_data: UserData { data: Box::new(()) },
+                    user_data: UserData::empty(),
                 })),
                 ptr: ptr,
                 is_wrapper: false,
@@ -217,14 +205,13 @@ pub(crate) struct NewProxyInner {
 }
 
 impl NewProxyInner {
-    pub(crate) unsafe fn implement<I: Interface, UD, Impl>(
+    pub(crate) unsafe fn implement<I: Interface, Impl>(
         self,
         implementation: Impl,
-        user_data: UD,
+        user_data: UserData,
     ) -> ProxyInner
     where
         Impl: Implementation<Proxy<I>, I::Event> + 'static,
-        UD: 'static,
     {
         let new_user_data = Box::new(ProxyUserData::new(implementation, user_data));
         let internal = new_user_data.internal.clone();
@@ -260,10 +247,9 @@ struct ProxyUserData<I: Interface> {
 }
 
 impl<I: Interface> ProxyUserData<I> {
-    fn new<Impl, UD>(implem: Impl, user_data: UD) -> ProxyUserData<I>
+    fn new<Impl>(implem: Impl, user_data: UserData) -> ProxyUserData<I>
     where
         Impl: Implementation<Proxy<I>, I::Event> + 'static,
-        UD: 'static,
     {
         ProxyUserData {
             internal: Arc::new(ProxyInternal::new(user_data)),

--- a/wayland-client/src/proxy.rs
+++ b/wayland-client/src/proxy.rs
@@ -98,6 +98,14 @@ impl<I: Interface> Proxy<I> {
     /// cannot access it mutably afterwards. If you need interior mutability,
     /// you are responsible for using a `Mutex` or similar type to achieve it.
     pub fn user_data<UD: Send + Sync + 'static>(&self) -> Option<&UD> {
+        unsafe { self.inner.get_user_data() }
+    }
+
+    /// Access the arbitrary payload associated to this object
+    ///
+    /// Same as `user_data`, but does not require the user data to be `Send + Sync`.
+    /// It is thus unsafe because it may only be called from the right thread.
+    pub unsafe fn user_data_nonsend<UD: 'static>(&self) -> Option<&UD> {
         self.inner.get_user_data()
     }
 
@@ -301,7 +309,7 @@ impl<I: Interface + 'static> NewProxy<I> {
     ) -> Proxy<I>
     where
         Impl: Implementation<Proxy<I>, I::Event> + 'static,
-        UD: Send + Sync + 'static,
+        UD: 'static,
         I::Event: MessageGroup<Map = ProxyMap>,
     {
         #[cfg(feature = "native_lib")]

--- a/wayland-client/src/rust_imp/display.rs
+++ b/wayland-client/src/rust_imp/display.rs
@@ -3,6 +3,7 @@ use std::os::unix::io::RawFd;
 use std::sync::{Arc, Mutex};
 
 use wayland_commons::map::Object;
+use wayland_commons::utils::UserData;
 
 use protocol::wl_display::{self, WlDisplay};
 
@@ -34,7 +35,7 @@ impl DisplayInner {
         let impl_map = map;
         let impl_last_error = connection.lock().unwrap().last_error.clone();
         // our implementation is Send, we are safe
-        let display_proxy = display_newproxy.implement::<WlDisplay, (), _>(
+        let display_proxy = display_newproxy.implement::<WlDisplay, _>(
             move |event, _| match event {
                 wl_display::Event::Error {
                     object_id,
@@ -63,7 +64,7 @@ impl DisplayInner {
                     }
                 }
             },
-            (),
+            UserData::empty(),
         );
 
         let default_event_queue = EventQueueInner::new(connection.clone(), None);

--- a/wayland-client/src/rust_imp/queues.rs
+++ b/wayland-client/src/rust_imp/queues.rs
@@ -8,6 +8,7 @@ use std::sync::{Arc, Mutex};
 use nix::poll::{poll, EventFlags, PollFd};
 
 use wayland_commons::map::ObjectMap;
+use wayland_commons::utils::UserData;
 use wayland_commons::wire::Message;
 
 use super::connection::{Connection, Error as CError};
@@ -162,11 +163,11 @@ impl EventQueueInner {
         let ret = display.sync(|np| {
             Proxy::wrap(unsafe {
                 let done2 = done.clone();
-                np.inner.implement::<WlCallback, (), _>(
+                np.inner.implement::<WlCallback, _>(
                     move |CbEvent::Done { .. }, _| {
                         done2.set(true);
                     },
-                    (),
+                    UserData::empty(),
                 )
             })
         });

--- a/wayland-client/src/rust_imp/queues.rs
+++ b/wayland-client/src/rust_imp/queues.rs
@@ -162,10 +162,12 @@ impl EventQueueInner {
         let ret = display.sync(|np| {
             Proxy::wrap(unsafe {
                 let done2 = done.clone();
-                np.inner
-                    .implement::<WlCallback, _>(move |CbEvent::Done { .. }, _| {
+                np.inner.implement::<WlCallback, (), _>(
+                    move |CbEvent::Done { .. }, _| {
                         done2.set(true);
-                    })
+                    },
+                    (),
+                )
             })
         });
 

--- a/wayland-commons/src/lib.rs
+++ b/wayland-commons/src/lib.rs
@@ -29,6 +29,7 @@ use downcast::Downcast;
 
 pub mod map;
 pub mod socket;
+pub mod utils;
 pub mod wire;
 
 /// A group of messages

--- a/wayland-commons/src/utils.rs
+++ b/wayland-commons/src/utils.rs
@@ -56,11 +56,11 @@ impl UserData {
     ///   is attempted from an other thread than the one it was created on
     pub fn get<T: 'static>(&self) -> Option<&T> {
         match self.inner {
-            UserDataInner::ThreadSafe(ref val) => val.downcast_ref(),
+            UserDataInner::ThreadSafe(ref val) => Any::downcast_ref::<T>(&**val),
             UserDataInner::NonThreadSafe(ref val, threadid) => {
                 // only give access if we are on the right thread
                 if threadid == thread::current().id() {
-                    val.downcast_ref()
+                    Any::downcast_ref::<T>(&**val)
                 } else {
                     None
                 }

--- a/wayland-commons/src/utils.rs
+++ b/wayland-commons/src/utils.rs
@@ -1,0 +1,71 @@
+//! Various utilities used for other implementations
+
+use std::any::Any;
+use std::thread::{self, ThreadId};
+
+/// A wrapper for user data, able to store any type, and correctly
+/// handling access from a wrong thread
+pub struct UserData {
+    inner: UserDataInner,
+}
+
+enum UserDataInner {
+    ThreadSafe(Box<Any + Send + Sync + 'static>),
+    NonThreadSafe(Box<Any + 'static>, ThreadId),
+    Empty,
+}
+
+// UserData itself is always threadsafe, as it only gives access to its
+// content if it is send+sync or we are on the right thread
+unsafe impl Send for UserData {}
+unsafe impl Sync for UserData {}
+
+impl UserData {
+    /// Create a new `UserData` using a threadsafe type
+    ///
+    /// Its contents can be accessed from any thread.
+    pub fn new_threadsafe<T: Send + Sync + 'static>(value: T) -> UserData {
+        UserData {
+            inner: UserDataInner::ThreadSafe(Box::new(value)),
+        }
+    }
+
+    /// Create a new `UserData` using a non-threadsafe type
+    ///
+    /// Its contents can only be accessed from the same thread as the one you
+    /// are creating it.
+    pub fn new<T: 'static>(value: T) -> UserData {
+        UserData {
+            inner: UserDataInner::NonThreadSafe(Box::new(value), thread::current().id()),
+        }
+    }
+
+    /// Create a new `UserData` containing nothing
+    pub fn empty() -> UserData {
+        UserData {
+            inner: UserDataInner::Empty,
+        }
+    }
+
+    /// Attempt to access the wrapped user data
+    ///
+    /// Will return `None` if either:
+    ///
+    /// - The requested type `T` does not match the itype used for construction
+    /// - This `UserData` has been created using the non-threadsafe variant and access
+    ///   is attempted from an other thread than the one it was created on
+    pub fn get<T: 'static>(&self) -> Option<&T> {
+        match self.inner {
+            UserDataInner::ThreadSafe(ref val) => val.downcast_ref(),
+            UserDataInner::NonThreadSafe(ref val, threadid) => {
+                // only give access if we are on the right thread
+                if threadid == thread::current().id() {
+                    val.downcast_ref()
+                } else {
+                    None
+                }
+            }
+            UserDataInner::Empty => None,
+        }
+    }
+}

--- a/wayland-server/src/resource.rs
+++ b/wayland-server/src/resource.rs
@@ -89,6 +89,14 @@ impl<I: Interface> Resource<I> {
     /// cannot access it mutably afterwards. If you need interior mutability,
     /// you are responsible for using a `Mutex` or similar type to achieve it.
     pub fn user_data<UD: Send + Sync + 'static>(&self) -> Option<&UD> {
+        unsafe { self.inner.get_user_data() }
+    }
+
+    /// Access the arbitrary payload associated to this object
+    ///
+    /// Same as `user_data`, but does not require the user data to be `Send + Sync`.
+    /// It is thus unsafe because it may only be called from the right thread.
+    pub unsafe fn user_data_nonsend<UD: 'static>(&self) -> Option<&UD> {
         self.inner.get_user_data()
     }
 
@@ -186,7 +194,12 @@ impl<I: Interface + 'static> NewResource<I> {
     }
 
     /// Implement this resource using given function, destructor, and user data.
-    pub fn implement<Impl, Dest, UD>(self, implementation: Impl, destructor: Option<Dest>, user_data: UD) -> Resource<I>
+    pub fn implement<Impl, Dest, UD>(
+        self,
+        implementation: Impl,
+        destructor: Option<Dest>,
+        user_data: UD,
+    ) -> Resource<I>
     where
         Impl: Implementation<Resource<I>, I::Request> + Send + 'static,
         Dest: FnMut(Resource<I>, Box<Implementation<Resource<I>, I::Request>>) + Send + 'static,
@@ -224,12 +237,16 @@ impl<I: Interface + 'static> NewResource<I> {
     where
         Impl: Implementation<Resource<I>, I::Request> + 'static,
         Dest: FnMut(Resource<I>, Box<Implementation<Resource<I>, I::Request>>) + 'static,
-        UD: Send + Sync + 'static,
+        UD: 'static,
         I::Request: MessageGroup<Map = ::imp::ResourceMap>,
     {
         let inner = unsafe {
-            self.inner
-                .implement::<I, Impl, Dest, UD>(implementation, destructor, user_data, Some(&token.inner))
+            self.inner.implement::<I, Impl, Dest, UD>(
+                implementation,
+                destructor,
+                user_data,
+                Some(&token.inner),
+            )
         };
         Resource {
             _i: ::std::marker::PhantomData,

--- a/wayland-server/src/rust_imp/clients.rs
+++ b/wayland-server/src/rust_imp/clients.rs
@@ -555,7 +555,7 @@ impl super::Dispatcher for DisplayDispatcher {
             // sync
             0 => if let Some(&Argument::NewId(new_id)) = msg.args.first() {
                 if let Some(cb) = map.get_new::<wl_callback::WlCallback>(new_id) {
-                    let cb = cb.implement(|r, _| match r {}, None::<fn(_, _)>);
+                    let cb = cb.implement(|r, _| match r {}, None::<fn(_, _)>, ());
                     // TODO: send a more meaningful serial ?
                     cb.send(wl_callback::Event::Done { callback_data: 0 });
                 } else {


### PR DESCRIPTION
cc #196 

This changes the user data mechanism to be the following:

- the user data of a wayland object is set once and for all at implementation time
- it can be accessed from any handle via a type `user_data<UD>(&self) -> Option<&UD>` method which is a thin wrapper around `Box<Any>::downcast_ref()`
- the user is responsible for integrating interior mutability to the type if they want

In particular, the previous behavior can be reached by using an `AtomicPtr` as the `UD` type, but it makes the default behavior much more safe.

What do you think of this, @Drakulix ?