### PR TITLE
commons: fix server ids handling in map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [commons] Fix incorrect number of server-side ids when using the rust implementation
+
 ## 0.21.10 -- 2019-01-06
 
 - [client] Undo protocol update which was a breakind change

--- a/tests/server_created_object.rs
+++ b/tests/server_created_object.rs
@@ -32,6 +32,8 @@ fn data_offer() {
                             .create_resource::<ServerDO>(ddevice.version())
                             .unwrap()
                             .implement(|_, _| {}, None::<fn(_)>, ());
+                        // this must be the first server-side ID
+                        assert_eq!(offer.id(), 0xFF000000);
                         ddevice.send(SDDEvt::DataOffer { id: offer })
                     }
                     _ => unimplemented!(),
@@ -63,6 +65,8 @@ fn data_offer() {
                     CDDEvt::DataOffer { id } => {
                         let doffer = id.implement(|_, _| {}, ());
                         assert!(doffer.version() == 3);
+                        // this must be the first server-side ID
+                        assert_eq!(doffer.id(), 0xFF000000);
                         *received2.lock().unwrap() = true;
                     }
                     _ => unimplemented!(),


### PR DESCRIPTION
Client ids start at 1 and server ids start at SERVER_ID_LIMIT, not
SERVER_ID_LIMIT+1.

cc #224