### PR TITLE
Update wlr-protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [commons] Fix incorrect number of server-side ids when using the rust implementation
+- [protocols] Update wlroots-protocols.
 
 ## 0.21.10 -- 2019-01-06
 

--- a/wayland-protocols/build.rs
+++ b/wayland-protocols/build.rs
@@ -28,6 +28,7 @@ static UNSTABLE_PROTOCOLS: &'static [(&'static str, &'static [&'static str])] = 
 ];
 
 static WLR_UNSTABLE_PROTOCOLS: &'static [(&'static str, &'static [&'static str])] = &[
+    ("wlr-data-control", &["v1"]),
     ("wlr-export-dmabuf", &["v1"]),
     ("wlr-foreign-toplevel-management", &["v1"]),
     ("wlr-gamma-control", &["v1"]),

--- a/wayland-protocols/src/wlr.rs
+++ b/wayland-protocols/src/wlr.rs
@@ -21,6 +21,22 @@ pub mod unstable {
     //! interface names are removed and the interface version number is
     //! reset.
 
+    pub mod data_control {
+        //! Control data devices, particularly the clipboard.
+        //!
+        //! An interface to control data devices, particularly to manage the current selection and
+        //! take the role of a clipboard manager.
+
+        wayland_protocol_versioned!(
+            "wlr-data-control",
+            [v1],
+            [
+                (wl_seat, wl_seat_interface)
+            ],
+            []
+        );
+    }
+
     pub mod export_dmabuf {
         //! A protocol for low overhead screen content capturing
         //!


### PR DESCRIPTION
Includes the new `data-control-unstable-v1` protocol.

I hit an issue trying to use it though. I have the following code:
```rust
use std::sync::{Arc, Mutex};

use wayland_client::{
    protocol::{
        wl_registry::RequestsTrait as WlRegistryRequestsTrait, wl_seat::WlSeat,
    },
    Display, GlobalEvent, GlobalManager, Interface,
};
use wayland_protocols::wlr::unstable::data_control::v1::client::{
    zwlr_data_control_manager_v1::{
        RequestsTrait as ZwlrDataControlManagerV1RequestsTrait,
        ZwlrDataControlManagerV1,
    },
    *,
};

fn main() {
    let (display, mut queue) =
        Display::connect_to_env().expect("Error connecting to a display");
    println!("Connected!");

    let seats = Arc::new(Mutex::new(vec![]));

    let global_manager = {
        let seats = seats.clone();
        GlobalManager::new_with_cb(&display, move |event, proxy| {
            if let GlobalEvent::New {
                id,
                interface,
                version,
            } = event
            {
                if interface == WlSeat::NAME && version >= WlSeat::VERSION {
                    seats.lock().unwrap().push(
                        proxy
                            .bind::<WlSeat, _>(WlSeat::VERSION, id, |seat| {
                                seat.implement(|_, _| (), ())
                            })
                            .unwrap(),
                    );
                }
            }
        })
    };

    queue.sync_roundtrip().expect("Error doing a roundtrip");

    let data_control_manager = global_manager
        .instantiate_exact::<ZwlrDataControlManagerV1, _>(
            ZwlrDataControlManagerV1::VERSION,
            |new_proxy| new_proxy.implement(|_, _| (), ()),
        )
        .expect("Error getting zwlr_data_control_manager_v1");

    for seat in &*seats.lock().unwrap() {
        data_control_manager
            .get_data_device(seat, |data_device| {
                data_device.implement(
                    |event, _| {
                        if let zwlr_data_control_device_v1::Event::DataOffer { id } =
                            event
                        {
                            id.implement(
                                |event, _| {
                                    let zwlr_data_control_offer_v1::Event::Offer {
                                        mime_type,
                                    } = event;
                                    println!("{}", mime_type);
                                },
                                (),
                            );
                        }
                    },
                    (),
                )
            })
            .unwrap();
    }

    queue.sync_roundtrip().expect("Error doing a roundtrip");
}
```
And when I try to run it (with something copied into the clipboard) I get a panic:
```
Connected!
thread 'main' panicked at 'attempt to subtract with overflow', /home/yalter/Source/rust/wayland-rs/wayland-commons/src/map.rs:218:14
stack backtrace:
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
             at src/libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:71
   2: std::panicking::default_hook::{{closure}}
             at src/libstd/sys_common/backtrace.rs:59
             at src/libstd/panicking.rs:211
   3: std::panicking::default_hook
             at src/libstd/panicking.rs:227
   4: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:491
   5: std::panicking::continue_panic_fmt
             at src/libstd/panicking.rs:398
   6: rust_begin_unwind
             at src/libstd/panicking.rs:325
   7: core::panicking::panic_fmt
             at src/libcore/panicking.rs:95
   8: core::panicking::panic
             at src/libcore/panicking.rs:59
   9: wayland_commons::map::insert_in_at
             at /home/yalter/Source/rust/wayland-rs/wayland-commons/src/map.rs:218
  10: <wayland_commons::map::ObjectMap<Meta>>::insert_at
             at /home/yalter/Source/rust/wayland-rs/wayland-commons/src/map.rs:148
  11: wayland_client::imp::connection::Connection::read_events::{{closure}}
             at /home/yalter/Source/rust/wayland-rs/wayland-client/src/rust_imp/connection.rs:104
  12: wayland_commons::socket::BufferedSocket::read_messages
             at /home/yalter/Source/rust/wayland-rs/wayland-commons/src/socket.rs:313
  13: wayland_client::imp::connection::Connection::read_events
             at /home/yalter/Source/rust/wayland-rs/wayland-client/src/rust_imp/connection.rs:64
  14: wayland_client::imp::queues::EventQueueInner::read_events
             at /home/yalter/Source/rust/wayland-rs/wayland-client/src/rust_imp/queues.rs:205
  15: wayland_client::imp::queues::EventQueueInner::dispatch
             at /home/yalter/Source/rust/wayland-rs/wayland-client/src/rust_imp/queues.rs:99
  16: wayland_client::imp::queues::EventQueueInner::sync_roundtrip
             at /home/yalter/Source/rust/wayland-rs/wayland-client/src/rust_imp/queues.rs:187
  17: wayland_client::event_queue::EventQueue::sync_roundtrip
             at /home/yalter/Source/rust/wayland-rs/wayland-client/src/event_queue.rs:95
  18: wayland_test::main
             at src/main.rs:80
  19: std::rt::lang_start::{{closure}}
             at /rustc/9fda7c2237db910e41d6a712e9a2139b352e558b/src/libstd/rt.rs:74
  20: std::panicking::try::do_call
             at src/libstd/rt.rs:59
             at src/libstd/panicking.rs:310
  21: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:102
  22: std::rt::lang_start_internal
             at src/libstd/panicking.rs:289
             at src/libstd/panic.rs:398
             at src/libstd/rt.rs:58
  23: std::rt::lang_start
             at /rustc/9fda7c2237db910e41d6a712e9a2139b352e558b/src/libstd/rt.rs:74
  24: main
  25: __libc_start_main
  26: _start
```
Some info I got from gdb:
```
Program received signal SIGABRT, Aborted.
0x00007ffff7d8dd7f in raise () from /usr/lib/libc.so.6
(gdb) bt
#0  0x00007ffff7d8dd7f in raise () from /usr/lib/libc.so.6
#1  0x00007ffff7d78672 in abort () from /usr/lib/libc.so.6
#2  0x00005555555e4197 in panic_abort::__rust_start_panic::abort () at src/libpanic_abort/lib.rs:60
#3  0x00005555555e4186 in __rust_start_panic () at src/libpanic_abort/lib.rs:55
#4  0x00005555555d6f29 in rust_panic () at src/libstd/panicking.rs:540
#5  0x00005555555d6f02 in std::panicking::rust_panic_with_hook () at src/libstd/panicking.rs:511
#6  0x00005555555d6942 in std::panicking::continue_panic_fmt () at src/libstd/panicking.rs:398
#7  0x00005555555d6826 in rust_begin_unwind () at src/libstd/panicking.rs:325
#8  0x00005555555e53cd in core::panicking::panic_fmt () at src/libcore/panicking.rs:95
#9  0x00005555555e52fc in core::panicking::panic () at src/libcore/panicking.rs:59
#10 0x000055555557f9d7 in wayland_commons::map::insert_in_at (store=0x555555613fc8, id=0, object=...)
    at /home/yalter/Source/rust/wayland-rs/wayland-commons/src/map.rs:218
#11 0x00005555555818c6 in <wayland_commons::map::ObjectMap<Meta>>::insert_at (self=0x555555613fb0, id=4278190080, object=...)
    at /home/yalter/Source/rust/wayland-rs/wayland-commons/src/map.rs:148
#12 0x00005555555a48e6 in wayland_client::imp::connection::Connection::read_events::{{closure}} (msg=...)
    at /home/yalter/Source/rust/wayland-rs/wayland-client/src/rust_imp/connection.rs:104
#13 0x00005555555a8ec5 in wayland_commons::socket::BufferedSocket::read_messages (self=0x5555556140a0, signature=..., callback=...)
    at /home/yalter/Source/rust/wayland-rs/wayland-commons/src/socket.rs:313
#14 0x00005555555a3d4b in wayland_client::imp::connection::Connection::read_events (self=0x5555556140a0)
    at /home/yalter/Source/rust/wayland-rs/wayland-client/src/rust_imp/connection.rs:64
#15 0x00005555555a6aa2 in wayland_client::imp::queues::EventQueueInner::read_events (self=0x555555610d40)
    at /home/yalter/Source/rust/wayland-rs/wayland-client/src/rust_imp/queues.rs:205
#16 0x00005555555a57e8 in wayland_client::imp::queues::EventQueueInner::dispatch (self=0x555555610d40)
    at /home/yalter/Source/rust/wayland-rs/wayland-client/src/rust_imp/queues.rs:99
#17 0x00005555555a67df in wayland_client::imp::queues::EventQueueInner::sync_roundtrip (self=0x555555610d40)
    at /home/yalter/Source/rust/wayland-rs/wayland-client/src/rust_imp/queues.rs:187
#18 0x00005555555a4190 in wayland_client::event_queue::EventQueue::sync_roundtrip (self=0x7fffffffd890)
    at /home/yalter/Source/rust/wayland-rs/wayland-client/src/event_queue.rs:95
#19 0x0000555555566ec6 in wayland_test::main () at src/main.rs:80
(gdb) frame 10
#10 0x000055555557f9d7 in wayland_commons::map::insert_in_at (store=0x555555613fc8, id=0, object=...)
    at /home/yalter/Source/rust/wayland-rs/wayland-commons/src/map.rs:218
218         let id = id - 1;
(gdb) p id
$1 = 0
(gdb) up
#11 0x00005555555818c6 in <wayland_commons::map::ObjectMap<Meta>>::insert_at (self=0x555555613fb0, id=4278190080, object=...)
    at /home/yalter/Source/rust/wayland-rs/wayland-commons/src/map.rs:148
148                 insert_in_at(&mut self.server_objects, (id - SERVER_ID_LIMIT) as usize, object)
(gdb) p id
$2 = 4278190080
(gdb) list
143         ///
144         /// Can fail if the requested id is not the next free id of this store.
145         /// (In which case this is a protocol error)
146         pub fn insert_at(&mut self, id: u32, object: Object<Meta>) -> Result<(), ()> {
147             if id >= SERVER_ID_LIMIT {
148                 insert_in_at(&mut self.server_objects, (id - SERVER_ID_LIMIT) as usize, object)
149             } else {
150                 insert_in_at(&mut self.client_objects, id as usize, object)
151             }
152         }
(gdb) p id
$3 = 4278190080
(gdb) up
#12 0x00005555555a48e6 in wayland_client::imp::connection::Connection::read_events::{{closure}} (msg=...)
    at /home/yalter/Source/rust/wayland-rs/wayland-client/src/rust_imp/connection.rs:104
104                         if let Err(()) = map.insert_at(new_id, child) {
(gdb) list
99                                  }
100                             })
101                             .next()
102                             .unwrap();
103                         let child_interface = child.interface;
104                         if let Err(()) = map.insert_at(new_id, child) {
105                             eprintln!(
106                                 "[wayland-client] Protocol error: server tried to create an object \"{}\" with invalid id \"{}\"
.",
107                                 child_interface,
108                                 new_id
(gdb) p child_interface
$4 = "zwlr_data_control_offer_v1"
(gdb)
```
I'm testing on rootston from https://github.com/swaywm/wlroots/commit/0e0ba65bc0187cc1dabd7591e2f081ab3bf44d01.