### PR TITLE
client+server: make non-send impls the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 - [client & server] Introduce `NewProxy/NewRequest::implement_closure()` which behaves
   like the previous `NewProxy/NewRequest::implement()` and
   `NewProxy/NewRequest::implement_dummy()` which adds an empty implementation.
+- **Breaking** [client/server] `implement()` method will now runtime-track which thread it
+  can be called on, making it safe to use non-`Send` implementation. `implement_nonsend()`
+  is removed as being non-`Send` is now the default. `implement_threadsafe()` is added
+  for when a threadsafe impl is needed.
+- **Breaking** [server] When the `native_lib` cargo feature is active, none of the types
+  of the server crate are threadsafe, as the underlying C lib actually never supported it.
+  The rust implementation remains threadsafe.
 
 ## 0.21.11 -- 2019-01-19
 

--- a/tests/client_dispatch.rs
+++ b/tests/client_dispatch.rs
@@ -76,10 +76,9 @@ fn client_dispatch() {
     // do a manual roundtrip
     let done = Rc::new(Cell::new(false));
     let done2 = done.clone();
-    let token = client.event_queue.get_token();
     client
         .display
-        .sync(move |newcb| unsafe { newcb.implement_nonsend(move |_, _| done2.set(true), (), &token) })
+        .sync(move |newcb| newcb.implement_closure(move |_, _| done2.set(true), ()))
         .unwrap();
     while !done.get() {
         client.event_queue.dispatch().unwrap();

--- a/tests/send_sync.rs
+++ b/tests/send_sync.rs
@@ -9,6 +9,7 @@ fn send_sync_client() {
     ensure_both::<wayc::Proxy<::wayc::protocol::wl_callback::WlCallback>>();
 }
 
+#[cfg(not(feature = "native_lib"))]
 #[test]
 fn send_sync_server() {
     ensure_both::<ways::Resource<::ways::protocol::wl_callback::WlCallback>>();

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -76,7 +76,7 @@ impl GlobalManager {
 
         let registry = display
             .get_registry(|registry| {
-                registry.implement_closure(
+                registry.implement_closure_threadsafe(
                     move |msg, _proxy| {
                         let mut inner = inner.lock().unwrap();
                         match msg {
@@ -122,7 +122,7 @@ impl GlobalManager {
 
         let registry = display
             .get_registry(|registry| {
-                registry.implement_closure(
+                registry.implement_closure_threadsafe(
                     move |msg, proxy| {
                         let mut inner = inner.lock().unwrap();
                         let inner = &mut *inner;

--- a/wayland-server/src/display.rs
+++ b/wayland-server/src/display.rs
@@ -4,7 +4,7 @@ use std::ffi::{OsStr, OsString};
 use std::io::{Error as IoError, ErrorKind, Result as IoResult};
 use std::os::unix::io::{IntoRawFd, RawFd};
 use std::path::PathBuf;
-use std::rc::{Rc, Weak};
+use std::rc::Rc;
 
 #[cfg(feature = "native_lib")]
 use wayland_sys::server::wl_display;
@@ -24,22 +24,6 @@ pub struct Display {
     inner: Rc<RefCell<DisplayInner>>,
 }
 
-/// A token that is required for providing non-Send implementations to resources
-///
-/// This is used to ensure you are indeed on the right thread.
-///
-/// See `NewResource::implement_nonsend()`.
-#[derive(Clone)]
-pub struct DisplayToken {
-    inner: Weak<RefCell<DisplayInner>>,
-}
-
-impl DisplayToken {
-    pub(crate) fn upgrade(&self) -> Option<Rc<RefCell<DisplayInner>>> {
-        Weak::upgrade(&self.inner)
-    }
-}
-
 impl Display {
     /// Create a new display
     ///
@@ -51,15 +35,6 @@ impl Display {
     pub fn new<Data: 'static>(handle: LoopHandle<Data>) -> Display {
         Display {
             inner: DisplayInner::new(handle),
-        }
-    }
-
-    /// Get a `DisplayToken` for make non-send implementations
-    ///
-    /// This is required by `NewResource::implement_nonsend`.
-    pub fn get_token(&self) -> DisplayToken {
-        DisplayToken {
-            inner: Rc::downgrade(&self.inner),
         }
     }
 

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -90,7 +90,7 @@ mod globals;
 mod resource;
 
 pub use client::Client;
-pub use display::{Display, DisplayToken};
+pub use display::Display;
 pub use globals::Global;
 pub use resource::{HandledBy, NewResource, Resource};
 

--- a/wayland-server/src/native_lib/resource.rs
+++ b/wayland-server/src/native_lib/resource.rs
@@ -32,9 +32,6 @@ pub(crate) struct ResourceInner {
     _hack: (bool, bool),
 }
 
-unsafe impl Send for ResourceInner {}
-unsafe impl Sync for ResourceInner {}
-
 impl ResourceInner {
     pub(crate) fn send<I: Interface>(&self, msg: I::Event) {
         if let Some(ref internal) = self.internal {
@@ -203,14 +200,6 @@ pub(crate) struct NewResourceInner {
 }
 
 impl NewResourceInner {
-    pub(crate) fn on_display(&self, display: &super::DisplayInner) -> bool {
-        unsafe {
-            let client_ptr = ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_get_client, self.ptr);
-            let display_ptr = ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_client_get_display, client_ptr);
-            display_ptr == display.ptr
-        }
-    }
-
     pub(crate) unsafe fn implement<I: Interface, F, Dest>(
         self,
         implementation: F,

--- a/wayland-server/src/rust_imp/resources.rs
+++ b/wayland-server/src/rust_imp/resources.rs
@@ -160,8 +160,8 @@ impl NewResourceInner {
         }
     }
 
-    pub(crate) fn on_display(&self, inner: &super::DisplayInner) -> bool {
-        inner.clients_mgr.borrow().has_client(&self.client)
+    pub(crate) fn is_loop_on_current_thread(&self) -> bool {
+        self.client.loop_thread == ::std::thread::current().id()
     }
 
     pub(crate) unsafe fn implement<I: Interface, F, Dest>(


### PR DESCRIPTION
The implementation methods are now `.implement()` which allows
non-`Send` implementations and panics if called from the wrong
thread, and `.implement_threadsafe()` which accepts only `Send`
implementations and can be called from any thread.

This is accompanied by removing any `Send` / `Sync` implementations
server-side when the `native_lib` feature is activated, as the
C library actually is never threadsafe (contrarily to the client
one).