### PR TITLE
Remove the Implementation trait

### DIFF
--- a/tests/destructors.rs
+++ b/tests/destructors.rs
@@ -3,7 +3,6 @@ mod helpers;
 use helpers::{roundtrip, wayc, ways, TestClient, TestServer};
 
 use ways::protocol::wl_output::WlOutput as ServerOutput;
-use ways::NewResource;
 
 use wayc::protocol::wl_output::{RequestsTrait, WlOutput};
 
@@ -18,11 +17,11 @@ fn resource_destructor() {
     let loop_token = server.event_loop.token();
     server
         .display
-        .create_global::<ServerOutput, _>(&loop_token, 3, move |_, newo: NewResource<_>| {
+        .create_global::<ServerOutput, _>(&loop_token, 3, move |newo, _| {
             let destructor_called_resource = destructor_called_global.clone();
             newo.implement(
                 |_, _| {},
-                Some(move |_, _| {
+                Some(move |_| {
                     *destructor_called_resource.lock().unwrap() = true;
                 }),
                 (),
@@ -56,11 +55,11 @@ fn resource_destructor_cleanup() {
     let loop_token = server.event_loop.token();
     server
         .display
-        .create_global::<ServerOutput, _>(&loop_token, 3, move |_, newo: NewResource<_>| {
+        .create_global::<ServerOutput, _>(&loop_token, 3, move |newo, _| {
             let destructor_called_resource = destructor_called_global.clone();
             newo.implement(
                 |_, _| {},
-                Some(move |_, _| {
+                Some(move |_| {
                     *destructor_called_resource.lock().unwrap() = true;
                 }),
                 (),
@@ -95,9 +94,9 @@ fn client_destructor_cleanup() {
     let loop_token = server.event_loop.token();
     server
         .display
-        .create_global::<ServerOutput, _>(&loop_token, 3, move |_, newo: NewResource<_>| {
+        .create_global::<ServerOutput, _>(&loop_token, 3, move |newo, _| {
             let destructor_called_resource = destructor_called_global.clone();
-            let output = newo.implement(|_, _| {}, None::<fn(_, _)>, ());
+            let output = newo.implement(|_, _| {}, None::<fn(_)>, ());
             let client = output.client().unwrap();
             client.set_user_data(Box::into_raw(Box::new(destructor_called_resource)) as *mut _);
             client.set_destructor(|data| {

--- a/tests/event_loop.rs
+++ b/tests/event_loop.rs
@@ -17,11 +17,10 @@ fn timer_wait() {
         .token()
         .add_timer_event_source({
             let timer_signal = timer_fired.clone();
-            move |_: TimerEvent, ()| {
+            move |_: TimerEvent| {
                 timer_signal.set(true);
             }
         })
-        .map_err(|(e, _)| e)
         .unwrap();
 
     timer.set_delay_ms(1000); // 1s
@@ -46,7 +45,7 @@ fn dispatch_idle() {
     let impl_dispatched = dispatched.clone();
     event_loop
         .token()
-        .add_idle_event_source(move |_, _| impl_dispatched.set(true));
+        .add_idle_event_source(move || impl_dispatched.set(true));
 
     event_loop.dispatch(Some(1)).unwrap();
 
@@ -62,9 +61,8 @@ fn event_loop_run() {
         .token()
         .add_timer_event_source(
             // stop loping when the timer fires
-            move |_: TimerEvent, ()| signal.stop(),
+            move |_: TimerEvent| signal.stop(),
         )
-        .map_err(|(e, _)| e)
         .unwrap();
 
     timer.set_delay_ms(1000);

--- a/tests/event_loop_signal.rs
+++ b/tests/event_loop_signal.rs
@@ -23,22 +23,21 @@ fn main() {
     sigprocmask(SigmaskHow::SIG_BLOCK, Some(&sigset), None).unwrap();
 
     // add a signal event source for it
-    let signal_source = event_loop
+    event_loop
         .token()
         .add_signal_event_source(Signal::SIGUSR1, {
             let signal = signal_received.clone();
-            move |SignalEvent(sig), ()| {
+            move |SignalEvent(sig)| {
                 assert!(sig == Signal::SIGUSR1);
                 signal.set(true);
             }
         })
-        .map_err(|(e, _)| e)
         .unwrap();
 
     // send ourselves a SIGUSR1
-    kill(Pid::this(), Signal::SIGUSR1);
+    kill(Pid::this(), Signal::SIGUSR1).unwrap();
 
-    event_loop.dispatch(Some(10));
+    event_loop.dispatch(Some(10)).unwrap();
 
     assert!(signal_received.get());
 }

--- a/tests/protocol_errors.rs
+++ b/tests/protocol_errors.rs
@@ -1,6 +1,6 @@
 mod helpers;
 
-use helpers::{roundtrip, wayc, ways, TestClient, TestServer};
+use helpers::TestServer;
 
 extern crate nix;
 extern crate wayland_commons as wc;

--- a/tests/send_sync.rs
+++ b/tests/send_sync.rs
@@ -1,8 +1,6 @@
 extern crate wayland_client as wayc;
 extern crate wayland_server as ways;
 
-fn ensure_send<I: Send>() {}
-fn ensure_sync<I: Sync>() {}
 fn ensure_both<I: Send + Sync>() {}
 
 #[test]

--- a/tests/server_resources.rs
+++ b/tests/server_resources.rs
@@ -3,23 +3,10 @@ mod helpers;
 use helpers::{roundtrip, wayc, ways, TestClient, TestServer};
 
 use ways::protocol::wl_output;
-use ways::{Implementation, NewResource, Resource};
 
 use wayc::protocol::wl_output::WlOutput as ClientOutput;
 
 use std::sync::{Arc, Mutex};
-
-struct Impl1;
-
-impl Implementation<Resource<wl_output::WlOutput>, wl_output::Request> for Impl1 {
-    fn receive(&mut self, _: wl_output::Request, _: Resource<wl_output::WlOutput>) {}
-}
-
-struct Impl2;
-
-impl Implementation<Resource<wl_output::WlOutput>, wl_output::Request> for Impl2 {
-    fn receive(&mut self, _: wl_output::Request, _: Resource<wl_output::WlOutput>) {}
-}
 
 #[test]
 fn resource_equals() {
@@ -31,11 +18,11 @@ fn resource_equals() {
 
     server
         .display
-        .create_global::<wl_output::WlOutput, _>(&loop_token, 1, move |_, newo: NewResource<_>| {
+        .create_global::<wl_output::WlOutput, _>(&loop_token, 1, move |newo, _| {
             outputs2
                 .lock()
                 .unwrap()
-                .push(newo.implement(|_, _| {}, None::<fn(_, _)>, ()));
+                .push(newo.implement(|_, _| {}, None::<fn(_)>, ()));
         });
 
     let mut client = TestClient::new(&server.socket_name);
@@ -73,9 +60,9 @@ fn resource_user_data() {
 
     server
         .display
-        .create_global::<wl_output::WlOutput, _>(&loop_token, 1, move |_, newo: NewResource<_>| {
+        .create_global::<wl_output::WlOutput, _>(&loop_token, 1, move |newo, _| {
             let mut guard = outputs2.lock().unwrap();
-            let output = newo.implement(|_, _| {}, None::<fn(_, _)>, 1000 + guard.len());
+            let output = newo.implement(|_, _| {}, None::<fn(_)>, 1000 + guard.len());
             guard.push(output);
         });
 
@@ -112,9 +99,9 @@ fn resource_user_data_wrong_thread() {
 
     server
         .display
-        .create_global::<wl_output::WlOutput, _>(&loop_token, 1, move |_, newo: NewResource<_>| {
+        .create_global::<wl_output::WlOutput, _>(&loop_token, 1, move |newo, _| {
             let mut guard = outputs2.lock().unwrap();
-            let output = newo.implement_nonsend(|_, _| {}, None::<fn(_, _)>, 0xDEADBEEFusize, &loop_token2);
+            let output = newo.implement_nonsend(|_, _| {}, None::<fn(_)>, 0xDEADBEEFusize, &loop_token2);
             *guard = Some(output);
         });
 
@@ -142,51 +129,6 @@ fn resource_user_data_wrong_thread() {
 }
 
 #[test]
-fn resource_is_implemented() {
-    let mut server = TestServer::new();
-    let loop_token = server.event_loop.token();
-
-    let outputs = Arc::new(Mutex::new(Vec::new()));
-    let outputs2 = outputs.clone();
-
-    server
-        .display
-        .create_global::<wl_output::WlOutput, _>(&loop_token, 1, move |_, newo: NewResource<_>| {
-            let mut guard = outputs2.lock().unwrap();
-            let output = if guard.len() == 0 {
-                newo.implement(Impl1, None::<fn(_, _)>, ())
-            } else {
-                newo.implement(Impl2, None::<fn(_, _)>, ())
-            };
-            guard.push(output);
-        });
-
-    let mut client = TestClient::new(&server.socket_name);
-    let manager = wayc::GlobalManager::new(&client.display);
-
-    roundtrip(&mut client, &mut server).unwrap();
-
-    // create two outputs
-    manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}, ()))
-        .unwrap();
-    manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}, ()))
-        .unwrap();
-
-    roundtrip(&mut client, &mut server).unwrap();
-
-    let outputs_lock = outputs.lock().unwrap();
-    assert!(outputs_lock[0].is_implemented_with::<Impl1>());
-    assert!(!outputs_lock[0].is_implemented_with::<Impl2>());
-    assert!(outputs_lock[1].is_implemented_with::<Impl2>());
-    assert!(!outputs_lock[1].is_implemented_with::<Impl1>());
-    let cloned = outputs_lock[0].clone();
-    assert!(cloned.is_implemented_with::<Impl1>());
-    assert!(!cloned.is_implemented_with::<Impl2>());
-}
-
-#[test]
 fn dead_resources() {
     use self::wayc::protocol::wl_output::RequestsTrait;
     let mut server = TestServer::new();
@@ -197,11 +139,11 @@ fn dead_resources() {
 
     server
         .display
-        .create_global::<wl_output::WlOutput, _>(&loop_token, 3, move |_, newo: NewResource<_>| {
+        .create_global::<wl_output::WlOutput, _>(&loop_token, 3, move |newo, _| {
             outputs2
                 .lock()
                 .unwrap()
-                .push(newo.implement(|_, _| {}, None::<fn(_, _)>, ()));
+                .push(newo.implement(|_, _| {}, None::<fn(_)>, ()));
         });
 
     let mut client = TestClient::new(&server.socket_name);

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -57,28 +57,8 @@
 //! Failure to do so (by dropping the `NewProxy<I>` for example) can cause future fatal
 //! errors if the server tries to send an event to this object.
 //!
-//! An implementation is just a struct implementing the `Implementation<Proxy<I>, I::Event>`
-//! trait, where `I` is the interface of the considered object:
-//!
-//! ```
-//! // Example implementation for the wl_surface interface
-//! use wayland_client::{Proxy, Implementation};
-//! use wayland_client::protocol::wl_surface;
-//!
-//! struct MyImpl {
-//!    // ...
-//! }
-//!
-//! impl Implementation<Proxy<wl_surface::WlSurface>, wl_surface::Event> for MyImpl {
-//!     fn receive(&mut self, msg: wl_surface::Event, proxy: Proxy<wl_surface::WlSurface>) {
-//!         // process the message...
-//!     }
-//! }
-//! # fn main() {}
-//! ```
-//!
-//! The trait is also automatically implemented for `FnMut(I::Event, Proxy<I>)` closures,
-//! so you can use them for simplicity if a full struct would be too cumbersome.
+//! An implementation is just an `FnMut(I::Event, Proxy<I>), where `I` is the interface of
+//! the considered object.
 //!
 //! ## Event Queues
 //!
@@ -151,9 +131,7 @@ pub mod cursor;
 #[cfg(feature = "egl")]
 pub mod egl;
 
-pub use wayland_commons::{
-    downcast_impl, AnonymousObject, Implementation, Interface, MessageGroup, NoMessage,
-};
+pub use wayland_commons::{AnonymousObject, Interface, MessageGroup, NoMessage};
 
 // rust implementation
 #[cfg(not(feature = "native_lib"))]

--- a/wayland-commons/Cargo.toml
+++ b/wayland-commons/Cargo.toml
@@ -14,7 +14,6 @@ travis-ci = { repository = "smithay/wayland-rs" }
 
 [dependencies]
 wayland-sys = { version = "0.21.0-alpha1", path = "../wayland-sys", optional = true }
-downcast-rs = "1.0"
 nix = "0.11"
 
 [features]

--- a/wayland-commons/src/lib.rs
+++ b/wayland-commons/src/lib.rs
@@ -15,8 +15,6 @@
 
 #![warn(missing_docs)]
 
-#[macro_use]
-extern crate downcast_rs as downcast;
 extern crate nix;
 #[cfg(feature = "native_lib")]
 extern crate wayland_sys;
@@ -24,8 +22,6 @@ extern crate wayland_sys;
 use std::os::raw::c_void;
 #[cfg(feature = "native_lib")]
 use wayland_sys::common as syscom;
-
-use downcast::Downcast;
 
 pub mod map;
 pub mod socket;
@@ -93,54 +89,6 @@ pub trait Interface: 'static {
     #[cfg(feature = "native_lib")]
     /// Pointer to the C representation of this interface
     fn c_interface() -> *const ::syscom::wl_interface;
-}
-
-/// Trait representing implementations for wayland objects
-///
-/// Several wayland objects require you to act when some messages
-/// are received. You program this act by providing an object
-/// implementing this trait.
-///
-/// The trait requires a single method: `self.receive(message, metadata)`.
-/// the `message` argument will often be an enum of the possible messages,
-/// and the `metadata` argument contains associated information. Typically
-/// an handle to the wayland object that received this message.
-///
-/// The trait is automatically implemented for `FnMut(Msg, Meta)` closures.
-///
-/// This is mostly used as a trait object in `wayland-client` and `wayland-server`,
-/// and thus also provide methods providing `Any`-like downcasting functionnality.
-/// See also the `downcast_impl` freestanding function.
-pub trait Implementation<Meta, Msg>: Downcast {
-    /// Receive a message
-    fn receive(&mut self, msg: Msg, meta: Meta);
-}
-
-impl_downcast!(Implementation<Meta, Msg>);
-
-impl<Meta, Msg, F> Implementation<Meta, Msg> for F
-where
-    F: FnMut(Msg, Meta) + 'static,
-{
-    fn receive(&mut self, msg: Msg, meta: Meta) {
-        (self)(msg, meta)
-    }
-}
-
-/// Attempt to downcast a boxed `Implementation` trait object.
-///
-/// Similar to `Box::<Any>::downcast()`.
-pub fn downcast_impl<Msg: 'static, Meta: 'static, T: Implementation<Meta, Msg>>(
-    b: Box<Implementation<Meta, Msg>>,
-) -> Result<Box<T>, Box<Implementation<Meta, Msg>>> {
-    if b.is::<T>() {
-        unsafe {
-            let raw: *mut Implementation<Meta, Msg> = Box::into_raw(b);
-            Ok(Box::from_raw(raw as *mut T))
-        }
-    } else {
-        Err(b)
-    }
 }
 
 /// Anonymous interface

--- a/wayland-server/src/display.rs
+++ b/wayland-server/src/display.rs
@@ -11,7 +11,7 @@ use wayland_sys::server::wl_display;
 
 use imp::DisplayInner;
 
-use {Client, EventLoop, Global, Implementation, Interface, LoopToken, NewResource};
+use {Client, EventLoop, Global, Interface, LoopToken, NewResource};
 
 /// The wayland display
 ///
@@ -47,14 +47,14 @@ impl Display {
     /// The version specified is the **highest supported version**, you must
     /// be able to handle clients that choose to instanciate this global with
     /// a lower version number.
-    pub fn create_global<I: Interface, Impl>(
+    pub fn create_global<I: Interface, F>(
         &mut self,
         token: &LoopToken,
         version: u32,
-        implementation: Impl,
+        implementation: F,
     ) -> Global<I>
     where
-        Impl: Implementation<NewResource<I>, u32> + 'static,
+        F: FnMut(NewResource<I>, u32) + 'static,
     {
         assert!(
             version <= I::VERSION,

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -48,28 +48,8 @@
 //! Failure to do so (by dropping the `NewResource<I>` for example) can cause future fatal
 //! protocol errors if the client tries to send a request to this object.
 //!
-//! An implementation is just a struct implementing the `Implementation<Resource<I>, I::Request>`
-//! trait, where `I` is the interface of the considered object:
-//!
-//! ```
-//! // Example implementation for the wl_surface interface
-//! use wayland_server::{Resource, Implementation};
-//! use wayland_server::protocol::wl_surface;
-//!
-//! struct MyImpl {
-//!    // ...
-//! }
-//!
-//! impl Implementation<Resource<wl_surface::WlSurface>, wl_surface::Request> for MyImpl {
-//!     fn receive(&mut self, msg: wl_surface::Request, resource: Resource<wl_surface::WlSurface>) {
-//!         // process the message...
-//!     }
-//! }
-//! # fn main() {}
-//! ```
-//!
-//! The trait is also automatically implemented for `FnMut(I::Request, Resource<I>)` closures,
-//! so you can use them for simplicity if a full struct would be too cumbersome.
+//! An implementation is just an `FnMut(I::Request, Resource<I>)` where `I` is the interface
+//! of the considered object.
 //!
 //! The `Resource<I>` passed to your implementation is garanteed to be alive (as it just received
 //! a request), unless the exact message received is a destructor (which is indicated in the API
@@ -119,9 +99,7 @@ pub use event_loop::{EventLoop, LoopSignal, LoopToken};
 pub use globals::Global;
 pub use resource::{NewResource, Resource};
 
-pub use wayland_commons::{
-    downcast_impl, AnonymousObject, Implementation, Interface, MessageGroup, NoMessage,
-};
+pub use wayland_commons::{AnonymousObject, Interface, MessageGroup, NoMessage};
 
 #[cfg(feature = "native_lib")]
 /// C-associated types

--- a/wayland-server/src/native_lib/display.rs
+++ b/wayland-server/src/native_lib/display.rs
@@ -12,7 +12,7 @@ use wayland_sys::server::*;
 use super::{ClientInner, EventLoopInner, GlobalInner};
 
 use display::get_runtime_dir;
-use {Implementation, Interface, NewResource};
+use {Interface, NewResource};
 
 pub(crate) struct DisplayInner {
     pub(crate) ptr: *mut wl_display,
@@ -51,16 +51,16 @@ impl DisplayInner {
         self.ptr
     }
 
-    pub(crate) fn create_global<I: Interface, Impl>(
+    pub(crate) fn create_global<I: Interface, F>(
         &mut self,
         _: &EventLoopInner,
         version: u32,
-        implementation: Impl,
+        implementation: F,
     ) -> GlobalInner<I>
     where
-        Impl: Implementation<NewResource<I>, u32> + 'static,
+        F: FnMut(NewResource<I>, u32) + 'static,
     {
-        let data = Box::new(Box::new(implementation) as Box<Implementation<NewResource<I>, u32>>);
+        let data = Box::new(Box::new(implementation) as Box<FnMut(NewResource<I>, u32)>);
 
         unsafe {
             let ptr = ffi_dispatch!(

--- a/wayland-server/src/sources.rs
+++ b/wayland-server/src/sources.rs
@@ -10,8 +10,6 @@
 use std::io::Error as IoError;
 use std::os::unix::io::RawFd;
 
-use wayland_commons::Implementation;
-
 use imp::{IdleSourceInner, SourceInner};
 
 /// A handle to an event source
@@ -74,7 +72,7 @@ impl Source<FdEvent> {
     ///
     /// You are returned the implementation you provided
     /// for this event source at creation.
-    pub fn remove(self) -> Box<Implementation<(), FdEvent>> {
+    pub fn remove(self) {
         self.inner.remove()
     }
 }
@@ -101,7 +99,7 @@ impl Source<TimerEvent> {
     ///
     /// You are returned the implementation you provided
     /// for this event source at creation.
-    pub fn remove(self) -> Box<Implementation<(), TimerEvent>> {
+    pub fn remove(self) {
         self.inner.remove()
     }
 }
@@ -119,7 +117,7 @@ impl Source<SignalEvent> {
     ///
     /// You are returned the implementation you provided
     /// for this event source at creation.
-    pub fn remove(self) -> Box<Implementation<(), SignalEvent>> {
+    pub fn remove(self) {
         self.inner.remove()
     }
 }
@@ -145,7 +143,7 @@ impl IdleSource {
     ///
     /// You retrieve the associated implementation. The event source
     /// is removed and if it hadn't been fired yet, it is cancelled.
-    pub fn remove(self) -> Box<Implementation<(), ()>> {
+    pub fn remove(self) {
         self.inner.remove()
     }
 }


### PR DESCRIPTION
Its main gain over simple FnMut(..)s was the downcasting abilities, to
check if an object has a given implementation. This advantage is no
longer present now that we have typed user_data since #198.

As such, lets get rid of Implementation, for the sake of simplicity.

To fully retreive all functionnality, it is needed to also introduce an
user-data mechanism on event sources, but this will be done when #185 is
adressed.

Fixes #197.