### PR TITLE
server: implement global filtering capabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,13 +58,13 @@ before_script:
         # sanity check, tarpaulin may fail to run after a rust upgrade and then needs recompilation
         cargo tarpaulin --version || env RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin --force
         # Building & running tests, we need to install the wayland lib
-        ./travis_install_wayland.sh "1.12.0"
+        ./travis_install_wayland.sh "1.13.0"
         export LD_LIBRARY_PATH="$HOME/install/lib:$LD_LIBRARY_PATH"
       elif [ -n "$BUILD_DOC" ]; then
         echo "Building doc, nothing to install..."
       else
         # Building & running tests, we need to install the wayland lib
-        ./travis_install_wayland.sh "1.12.0"
+        ./travis_install_wayland.sh "1.13.0"
         export LD_LIBRARY_PATH="$HOME/install/lib:$LD_LIBRARY_PATH"
       fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   actual `wl_display`
 - [client] Rework user-data mechanism to introduce type-safety
 - [server] Rework `Resource` user-data mechanism to introduce type-safety
+- [server] Implement global filtering capabilities, to selectively advertize globals to clients.
+  - **Breaking**: this bumps the minimal version of the C libraries to 1.13.0
 
 # 0.21.0-alpha1 - 2018-07-18
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,4 +70,7 @@ name = "server_created_object"
 name = "server_clients"
 
 [[test]]
+name = "server_global_filter"
+
+[[test]]
 name = "server_resources"

