### PR TITLE
Trait-based event handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- [scanner] Generate `EventHandler` and `RequestHandler` traits for trait-based event
+  and request handling (as opposed to manually matching on enums).
+- [client & server] **Breaking**: Change `NewProxy/NewRequest::implement()` to accept
+  a handler struct which implements the corresponding `EventHandler/RequestHandler` trait.
+- [client & server] Introduce `NewProxy/NewRequest::implement_closure()` which behaves
+  like the previous `NewProxy/NewRequest::implement()` and
+  `NewProxy/NewRequest::implement_dummy()` which adds an empty implementation.
+
 ## 0.21.11 -- 2019-01-19
 
 - [commons] Fix incorrect number of server-side ids when using the rust implementation

--- a/tests/attach_to_surface.rs
+++ b/tests/attach_to_surface.rs
@@ -115,12 +115,10 @@ fn attach_null() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let compositor = manager
-        .instantiate_exact::<wayc::protocol::wl_compositor::WlCompositor, _>(1, |comp| {
-            comp.implement(|_, _| {}, ())
-        })
+        .instantiate_exact::<wayc::protocol::wl_compositor::WlCompositor, _>(1, |comp| comp.implement_dummy())
         .unwrap();
     let surface = compositor
-        .create_surface(|surface| surface.implement(|_, _| {}, ()))
+        .create_surface(|surface| surface.implement_dummy())
         .unwrap();
     surface.attach(None, 0, 0);
 
@@ -146,26 +144,24 @@ fn attach_buffer() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let shm = manager
-        .instantiate_exact::<wayc::protocol::wl_shm::WlShm, _>(1, |shm| shm.implement(|_, _| {}, ()))
+        .instantiate_exact::<wayc::protocol::wl_shm::WlShm, _>(1, |shm| shm.implement_dummy())
         .unwrap();
 
     let mut file = tempfile::tempfile().unwrap();
     write!(file, "I like trains!").unwrap();
     file.flush().unwrap();
     let pool = shm
-        .create_pool(file.as_raw_fd(), 42, |newp| newp.implement(|_, _| {}, ()))
+        .create_pool(file.as_raw_fd(), 42, |newp| newp.implement_dummy())
         .unwrap();
     let buffer = pool
-        .create_buffer(0, 0, 0, 0, Format::Argb8888, |newb| newb.implement(|_, _| {}, ()))
+        .create_buffer(0, 0, 0, 0, Format::Argb8888, |newb| newb.implement_dummy())
         .unwrap();
 
     let compositor = manager
-        .instantiate_exact::<wayc::protocol::wl_compositor::WlCompositor, _>(1, |comp| {
-            comp.implement(|_, _| {}, ())
-        })
+        .instantiate_exact::<wayc::protocol::wl_compositor::WlCompositor, _>(1, |comp| comp.implement_dummy())
         .unwrap();
     let surface = compositor
-        .create_surface(|surface| surface.implement(|_, _| {}, ()))
+        .create_surface(|surface| surface.implement_dummy())
         .unwrap();
     surface.attach(Some(&buffer), 0, 0);
 

--- a/tests/client_proxies.rs
+++ b/tests/client_proxies.rs
@@ -19,11 +19,11 @@ fn proxy_equals() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let compositor1 = manager
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement_dummy())
         .unwrap();
 
     let compositor2 = manager
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement_dummy())
         .unwrap();
 
     let compositor3 = compositor1.clone();
@@ -44,11 +44,15 @@ fn proxy_user_data() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let compositor1 = manager
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement(|_, _| {}, 0xDEADBEEFusize))
+        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| {
+            newp.implement_closure(|_, _| {}, 0xDEADBEEFusize)
+        })
         .unwrap();
 
     let compositor2 = manager
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement(|_, _| {}, 0xBADC0FFEusize))
+        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| {
+            newp.implement_closure(|_, _| {}, 0xBADC0FFEusize)
+        })
         .unwrap();
 
     let compositor3 = compositor1.clone();
