### PR TITLE
travis: cache the wayland libs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: rust
 
-cache: cargo
+cache:
+  cargo: true
+  directories:
+    - install
 
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,18 @@
 language: rust
 
+# only cache cargo subcommand binaries and wayland libs .so
+# the build artifacts take a lot of space and are slower to
+# cache than to actually rebuild anyway...
+# We need to cache the whole .cargo directory to keep the
+# .crates.toml file.
 cache:
-  cargo: true
   directories:
-    - install
+    - /home/travis/install
+    - /home/travis/.cargo
+
+# But don't cache the cargo registry
+before_cache:
+  - rm -rf /home/travis/.cargo/registry
 
 dist: trusty
 

--- a/travis_install_wayland.sh
+++ b/travis_install_wayland.sh
@@ -1,6 +1,14 @@
-#!/bin/sh
+#!/bin/bash
 
 # download and compile the wayland libs for given version, they will be installed in ~/install
+
+# early exit if the file is already here, we have a cache
+clientlib="$HOME/install/lib/libwayland-client.so.0.3.0"
+serverlib="$HOME/install/lib/libwayland-server.so.0.1.0"
+if [ -f "$clientlib" -a -f "$serverlib" ]; then
+    echo "Cache is present, not rebuilding the wayland libs."
+    exit 0
+fi
 
 wayland_version=$1
 


### PR DESCRIPTION
This avoids rebuilding them every run of the CI, speeding things up.

Fixes #188.