--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ The documentation for the releases can be found on [docs.rs](https://docs.rs/):
 
 ## Requirements
 
-Requires at least rust 1.21 to be used, and version 1.12 of the wayland system libraries if using the
+Requires at least rust 1.21 to be used, and version 1.13 of the wayland system libraries if using the
 `native_lib` cargo feature.

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -9,6 +9,7 @@ pub extern crate wayland_server as ways;
 use std::cell::Cell;
 use std::ffi::{OsStr, OsString};
 use std::io;
+use std::os::unix::io::RawFd;
 use std::rc::Rc;
 
 pub struct TestServer {
@@ -58,6 +59,14 @@ impl TestClient {
     pub fn new_auto() -> TestClient {
         let (display, event_queue) =
             self::wayc::Display::connect_to_env().expect("Failed to connect to server.");
+        TestClient {
+            display: display,
+            event_queue: event_queue,
+        }
+    }
+
+    pub unsafe fn from_fd(fd: RawFd) -> TestClient {
+        let (display, event_queue) = self::wayc::Display::from_fd(fd).unwrap();
         TestClient {
             display: display,
             event_queue: event_queue,

--- a/tests/server_global_filter.rs
+++ b/tests/server_global_filter.rs
@@ -1,0 +1,125 @@
+mod helpers;
+
+use helpers::{roundtrip, wayc, ways, TestClient, TestServer};
+
+use ways::protocol::{wl_compositor, wl_output, wl_shm};
+
+struct Privilegied;
+
+#[test]
+fn global_filter() {
+    use std::os::unix::io::IntoRawFd;
+
+    let mut server = TestServer::new();
+    let loop_token = server.event_loop.token();
+
+    // everyone see the compositor
+    server
+        .display
+        .create_global::<wl_compositor::WlCompositor, _>(&loop_token, 1, |_, _| {});
+
+    // everyone see the shm
+    server
+        .display
+        .create_global_with_filter::<wl_shm::WlShm, _, _>(&loop_token, 1, |_, _| {}, |_| true);
+
+    // only privilegied clients see the output
+    let privilegied_output = server
+        .display
+        .create_global_with_filter::<wl_output::WlOutput, _, _>(
+            &loop_token,
+            1,
+            |_, _| {},
+            |client| client.data_map().get::<Privilegied>().is_some(),
+        );
+
+    // normal client only sees wo globals
+    let mut client = TestClient::new(&server.socket_name);
+    let manager = wayc::GlobalManager::new(&client.display);
+
+    roundtrip(&mut client, &mut server).unwrap();
+
+    assert_eq!(manager.list().len(), 2);
+
+    let (server_cx, client_cx) = ::std::os::unix::net::UnixStream::pair().unwrap();
+
+    let priv_client = unsafe { server.display.create_client(server_cx.into_raw_fd()) };
+    priv_client.data_map().insert_if_missing(|| Privilegied);
+
+    let mut client2 = unsafe { TestClient::from_fd(client_cx.into_raw_fd()) };
+    let manager2 = wayc::GlobalManager::new(&client2.display);
+
+    roundtrip(&mut client2, &mut server).unwrap();
+
+    assert_eq!(manager2.list().len(), 3);
+
+    // now destroy the privilegied globa
+    // only privilegied clients will receive the destroy event
+    // if a regular client received it, it would panic as the server destroyed an
+    // unknown global
+
+    privilegied_output.destroy();
+
+    roundtrip(&mut client, &mut server).unwrap();
+    roundtrip(&mut client2, &mut server).unwrap();
+
+    assert_eq!(manager.list().len(), 2);
+    assert_eq!(manager2.list().len(), 2);
+}
+
+#[test]
+fn global_filter_try_force() {
+    use wayc::protocol::wl_display::RequestsTrait as DisplayRequests;
+    use wayc::protocol::wl_output::WlOutput;
+    use wayc::protocol::wl_registry::RequestsTrait as RegistryRequests;
+
+    use std::os::unix::io::IntoRawFd;
+
+    let mut server = TestServer::new();
+    let loop_token = server.event_loop.token();
+
+    // only privilegied clients see the output
+    server
+        .display
+        .create_global_with_filter::<wl_output::WlOutput, _, _>(
+            &loop_token,
+            1,
+            |_, _| {},
+            |client| client.data_map().get::<Privilegied>().is_some(),
+        );
+
+    // normal client that cannot bind the privilegied global
+    let mut client = TestClient::new(&server.socket_name);
+
+    // privilegied client that can
+    let (server_cx, client_cx) = ::std::os::unix::net::UnixStream::pair().unwrap();
+
+    let priv_client = unsafe { server.display.create_client(server_cx.into_raw_fd()) };
+    priv_client.data_map().insert_if_missing(|| Privilegied);
+
+    let mut client2 = unsafe { TestClient::from_fd(client_cx.into_raw_fd()) };
+
+    // privilegied client can bind it
+
+    let registry2 = client2
+        .display
+        .get_registry(|newp| newp.implement(|_, _| {}, ()))
+        .unwrap();
+    registry2
+        .bind::<WlOutput, _>(1, 1, |newp| newp.implement(|_, _| {}, ()))
+        .unwrap();
+
+    roundtrip(&mut client2, &mut server).unwrap();
+
+    // unprivilegied client cannot
+
+    let registry = client
+        .display
+        .get_registry(|newp| newp.implement(|_, _| {}, ()))
+        .unwrap();
+    registry
+        .bind::<WlOutput, _>(1, 1, |newp| newp.implement(|_, _| {}, ()))
+        .unwrap();
+
+    assert!(roundtrip(&mut client, &mut server).is_err());
+}

--- a/wayland-server/src/rust_imp/display.rs
+++ b/wayland-server/src/rust_imp/display.rs
@@ -51,18 +51,20 @@ impl DisplayInner {
         (display, evl)
     }
 
-    pub(crate) fn create_global<I: Interface, F>(
+    pub(crate) fn create_global<I: Interface, F1, F2>(
         &mut self,
         evl: &EventLoopInner,
         version: u32,
-        implementation: F,
+        implementation: F1,
+        filter: Option<F2>,
     ) -> GlobalInner<I>
     where
-        F: FnMut(NewResource<I>, u32) + 'static,
+        F1: FnMut(NewResource<I>, u32) + 'static,
+        F2: FnMut(ClientInner) -> bool + 'static,
     {
         self.global_mgr
             .borrow_mut()
-            .add_global(evl, version, implementation)
+            .add_global(evl, version, implementation, filter)
     }
 
     pub(crate) fn flush_clients(&mut self) {

--- a/wayland-sys/src/server.rs
+++ b/wayland-sys/src/server.rs
@@ -23,6 +23,7 @@ pub type wl_event_loop_idle_func_t = unsafe extern "C" fn(*mut c_void) -> ();
 pub type wl_global_bind_func_t = unsafe extern "C" fn(*mut wl_client, *mut c_void, u32, u32) -> ();
 pub type wl_notify_func_t = unsafe extern "C" fn(*mut wl_listener, *mut c_void) -> ();
 pub type wl_resource_destroy_func_t = unsafe extern "C" fn(*mut wl_resource) -> ();
+pub type wl_display_global_filter_func_t = unsafe extern "C" fn(*const wl_client, *const wl_global, *mut c_void) -> bool;
 
 #[repr(C)]
 pub struct wl_listener {
@@ -66,6 +67,7 @@ external_library!(WaylandServer, "wayland-server",
         fn wl_global_create(*mut wl_display, *const wl_interface, c_int, *mut c_void, wl_global_bind_func_t) -> *mut wl_global,
         fn wl_display_init_shm(*mut wl_display) -> c_int,
         fn wl_display_add_client_created_listener(*mut wl_display, *mut wl_listener) -> (),
+        fn wl_display_set_global_filter(*mut wl_display, wl_display_global_filter_func_t, *mut c_void) -> (),
     // wl_event_loop
         fn wl_event_loop_create() -> *mut wl_event_loop,
         fn wl_event_loop_destroy(*mut wl_event_loop) -> (),
@@ -85,6 +87,7 @@ external_library!(WaylandServer, "wayland-server",
         fn wl_event_source_check(*mut wl_event_source) -> (),
     // wl_global
         fn wl_global_destroy(*mut wl_global) -> (),
+        fn wl_global_get_user_data(*const wl_global) -> *mut c_void,
     // wl_resource
         fn wl_resource_post_event_array(*mut wl_resource, u32, *mut wl_argument) -> (),
         fn wl_resource_queue_event_array(*mut wl_resource, u32, *mut wl_argument) -> (),


### PR DESCRIPTION
When creating a global, it is possible to associate a closure to it
that can be used to filter which clients are allowed to see the
existence of this global.

This bumps the minimal version of the wayland libs to 1.13.0.

Fixes #168