@@ -119,7 +123,7 @@ fn dead_proxies() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let output = manager
-        .instantiate_auto::<wl_output::WlOutput, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<wl_output::WlOutput, _>(|newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();

--- a/tests/destructors.rs
+++ b/tests/destructors.rs
@@ -33,7 +33,7 @@ fn resource_destructor() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let output = manager
-        .instantiate_auto::<WlOutput, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<WlOutput, _>(|newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();
@@ -70,7 +70,7 @@ fn resource_destructor_cleanup() {
     roundtrip(&mut client, &mut server).unwrap();
 
     manager
-        .instantiate_auto::<WlOutput, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<WlOutput, _>(|newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();
@@ -106,7 +106,7 @@ fn client_destructor_cleanup() {
     roundtrip(&mut client, &mut server).unwrap();
 
     manager
-        .instantiate_auto::<WlOutput, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<WlOutput, _>(|newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();

--- a/tests/destructors.rs
+++ b/tests/destructors.rs
@@ -18,7 +18,7 @@ fn resource_destructor() {
         .display
         .create_global::<ServerOutput, _>(3, move |newo, _| {
             let destructor_called_resource = destructor_called_global.clone();
-            newo.implement(
+            newo.implement_closure(
                 |_, _| {},
                 Some(move |_| {
                     *destructor_called_resource.lock().unwrap() = true;
@@ -55,7 +55,7 @@ fn resource_destructor_cleanup() {
         .display
         .create_global::<ServerOutput, _>(3, move |newo, _| {
             let destructor_called_resource = destructor_called_global.clone();
-            newo.implement(
+            newo.implement_closure(
                 |_, _| {},
                 Some(move |_| {
                     *destructor_called_resource.lock().unwrap() = true;
@@ -93,7 +93,7 @@ fn client_destructor_cleanup() {
         .display
         .create_global::<ServerOutput, _>(3, move |newo, _| {
             let destructor_called_resource = destructor_called_global.clone();
-            let output = newo.implement(|_, _| {}, None::<fn(_)>, ());
+            let output = newo.implement_dummy();
             let client = output.client().unwrap();
             client.add_destructor(move |_| {
                 *destructor_called_resource.lock().unwrap() = true;

--- a/tests/globals.rs
+++ b/tests/globals.rs
@@ -123,25 +123,24 @@ fn auto_instantiate() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let compositor = manager
-        .instantiate_auto::<WlCompositor, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<WlCompositor, _>(|newp| newp.implement_dummy())
         .unwrap();
     assert!(compositor.version() == 4);
     let shell = manager
-        .instantiate_auto::<WlShell, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<WlShell, _>(|newp| newp.implement_dummy())
         .unwrap();
     assert!(shell.version() == 1);
 
     assert!(
-        manager.instantiate_exact::<WlCompositor, _>(5, |newp| newp.implement(|_, _| {}, ()))
+        manager.instantiate_exact::<WlCompositor, _>(5, |newp| newp.implement_dummy())
             == Err(GlobalError::VersionTooLow(4))
     );
     assert!(
-        manager.instantiate_exact::<WlOutput, _>(5, |newp| newp.implement(|_, _| {}, ()))
+        manager.instantiate_exact::<WlOutput, _>(5, |newp| newp.implement_dummy())
             == Err(GlobalError::Missing)
     );
     assert!(
-        manager.instantiate_auto::<WlOutput, _>(|newp| newp.implement(|_, _| {}, ()))
-            == Err(GlobalError::Missing)
+        manager.instantiate_auto::<WlOutput, _>(|newp| newp.implement_dummy()) == Err(GlobalError::Missing)
     );
 }
 
@@ -165,14 +164,14 @@ fn wrong_global() {
     let mut client = TestClient::new(&server.socket_name);
     let registry = client
         .display
-        .get_registry(|newp| newp.implement(|_, _| {}, ()))
+        .get_registry(|newp| newp.implement_dummy())
         .unwrap();
 
     // instantiate a wrong global, this should kill the client
     // but currently does not fail on native_lib
 
     registry
-        .bind::<WlOutput, _>(1, 1, |newp| newp.implement(|_, _| {}, ()))
+        .bind::<WlOutput, _>(1, 1, |newp| newp.implement_dummy())
         .unwrap();
 
     assert!(roundtrip(&mut client, &mut server).is_err());
@@ -190,13 +189,13 @@ fn wrong_global_version() {
     let mut client = TestClient::new(&server.socket_name);
     let registry = client
         .display
-        .get_registry(|newp| newp.implement(|_, _| {}, ()))
+        .get_registry(|newp| newp.implement_dummy())
         .unwrap();
 
     // instantiate a global with wrong version, this should kill the client
 
     registry
-        .bind::<WlCompositor, _>(2, 1, |newp| newp.implement(|_, _| {}, ()))
+        .bind::<WlCompositor, _>(2, 1, |newp| newp.implement_dummy())
         .unwrap();
 
     assert!(roundtrip(&mut client, &mut server).is_err());
@@ -214,13 +213,13 @@ fn invalid_global_version() {
     let mut client = TestClient::new(&server.socket_name);
     let registry = client
         .display
-        .get_registry(|newp| newp.implement(|_, _| {}, ()))
+        .get_registry(|newp| newp.implement_dummy())
         .unwrap();
 
     // instantiate a global with version 0, which is invalid this should kill the client
 
     registry
-        .bind::<WlCompositor, _>(0, 1, |newp| newp.implement(|_, _| {}, ()))
+        .bind::<WlCompositor, _>(0, 1, |newp| newp.implement_dummy())
         .unwrap();
 
     assert!(roundtrip(&mut client, &mut server).is_err());
@@ -238,13 +237,13 @@ fn wrong_global_id() {
     let mut client = TestClient::new(&server.socket_name);
     let registry = client
         .display
-        .get_registry(|newp| newp.implement(|_, _| {}, ()))
+        .get_registry(|newp| newp.implement_dummy())
         .unwrap();
 
     // instantiate a global with wrong id, this should kill the client
 
     registry
-        .bind::<WlCompositor, _>(1, 3, |newp| newp.implement(|_, _| {}, ()))
+        .bind::<WlCompositor, _>(1, 3, |newp| newp.implement_dummy())
         .unwrap();
 
     assert!(roundtrip(&mut client, &mut server).is_err());
@@ -269,11 +268,11 @@ fn two_step_binding() {
     roundtrip(&mut client, &mut server).unwrap();
 
     manager
-        .instantiate_auto::<WlCompositor, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<WlCompositor, _>(|newp| newp.implement_dummy())
         .unwrap();
 
     manager
-        .instantiate_auto::<WlOutput, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<WlOutput, _>(|newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();

--- a/tests/scanner_assets/client_c_code.rs
+++ b/tests/scanner_assets/client_c_code.rs
@@ -3,8 +3,8 @@ pub mod wl_foo {
     use super::sys::client::*;
     use super::sys::common::{wl_argument, wl_array, wl_interface};
     use super::{
-        AnonymousObject, Argument, ArgumentType, Interface, Message, MessageDesc, MessageGroup, NewProxy,
-        Object, ObjectMetadata, Proxy,
+        AnonymousObject, Argument, ArgumentType, HandledBy, Interface, Message, MessageDesc, MessageGroup,
+        NewProxy, Object, ObjectMetadata, Proxy,
     };
     #[doc = "Possible cake kinds\n\nList of the possible kind of cake supported by the protocol."]
     #[repr(u32)]
@@ -285,6 +285,19 @@ pub mod wl_foo {
             self.send_constructor(msg, implementor, None)
         }
     }
+    #[doc = r" An interface for handling events."]
+    pub trait EventHandler {
+        #[doc = "a cake is possible\n\nThe server advertises that a kind of cake is available\n\nOnly available since version 2 of the interface."]
+        fn cake(&mut self, proxy: Proxy<WlFoo>, kind: CakeKind, amount: u32) {}
+    }
+    impl<T: EventHandler> HandledBy<T> for WlFoo {
+        #[inline]
+        fn handle(handler: &mut T, event: Event, proxy: Proxy<Self>) {
+            match event {
+                Event::Cake { kind, amount } => handler.cake(proxy, kind, amount),
+            }
+        }
+    }
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_FOO_IT_SINCE: u16 = 1u16;
     #[doc = r" The minimal object version supporting this request"]
@@ -297,8 +310,8 @@ pub mod wl_bar {
     use super::sys::client::*;
     use super::sys::common::{wl_argument, wl_array, wl_interface};
     use super::{
-        AnonymousObject, Argument, ArgumentType, Interface, Message, MessageDesc, MessageGroup, NewProxy,
-        Object, ObjectMetadata, Proxy,
+        AnonymousObject, Argument, ArgumentType, HandledBy, Interface, Message, MessageDesc, MessageGroup,
+        NewProxy, Object, ObjectMetadata, Proxy,
     };
     pub enum Request {
         #[doc = "ask for a bar delivery\n\nProceed to a bar delivery of given foo.\n\nOnly available since version 2 of the interface"]
@@ -501,6 +514,14 @@ pub mod wl_bar {
             self.send(msg);
         }
     }
+    #[doc = r" An interface for handling events."]
+    pub trait EventHandler {}
+    impl<T: EventHandler> HandledBy<T> for WlBar {
+        #[inline]
+        fn handle(handler: &mut T, event: Event, proxy: Proxy<Self>) {
+            match event {}
+        }
+    }
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_BAR_DELIVERY_SINCE: u16 = 2u16;
     #[doc = r" The minimal object version supporting this request"]
@@ -511,8 +532,8 @@ pub mod wl_display {
     use super::sys::client::*;
     use super::sys::common::{wl_argument, wl_array, wl_interface};
     use super::{
-        AnonymousObject, Argument, ArgumentType, Interface, Message, MessageDesc, MessageGroup, NewProxy,
-        Object, ObjectMetadata, Proxy,
+        AnonymousObject, Argument, ArgumentType, HandledBy, Interface, Message, MessageDesc, MessageGroup,
+        NewProxy, Object, ObjectMetadata, Proxy,
     };
     pub enum Request {}
     impl super::MessageGroup for Request {
@@ -600,14 +621,22 @@ pub mod wl_display {
     }
     pub trait RequestsTrait {}
     impl RequestsTrait for Proxy<WlDisplay> {}
+    #[doc = r" An interface for handling events."]
+    pub trait EventHandler {}
+    impl<T: EventHandler> HandledBy<T> for WlDisplay {
+        #[inline]
+        fn handle(handler: &mut T, event: Event, proxy: Proxy<Self>) {
+            match event {}
+        }
+    }
 }
 #[doc = "global registry object\n\nThis global is special and should only generate code client-side, not server-side."]
 pub mod wl_registry {
     use super::sys::client::*;
     use super::sys::common::{wl_argument, wl_array, wl_interface};
     use super::{
-        AnonymousObject, Argument, ArgumentType, Interface, Message, MessageDesc, MessageGroup, NewProxy,
-        Object, ObjectMetadata, Proxy,
+        AnonymousObject, Argument, ArgumentType, HandledBy, Interface, Message, MessageDesc, MessageGroup,
+        NewProxy, Object, ObjectMetadata, Proxy,
     };
     pub enum Request {
         #[doc = "bind an object to the display\n\nThis request is a special code-path, as its new-id argument as no target type."]
@@ -746,6 +775,14 @@ pub mod wl_registry {
             self.send_constructor(msg, implementor, Some(version))
         }
     }
+    #[doc = r" An interface for handling events."]
+    pub trait EventHandler {}
+    impl<T: EventHandler> HandledBy<T> for WlRegistry {
+        #[inline]
+        fn handle(handler: &mut T, event: Event, proxy: Proxy<Self>) {
+            match event {}
+        }
+    }
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_BIND_SINCE: u16 = 1u16;
 }
@@ -754,8 +791,8 @@ pub mod wl_callback {
     use super::sys::client::*;
     use super::sys::common::{wl_argument, wl_array, wl_interface};
     use super::{
-        AnonymousObject, Argument, ArgumentType, Interface, Message, MessageDesc, MessageGroup, NewProxy,
-        Object, ObjectMetadata, Proxy,
+        AnonymousObject, Argument, ArgumentType, HandledBy, Interface, Message, MessageDesc, MessageGroup,
+        NewProxy, Object, ObjectMetadata, Proxy,
     };
     pub enum Request {}
     impl super::MessageGroup for Request {
@@ -872,6 +909,19 @@ pub mod wl_callback {
     }
     pub trait RequestsTrait {}
     impl RequestsTrait for Proxy<WlCallback> {}
+    #[doc = r" An interface for handling events."]
+    pub trait EventHandler {
+        #[doc = "done event\n\nThis event is actually a destructor, but the protocol XML has no way of specifying it.\nAs such, the scanner should consider wl_callback.done as a special case.\n\nThis is a destructor, you cannot send requests to this object any longer once this method is called."]
+        fn done(&mut self, proxy: Proxy<WlCallback>, callback_data: u32) {}
+    }
+    impl<T: EventHandler> HandledBy<T> for WlCallback {
+        #[inline]
+        fn handle(handler: &mut T, event: Event, proxy: Proxy<Self>) {
+            match event {
+                Event::Done { callback_data } => handler.done(proxy, callback_data),
+            }
+        }
+    }
     #[doc = r" The minimal object version supporting this event"]
     pub const EVT_DONE_SINCE: u16 = 1u16;
 }

--- a/tests/scanner_assets/client_rust_code.rs
+++ b/tests/scanner_assets/client_rust_code.rs
@@ -1,8 +1,8 @@
 #[doc = "Interface for fooing\n\nThis is the dedicated interface for doing foos over any\nkind of other foos."]
 pub mod wl_foo {
     use super::{
-        AnonymousObject, Argument, ArgumentType, Interface, Message, MessageDesc, MessageGroup, NewProxy,
-        Object, ObjectMetadata, Proxy,
+        AnonymousObject, Argument, ArgumentType, HandledBy, Interface, Message, MessageDesc, MessageGroup,
+        NewProxy, Object, ObjectMetadata, Proxy,
     };
     #[doc = "Possible cake kinds\n\nList of the possible kind of cake supported by the protocol."]
     #[repr(u32)]
@@ -223,6 +223,19 @@ pub mod wl_foo {
             self.send_constructor(msg, implementor, None)
         }
     }
+    #[doc = r" An interface for handling events."]
+    pub trait EventHandler {
+        #[doc = "a cake is possible\n\nThe server advertises that a kind of cake is available\n\nOnly available since version 2 of the interface."]
+        fn cake(&mut self, proxy: Proxy<WlFoo>, kind: CakeKind, amount: u32) {}
+    }
+    impl<T: EventHandler> HandledBy<T> for WlFoo {
+        #[inline]
+        fn handle(handler: &mut T, event: Event, proxy: Proxy<Self>) {
+            match event {
+                Event::Cake { kind, amount } => handler.cake(proxy, kind, amount),
+            }
+        }
+    }
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_FOO_IT_SINCE: u16 = 1u16;
     #[doc = r" The minimal object version supporting this request"]
@@ -233,8 +246,8 @@ pub mod wl_foo {
 #[doc = "Interface for bars\n\nThis interface allows you to bar your foos."]
 pub mod wl_bar {
     use super::{
-        AnonymousObject, Argument, ArgumentType, Interface, Message, MessageDesc, MessageGroup, NewProxy,
-        Object, ObjectMetadata, Proxy,
+        AnonymousObject, Argument, ArgumentType, HandledBy, Interface, Message, MessageDesc, MessageGroup,
+        NewProxy, Object, ObjectMetadata, Proxy,
     };
     pub enum Request {
         #[doc = "ask for a bar delivery\n\nProceed to a bar delivery of given foo.\n\nOnly available since version 2 of the interface"]
@@ -375,6 +388,14 @@ pub mod wl_bar {
             self.send(msg);
         }
     }
+    #[doc = r" An interface for handling events."]
+    pub trait EventHandler {}
+    impl<T: EventHandler> HandledBy<T> for WlBar {
+        #[inline]
+        fn handle(handler: &mut T, event: Event, proxy: Proxy<Self>) {
+            match event {}
+        }
+    }
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_BAR_DELIVERY_SINCE: u16 = 2u16;
     #[doc = r" The minimal object version supporting this request"]
@@ -383,8 +404,8 @@ pub mod wl_bar {
 #[doc = "core global object\n\nThis global is special and should only generate code client-side, not server-side."]
 pub mod wl_display {
     use super::{
-        AnonymousObject, Argument, ArgumentType, Interface, Message, MessageDesc, MessageGroup, NewProxy,
-        Object, ObjectMetadata, Proxy,
+        AnonymousObject, Argument, ArgumentType, HandledBy, Interface, Message, MessageDesc, MessageGroup,
+        NewProxy, Object, ObjectMetadata, Proxy,
     };
     pub enum Request {}
     impl super::MessageGroup for Request {
@@ -441,12 +462,20 @@ pub mod wl_display {
     }
     pub trait RequestsTrait {}
     impl RequestsTrait for Proxy<WlDisplay> {}
+    #[doc = r" An interface for handling events."]
+    pub trait EventHandler {}
+    impl<T: EventHandler> HandledBy<T> for WlDisplay {
+        #[inline]
+        fn handle(handler: &mut T, event: Event, proxy: Proxy<Self>) {
+            match event {}
+        }
+    }
 }
 #[doc = "global registry object\n\nThis global is special and should only generate code client-side, not server-side."]
 pub mod wl_registry {
     use super::{
-        AnonymousObject, Argument, ArgumentType, Interface, Message, MessageDesc, MessageGroup, NewProxy,
-        Object, ObjectMetadata, Proxy,
+        AnonymousObject, Argument, ArgumentType, HandledBy, Interface, Message, MessageDesc, MessageGroup,
+        NewProxy, Object, ObjectMetadata, Proxy,
     };
     pub enum Request {
         #[doc = "bind an object to the display\n\nThis request is a special code-path, as its new-id argument as no target type."]
@@ -544,14 +573,22 @@ pub mod wl_registry {
             self.send_constructor(msg, implementor, Some(version))
         }
     }
+    #[doc = r" An interface for handling events."]
+    pub trait EventHandler {}
+    impl<T: EventHandler> HandledBy<T> for WlRegistry {
+        #[inline]
+        fn handle(handler: &mut T, event: Event, proxy: Proxy<Self>) {
+            match event {}
+        }
+    }
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_BIND_SINCE: u16 = 1u16;
 }
 #[doc = "callback object\n\nThis object has a special behavior regarding its destructor."]
 pub mod wl_callback {
     use super::{
-        AnonymousObject, Argument, ArgumentType, Interface, Message, MessageDesc, MessageGroup, NewProxy,
-        Object, ObjectMetadata, Proxy,
+        AnonymousObject, Argument, ArgumentType, HandledBy, Interface, Message, MessageDesc, MessageGroup,
+        NewProxy, Object, ObjectMetadata, Proxy,
     };
     pub enum Request {}
     impl super::MessageGroup for Request {
@@ -631,6 +668,19 @@ pub mod wl_callback {
     }
     pub trait RequestsTrait {}
     impl RequestsTrait for Proxy<WlCallback> {}
+    #[doc = r" An interface for handling events."]
+    pub trait EventHandler {
+        #[doc = "done event\n\nThis event is actually a destructor, but the protocol XML has no way of specifying it.\nAs such, the scanner should consider wl_callback.done as a special case.\n\nThis is a destructor, you cannot send requests to this object any longer once this method is called."]
+        fn done(&mut self, proxy: Proxy<WlCallback>, callback_data: u32) {}
+    }
+    impl<T: EventHandler> HandledBy<T> for WlCallback {
+        #[inline]
+        fn handle(handler: &mut T, event: Event, proxy: Proxy<Self>) {
+            match event {
+                Event::Done { callback_data } => handler.done(proxy, callback_data),
+            }
+        }
+    }
     #[doc = r" The minimal object version supporting this event"]
     pub const EVT_DONE_SINCE: u16 = 1u16;
 }

--- a/tests/server_clients.rs
+++ b/tests/server_clients.rs
@@ -20,7 +20,7 @@ fn client_user_data() {
     server.display.create_global::<wl_output::WlOutput, _>(1, {
         let clients = clients.clone();
         move |newo, _| {
-            let output = newo.implement(|_, _| {}, None::<fn(_)>, ());
+            let output = newo.implement_dummy();
             let client = output.client().unwrap();
             let ret = client.data_map().insert_if_missing(|| HasOutput);
             // the data should not be already here
@@ -33,7 +33,7 @@ fn client_user_data() {
         .create_global::<wl_compositor::WlCompositor, _>(1, {
             let clients = clients.clone();
             move |newo, _| {
-                let compositor = newo.implement(|_, _| {}, None::<fn(_)>, ());
+                let compositor = newo.implement_dummy();
                 let client = compositor.client().unwrap();
                 let ret = client.data_map().insert_if_missing(|| HasCompositor);
                 // the data should not be already here

--- a/tests/server_clients.rs
+++ b/tests/server_clients.rs
@@ -49,7 +49,7 @@ fn client_user_data() {
 
     // Instantiate the globals
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();
@@ -63,7 +63,7 @@ fn client_user_data() {
     }
 
     manager
-        .instantiate_auto::<ClientCompositor, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<ClientCompositor, _>(|newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();

--- a/tests/server_created_object.rs
+++ b/tests/server_created_object.rs
@@ -4,14 +4,23 @@ use helpers::{roundtrip, wayc, ways, TestClient, TestServer};
 
 use std::sync::{Arc, Mutex};
 
-use ways::protocol::wl_data_device::Event as SDDEvt;
-use ways::protocol::wl_data_device_manager::{Request as SDDMReq, WlDataDeviceManager as ServerDDMgr};
+use ways::protocol::wl_data_device::{Event as SDDEvt, WlDataDevice as ServerDD};
+use ways::protocol::wl_data_device_manager::{
+    Request as SDDMReq, RequestHandler as ServerDDMHandler, WlDataDeviceManager as ServerDDMgr,
+};
 use ways::protocol::wl_data_offer::WlDataOffer as ServerDO;
+use ways::protocol::wl_data_source::WlDataSource as ServerDS;
 use ways::protocol::wl_seat::WlSeat as ServerSeat;
+use ways::{NewResource, Resource};
 
-use wayc::protocol::wl_data_device::Event as CDDEvt;
+use wayc::protocol::wl_data_device::{
+    Event as CDDEvt, EventHandler as ClientDDHandler, WlDataDevice as ClientDD,
+};
 use wayc::protocol::wl_data_device_manager::{RequestsTrait, WlDataDeviceManager as ClientDDMgr};
+use wayc::protocol::wl_data_offer::WlDataOffer as ClientDO;
 use wayc::protocol::wl_seat::WlSeat as ClientSeat;
+use wayc::protocol::wl_surface::WlSurface as ClientSurface;
+use wayc::{NewProxy, Proxy};
 
 #[test]
 fn data_offer() {
@@ -73,6 +82,112 @@ fn data_offer() {
                 },
                 (),
             )
+        })
+        .unwrap();
+
+    roundtrip(&mut client, &mut server).unwrap();
+
+    assert!(*received.lock().unwrap());
+}
+
+#[test]
+fn data_offer_trait_impls() {
+    let mut server = TestServer::new();
+    server.display.create_global::<ServerSeat, _>(1, |_, _| {});
+
+    struct ServerHandler;
+    impl ServerDDMHandler for ServerHandler {
+        fn get_data_device(
+            &mut self,
+            _resource: Resource<ServerDDMgr>,
+            id: NewResource<ServerDD>,
+            _seat: Resource<ServerSeat>,
+        ) {
+            let ddevice = id.implement_dummy();
+            // create a data offer and send it
+            let offer = ddevice
+                .client()
+                .unwrap()
+                .create_resource::<ServerDO>(ddevice.version())
+                .unwrap()
+                .implement_dummy();
+            // this must be the first server-side ID
+            assert_eq!(offer.id(), 0xFF000000);
+            ddevice.send(SDDEvt::DataOffer { id: offer })
+        }
+
+        fn create_data_source(&mut self, _resource: Resource<ServerDDMgr>, _id: NewResource<ServerDS>) {
+            unimplemented!()
+        }
+    }
+
+    server
+        .display
+        .create_global::<ServerDDMgr, _>(3, |new_resource, version| {
+            assert!(version == 3);
+            new_resource.implement(ServerHandler, None::<fn(_)>, ());
+        });
+
+    let mut client = TestClient::new(&server.socket_name);
+    let manager = wayc::GlobalManager::new(&client.display);
+
+    roundtrip(&mut client, &mut server).unwrap();
+
+    let seat = manager
+        .instantiate_auto::<ClientSeat, _>(|newseat| newseat.implement_dummy())
+        .unwrap();
+    let ddmgr = manager
+        .instantiate_auto::<ClientDDMgr, _>(|newddmgr| newddmgr.implement_dummy())
+        .unwrap();
+
+    let received = Arc::new(Mutex::new(false));
+    let received2 = received.clone();
+
+    struct ClientHandler {
+        received: Arc<Mutex<bool>>,
+    }
+
+    impl ClientDDHandler for ClientHandler {
+        fn data_offer(&mut self, _proxy: Proxy<ClientDD>, id: NewProxy<ClientDO>) {
+            let doffer = id.implement_dummy();
+            assert!(doffer.version() == 3);
+            // this must be the first server-side ID
+            assert_eq!(doffer.id(), 0xFF000000);
+            *self.received.lock().unwrap() = true;
+        }
+
+        fn enter(
+            &mut self,
+            _proxy: Proxy<ClientDD>,
+            _serial: u32,
+            _surface: Proxy<ClientSurface>,
+            _x: f64,
+            _y: f64,
+            _id: Option<Proxy<ClientDO>>,
+        ) {
+            unimplemented!()
+        }
+
+        fn leave(&mut self, _proxy: Proxy<ClientDD>) {
+            unimplemented!()
+        }
+
+        fn motion(&mut self, _proxy: Proxy<ClientDD>, _time: u32, _x: f64, _y: f64) {
+            unimplemented!()
+        }
+
+        fn drop(&mut self, _proxy: Proxy<ClientDD>) {
+            unimplemented!()
+        }
+
+        fn selection(&mut self, _proxy: Proxy<ClientDD>, _id: Option<Proxy<ClientDO>>) {
+            unimplemented!()
+        }
+    }
+
+    ddmgr
+        .get_data_device(&seat, move |newdd| {
+            newdd.implement(ClientHandler { received: received2 }, ())
         })
         .unwrap();
 

--- a/tests/server_created_object.rs
+++ b/tests/server_created_object.rs
@@ -21,17 +21,17 @@ fn data_offer() {
         .display
         .create_global::<ServerDDMgr, _>(3, |new_resource, version| {
             assert!(version == 3);
-            new_resource.implement(
+            new_resource.implement_closure(
                 |request, _| match request {
                     SDDMReq::GetDataDevice { id, .. } => {
-                        let ddevice = id.implement(|_, _| {}, None::<fn(_)>, ());
+                        let ddevice = id.implement_dummy();
                         // create a data offer and send it
                         let offer = ddevice
                             .client()
                             .unwrap()
                             .create_resource::<ServerDO>(ddevice.version())
                             .unwrap()
-                            .implement(|_, _| {}, None::<fn(_)>, ());
+                            .implement_dummy();
                         // this must be the first server-side ID
                         assert_eq!(offer.id(), 0xFF000000);
                         ddevice.send(SDDEvt::DataOffer { id: offer })

--- a/tests/server_created_object.rs
+++ b/tests/server_created_object.rs
@@ -49,10 +49,10 @@ fn data_offer() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let seat = manager
-        .instantiate_auto::<ClientSeat, _>(|newseat| newseat.implement(|_, _| {}, ()))
+        .instantiate_auto::<ClientSeat, _>(|newseat| newseat.implement_dummy())
         .unwrap();
     let ddmgr = manager
-        .instantiate_auto::<ClientDDMgr, _>(|newddmgr| newddmgr.implement(|_, _| {}, ()))
+        .instantiate_auto::<ClientDDMgr, _>(|newddmgr| newddmgr.implement_dummy())
         .unwrap();
 
     let received = Arc::new(Mutex::new(false));
@@ -60,10 +60,10 @@ fn data_offer() {
 
     ddmgr
         .get_data_device(&seat, move |newdd| {
-            newdd.implement(
+            newdd.implement_closure(
                 move |evt, _| match evt {
                     CDDEvt::DataOffer { id } => {
-                        let doffer = id.implement(|_, _| {}, ());
+                        let doffer = id.implement_dummy();
                         assert!(doffer.version() == 3);
                         // this must be the first server-side ID
                         assert_eq!(doffer.id(), 0xFF000000);

--- a/tests/server_global_filter.rs
+++ b/tests/server_global_filter.rs
@@ -103,10 +103,10 @@ fn global_filter_try_force() {
 
     let registry2 = client2
         .display
-        .get_registry(|newp| newp.implement(|_, _| {}, ()))
+        .get_registry(|newp| newp.implement_dummy())
         .unwrap();
     registry2
-        .bind::<WlOutput, _>(1, 1, |newp| newp.implement(|_, _| {}, ()))
+        .bind::<WlOutput, _>(1, 1, |newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client2, &mut server).unwrap();
@@ -115,10 +115,10 @@ fn global_filter_try_force() {
 
     let registry = client
         .display
-        .get_registry(|newp| newp.implement(|_, _| {}, ()))
+        .get_registry(|newp| newp.implement_dummy())
         .unwrap();
     registry
-        .bind::<WlOutput, _>(1, 1, |newp| newp.implement(|_, _| {}, ()))
+        .bind::<WlOutput, _>(1, 1, |newp| newp.implement_dummy())
         .unwrap();
 
     assert!(roundtrip(&mut client, &mut server).is_err());

--- a/tests/server_resources.rs
+++ b/tests/server_resources.rs
@@ -18,10 +18,7 @@ fn resource_equals() {
     server
         .display
         .create_global::<wl_output::WlOutput, _>(1, move |newo, _| {
-            outputs2
-                .lock()
-                .unwrap()
-                .push(newo.implement(|_, _| {}, None::<fn(_)>, ()));
+            outputs2.lock().unwrap().push(newo.implement_dummy());
         });
 
     let mut client = TestClient::new(&server.socket_name);
@@ -60,7 +57,7 @@ fn resource_user_data() {
         .display
         .create_global::<wl_output::WlOutput, _>(1, move |newo, _| {
             let mut guard = outputs2.lock().unwrap();
-            let output = newo.implement(|_, _| {}, None::<fn(_)>, 1000 + guard.len());
+            let output = newo.implement_closure(|_, _| {}, None::<fn(_)>, 1000 + guard.len());
             guard.push(output);
         });
 
@@ -138,10 +135,7 @@ fn dead_resources() {
     server
         .display
         .create_global::<wl_output::WlOutput, _>(3, move |newo, _| {
-            outputs2
-                .lock()
-                .unwrap()
-                .push(newo.implement(|_, _| {}, None::<fn(_)>, ()));
+            outputs2.lock().unwrap().push(newo.implement_dummy());
         });
 
     let mut client = TestClient::new(&server.socket_name);

--- a/tests/server_resources.rs
+++ b/tests/server_resources.rs
@@ -31,10 +31,10 @@ fn resource_equals() {
 
     // create two outputs
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement_dummy())
         .unwrap();
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();
@@ -71,10 +71,10 @@ fn resource_user_data() {
 
     // create two outputs
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement_dummy())
         .unwrap();
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();
@@ -109,7 +109,7 @@ fn resource_user_data_wrong_thread() {
     roundtrip(&mut client, &mut server).unwrap();
 
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();
@@ -150,10 +150,10 @@ fn dead_resources() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let client_output1 = manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement_dummy())
         .unwrap();
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement(|_, _| {}, ()))
+        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -76,7 +76,7 @@ impl GlobalManager {
 
         let registry = display
             .get_registry(|registry| {
-                registry.implement(
+                registry.implement_closure(
                     move |msg, _proxy| {
                         let mut inner = inner.lock().unwrap();
                         match msg {
@@ -122,7 +122,7 @@ impl GlobalManager {
 
         let registry = display
             .get_registry(|registry| {
-                registry.implement(
+                registry.implement_closure(
                     move |msg, proxy| {
                         let mut inner = inner.lock().unwrap();
                         let inner = &mut *inner;
@@ -140,26 +140,26 @@ impl GlobalManager {
                                         version: version,
                                     },
                                     proxy,
-                                );
+                                    );
                             }
                             wl_registry::Event::GlobalRemove { name } => {
                                 if let Some((i, _)) =
                                     inner.list.iter().enumerate().find(|&(_, &(n, _, _))| n == name)
-                                {
-                                    let (id, interface, _) = inner.list.swap_remove(i);
-                                    (inner.callback)(
-                                        GlobalEvent::Removed {
-                                            id: id,
-                                            interface: interface,
-                                        },
-                                        proxy,
-                                    );
-                                } else {
-                                    panic!(
-                                    "Wayland protocol error: the server removed non-existing global \"{}\".",
-                                    name
-                                );
-                                }
+                                    {
+                                        let (id, interface, _) = inner.list.swap_remove(i);
+                                        (inner.callback)(
+                                            GlobalEvent::Removed {
+                                                id: id,
+                                                interface: interface,
+                                            },
+                                            proxy,
+                                            );
+                                    } else {
+                                        panic!(
+                                            "Wayland protocol error: the server removed non-existing global \"{}\".",
+                                            name
+                                        );
+                                    }
                             }
                         }
                     },

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -192,7 +192,7 @@ mod generated {
         pub(crate) use wayland_commons::wire::{Argument, ArgumentType, Message, MessageDesc};
         pub(crate) use wayland_commons::{AnonymousObject, Interface, MessageGroup};
         pub(crate) use wayland_sys as sys;
-        pub(crate) use {NewProxy, Proxy, ProxyMap};
+        pub(crate) use {HandledBy, NewProxy, Proxy, ProxyMap};
         include!(concat!(env!("OUT_DIR"), "/wayland_c_api.rs"));
     }
     #[cfg(not(feature = "native_lib"))]
@@ -200,7 +200,7 @@ mod generated {
         pub(crate) use wayland_commons::map::{Object, ObjectMetadata};
         pub(crate) use wayland_commons::wire::{Argument, ArgumentType, Message, MessageDesc};
         pub(crate) use wayland_commons::{AnonymousObject, Interface, MessageGroup};
-        pub(crate) use {NewProxy, Proxy, ProxyMap};
+        pub(crate) use {HandledBy, NewProxy, Proxy, ProxyMap};
         include!(concat!(env!("OUT_DIR"), "/wayland_rust_api.rs"));
     }
 }

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -57,8 +57,10 @@
 //! Failure to do so (by dropping the `NewProxy<I>` for example) can cause future fatal
 //! errors if the server tries to send an event to this object.
 //!
-//! An implementation is just an `FnMut(I::Event, Proxy<I>), where `I` is the interface of
-//! the considered object.
+//! An implementation is a struct implementing the `EventHandler` trait for the interface
+//! of the considered object. Alternatively, an `FnMut(I::Event, Proxy<I>)` closure can be
+//! used with the `implement_closure()` method, where `I` is the interface
+//! of the considered object.
 //!
 //! ## Event Queues
 //!

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -140,7 +140,7 @@ pub use display::{ConnectError, Display};
 pub use event_queue::{EventQueue, QueueToken, ReadEventsGuard};
 pub use globals::{GlobalError, GlobalEvent, GlobalImplementor, GlobalManager};
 pub use imp::ProxyMap;
-pub use proxy::{NewProxy, Proxy};
+pub use proxy::{HandledBy, NewProxy, Proxy};
 
 #[cfg(feature = "cursor")]
 pub mod cursor;

--- a/wayland-client/src/proxy.rs
+++ b/wayland-client/src/proxy.rs
@@ -359,3 +359,11 @@ impl<I: Interface + 'static> NewProxy<I> {
         }
     }
 }
+
+/// Provides a callback function to handle events of the implementing interface via `T`.
+///
+/// This trait is meant to be implemented automatically by code generated with `wayland-scanner`.
+pub trait HandledBy<T>: Interface + Sized {
+    /// Handles an event.
+    fn handle(handler: &mut T, event: Self::Event, proxy: Proxy<Self>);
+}

--- a/wayland-protocols/src/protocol_macro.rs
+++ b/wayland-protocols/src/protocol_macro.rs
@@ -19,7 +19,7 @@ macro_rules! wayland_protocol(
             #[cfg(feature = "client")]
             pub mod client {
                 //! Client-side API of this protocol
-                pub(crate) use wayland_client::{NewProxy, Proxy, ProxyMap};
+                pub(crate) use wayland_client::{NewProxy, Proxy, ProxyMap, HandledBy};
                 pub(crate) use wayland_commons::map::{Object, ObjectMetadata};
                 pub(crate) use wayland_commons::{AnonymousObject, Interface, MessageGroup};
                 pub(crate) use wayland_commons::wire::{Argument, MessageDesc, ArgumentType, Message};
@@ -68,7 +68,7 @@ macro_rules! wayland_protocol(
             #[cfg(feature = "client")]
             pub mod client {
                 //! Client-side API of this protocol
-                pub(crate) use wayland_client::{NewProxy, Proxy, ProxyMap};
+                pub(crate) use wayland_client::{NewProxy, Proxy, ProxyMap, HandledBy};
                 pub(crate) use wayland_commons::map::{Object, ObjectMetadata};
                 pub(crate) use wayland_commons::{AnonymousObject, Interface, MessageGroup};
                 pub(crate) use wayland_commons::wire::{Argument, MessageDesc, ArgumentType, Message};

--- a/wayland-protocols/src/protocol_macro.rs
+++ b/wayland-protocols/src/protocol_macro.rs
@@ -33,7 +33,7 @@ macro_rules! wayland_protocol(
             #[cfg(feature = "server")]
             pub mod server {
                 //! Server-side API of this protocol
-                pub(crate) use wayland_server::{NewResource, Resource, ResourceMap};
+                pub(crate) use wayland_server::{NewResource, Resource, ResourceMap, HandledBy};
                 pub(crate) use wayland_commons::map::{Object, ObjectMetadata};
                 pub(crate) use wayland_commons::{AnonymousObject, Interface, MessageGroup};
                 pub(crate) use wayland_commons::wire::{Argument, MessageDesc, ArgumentType, Message};
@@ -83,7 +83,7 @@ macro_rules! wayland_protocol(
             #[cfg(feature = "server")]
             pub mod server {
                 //! Server-side API of this protocol
-                pub(crate) use wayland_server::{NewResource, Resource, ResourceMap};
+                pub(crate) use wayland_server::{NewResource, Resource, ResourceMap, HandledBy};
                 pub(crate) use wayland_commons::map::{Object, ObjectMetadata};
                 pub(crate) use wayland_commons::{AnonymousObject, Interface, MessageGroup};
                 pub(crate) use wayland_commons::wire::{Argument, MessageDesc, ArgumentType, Message};

--- a/wayland-scanner/src/c_code_gen.rs
+++ b/wayland-scanner/src/c_code_gen.rs
@@ -41,6 +41,7 @@ pub(crate) fn generate_protocol_client(protocol: Protocol) -> TokenStream {
         );
 
         let client_methods = gen_client_methods(&iface_name, &iface.requests);
+        let event_handler_trait = gen_event_handler_trait(&iface_name, &iface.events);
         let sinces = gen_since_constants(&iface.requests, &iface.events);
 
         quote! {
@@ -48,7 +49,7 @@ pub(crate) fn generate_protocol_client(protocol: Protocol) -> TokenStream {
             pub mod #mod_name {
                 use super::{
                     Proxy, NewProxy, AnonymousObject, Interface, MessageGroup, MessageDesc, ArgumentType,
-                    Object, Message, Argument, ObjectMetadata
+                    Object, Message, Argument, ObjectMetadata, HandledBy
                 };
                 use super::sys::common::{wl_argument, wl_interface, wl_array};
                 use super::sys::client::*;
@@ -58,6 +59,7 @@ pub(crate) fn generate_protocol_client(protocol: Protocol) -> TokenStream {
                 #events
                 #interface
                 #client_methods
+                #event_handler_trait
                 #sinces
             }
         }

--- a/wayland-scanner/src/rust_code_gen.rs
+++ b/wayland-scanner/src/rust_code_gen.rs
@@ -33,6 +33,7 @@ pub(crate) fn generate_protocol_client(protocol: Protocol) -> TokenStream {
             None,
         );
         let client_methods = gen_client_methods(&iface_name, &iface.requests);
+        let event_handler_trait = gen_event_handler_trait(&iface_name, &iface.events);
         let sinces = gen_since_constants(&iface.requests, &iface.events);
 
         quote! {
@@ -40,7 +41,7 @@ pub(crate) fn generate_protocol_client(protocol: Protocol) -> TokenStream {
             pub mod #mod_name {
                 use super::{
                     Proxy, NewProxy, AnonymousObject, Interface, MessageGroup, MessageDesc, ArgumentType, Object,
-                    Message, Argument, ObjectMetadata,
+                    Message, Argument, ObjectMetadata, HandledBy
                 };
 
                 #(#enums)*
@@ -48,6 +49,7 @@ pub(crate) fn generate_protocol_client(protocol: Protocol) -> TokenStream {
                 #events
                 #interface
                 #client_methods
+                #event_handler_trait
                 #sinces
             }
         }

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -139,7 +139,7 @@ mod generated {
         pub(crate) use wayland_commons::wire::{Argument, ArgumentType, Message, MessageDesc};
         pub(crate) use wayland_commons::{AnonymousObject, Interface, MessageGroup};
         pub(crate) use wayland_sys as sys;
-        pub(crate) use {NewResource, Resource, ResourceMap};
+        pub(crate) use {HandledBy, NewResource, Resource, ResourceMap};
         include!(concat!(env!("OUT_DIR"), "/wayland_c_api.rs"));
     }
     #[cfg(not(feature = "native_lib"))]
@@ -147,7 +147,7 @@ mod generated {
         pub(crate) use wayland_commons::map::{Object, ObjectMetadata};
         pub(crate) use wayland_commons::wire::{Argument, ArgumentType, Message, MessageDesc};
         pub(crate) use wayland_commons::{AnonymousObject, Interface, MessageGroup};
-        pub(crate) use {NewResource, Resource, ResourceMap};
+        pub(crate) use {HandledBy, NewResource, Resource, ResourceMap};
         include!(concat!(env!("OUT_DIR"), "/wayland_rust_api.rs"));
     }
 }

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -48,7 +48,9 @@
 //! Failure to do so (by dropping the `NewResource<I>` for example) can cause future fatal
 //! protocol errors if the client tries to send a request to this object.
 //!
-//! An implementation is just an `FnMut(I::Request, Resource<I>)` where `I` is the interface
+//! An implementation is a struct implementing the `RequestHandler` trait for the interface
+//! of the considered object. Alternatively, an `FnMut(I::Request, Resource<I>)` closure can be
+//! used with the `implement_closure()` method, where `I` is the interface
 //! of the considered object.
 //!
 //! The `Resource<I>` passed to your implementation is guaranteed to be alive (as it just received

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -90,7 +90,7 @@ mod resource;
 pub use client::Client;
 pub use display::{Display, DisplayToken};
 pub use globals::Global;
-pub use resource::{NewResource, Resource};
+pub use resource::{HandledBy, NewResource, Resource};
 
 pub use wayland_commons::utils::UserDataMap;
 pub use wayland_commons::{AnonymousObject, Interface, MessageGroup, NoMessage};

--- a/wayland-server/src/native_lib/display.rs
+++ b/wayland-server/src/native_lib/display.rs
@@ -131,7 +131,7 @@ impl DisplayInner {
                 return Err(IoError::new(
                     ErrorKind::InvalidInput,
                     "nulls are not allowed in socket name",
-                ))
+                ));
             }
             None => None,
         };

--- a/wayland-server/src/resource.rs
+++ b/wayland-server/src/resource.rs
@@ -286,3 +286,11 @@ impl<I: Interface> Clone for Resource<I> {
         }
     }
 }
+
+/// Provides a callback function to handle requests of the implementing interface via `T`.
+///
+/// This trait is meant to be implemented automatically by code generated with `wayland-scanner`.
+pub trait HandledBy<T>: Interface + Sized {
+    /// Handles an event.
+    fn handle(handler: &mut T, request: Self::Request, resource: Resource<Self>);
+}

--- a/wayland-server/src/rust_imp/clients.rs
+++ b/wayland-server/src/rust_imp/clients.rs
@@ -560,7 +560,7 @@ impl super::Dispatcher for DisplayDispatcher {
             0 => {
                 if let Some(&Argument::NewId(new_id)) = msg.args.first() {
                     if let Some(cb) = map.get_new::<wl_callback::WlCallback>(new_id) {
-                        let cb = cb.implement(|r, _| match r {}, None::<fn(_)>, ());
+                        let cb = cb.implement_dummy();
                         // TODO: send a more meaningful serial ?
                         cb.send(wl_callback::Event::Done { callback_data: 0 });
                     } else {


### PR DESCRIPTION
As discussed in #228 (PoC v2 + `implement_closure()` + `implement_dummy()`).

Implemented client- and server-side.

Additionally I changed the `dynamic_globals` example to use trait-based event handling for `wl_output` as I thought it was a good place where the closure implementation was rather complex with lots of enum cases.