### PR TITLE
Refactor to remove RequestsTrait and much of Proxy<_> wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 - [scanner] Generate `EventHandler` and `RequestHandler` traits for trait-based event
   and request handling (as opposed to manually matching on enums).
-- [client & server] **Breaking**: Change `NewProxy/NewRequest::implement()` to accept
+- **Breaking** [client/server] Change `NewProxy/NewRequest::implement()` to accept
   a handler struct which implements the corresponding `EventHandler/RequestHandler` trait.
-- [client & server] Introduce `NewProxy/NewRequest::implement_closure()` which behaves
+- [client/server] Introduce `NewProxy/NewRequest::implement_closure()` which behaves
   like the previous `NewProxy/NewRequest::implement()` and
   `NewProxy/NewRequest::implement_dummy()` which adds an empty implementation.
 - **Breaking** [client/server] `implement()` method will now runtime-track which thread it
@@ -16,6 +16,19 @@
 - **Breaking** [server] When the `native_lib` cargo feature is active, none of the types
   of the server crate are threadsafe, as the underlying C lib actually never supported it.
   The rust implementation remains threadsafe.
+- **Breaking** [client/server] `Proxy<I>` and `Resource<I>` are now wrapped in their
+  corresponding `I` objects. All `RequestsTrait` traits were removed and methods for
+  sending requests and events are now part of the `I` objects themselves. This means that
+  it is no longer needed to import all necessary `RequestsTrait` traits into scope and
+  deal with their name clashes. This also means that a lot of `Proxy<I>` and `Resource<I>`
+  types were replaced with just `I`. To convert between `Proxy/Resource<I>` and `I`,
+  `From` implementations are provided (use `.into()`), as well as an
+  `AsRef<Proxy/Resource<I>>` implementation for `I`.
+- **Breaking** [client/server/commons] `AnonymousObject` was moved out of
+  `wayland-commons` into `wayland-client` and `wayland-server`. This is to accommodate the
+  design change above.
+- [scanner] Fixed a number of cases where invalid Rust code would be generated if variable
+  or method names in the protocol were Rust keywords.
 
 ## 0.21.11 -- 2019-01-19
 

--- a/tests/attach_to_surface.rs
+++ b/tests/attach_to_surface.rs
@@ -12,9 +12,8 @@ use helpers::{roundtrip, wayc, ways, TestClient, TestServer};
 use wayc::protocol::wl_shm::Format;
 
 use ways::protocol::wl_buffer::WlBuffer as ServerBuffer;
-use ways::Resource;
 
-fn insert_compositor(server: &mut TestServer) -> Arc<Mutex<Option<Option<Resource<ServerBuffer>>>>> {
+fn insert_compositor(server: &mut TestServer) -> Arc<Mutex<Option<Option<ServerBuffer>>>> {
     use ways::protocol::{wl_compositor, wl_surface};
 
     let buffer_found = Arc::new(Mutex::new(None));
@@ -55,7 +54,7 @@ fn insert_compositor(server: &mut TestServer) -> Arc<Mutex<Option<Option<Resourc
     buffer_found2
 }
 
-fn insert_shm(server: &mut TestServer) -> Arc<Mutex<Option<(RawFd, Option<Resource<ServerBuffer>>)>>> {
+fn insert_shm(server: &mut TestServer) -> Arc<Mutex<Option<(RawFd, Option<ServerBuffer>)>>> {
     use ways::protocol::{wl_shm, wl_shm_pool};
 
     let buffer = Arc::new(Mutex::new(None));

--- a/tests/attach_to_surface.rs
+++ b/tests/attach_to_surface.rs
@@ -9,10 +9,7 @@ mod helpers;
 
 use helpers::{roundtrip, wayc, ways, TestClient, TestServer};
 
-use wayc::protocol::wl_compositor::RequestsTrait as CompositorRequests;
-use wayc::protocol::wl_shm::{Format, RequestsTrait as ShmRequests};
-use wayc::protocol::wl_shm_pool::RequestsTrait as PoolRequests;
-use wayc::protocol::wl_surface::RequestsTrait as SurfaceRequests;
+use wayc::protocol::wl_shm::Format;
 
 use ways::protocol::wl_buffer::WlBuffer as ServerBuffer;
 use ways::Resource;

--- a/tests/client_dispatch.rs
+++ b/tests/client_dispatch.rs
@@ -1,14 +1,12 @@
 mod helpers;
 
-use helpers::{wayc, ways, TestClient};
+use helpers::{ways, TestClient};
 
 use std::cell::Cell;
 use std::ffi::OsStr;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-
-use self::wayc::protocol::wl_display::RequestsTrait;
 
 #[test]
 fn client_sync_roundtrip() {

--- a/tests/client_proxies.rs
+++ b/tests/client_proxies.rs
@@ -49,14 +49,14 @@ fn proxy_user_data() {
             newp.implement_closure(|_, _| {}, 0xDEADBEEFusize)
         })
         .unwrap();
-    let compositor1 = compositor1.as_proxy();
+    let compositor1 = compositor1.as_ref();
 
     let compositor2 = manager
         .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| {
             newp.implement_closure(|_, _| {}, 0xBADC0FFEusize)
         })
         .unwrap();
-    let compositor2 = compositor2.as_proxy();
+    let compositor2 = compositor2.as_ref();
 
     let compositor3 = compositor1.clone();
 
@@ -103,9 +103,8 @@ fn proxy_wrapper() {
 
     let mut event_queue_2 = client.display.create_event_queue();
     let manager = wayc::GlobalManager::new(
-        &client
-            .display
-            .as_proxy()
+        &(*client.display)
+            .as_ref()
             .make_wrapper(&event_queue_2.get_token())
             .unwrap(),
     );
@@ -165,7 +164,7 @@ fn proxy_implement_wrapper_threaded() {
 
     ::std::thread::spawn(move || {
         let evq2 = display2.create_event_queue();
-        let compositor_wrapper = compositor.as_proxy().make_wrapper(&evq2.get_token()).unwrap();
+        let compositor_wrapper = compositor.as_ref().make_wrapper(&evq2.get_token()).unwrap();
         compositor_wrapper
             .create_surface(|newp| newp.implement_closure(|_, _| {}, ())) // should not panic
             .unwrap();
@@ -217,14 +216,14 @@ fn dead_proxies() {
     let output2 = output.clone();
 
     assert!(output == output2);
-    assert!(output.as_proxy().is_alive());
-    assert!(output2.as_proxy().is_alive());
+    assert!(output.as_ref().is_alive());
+    assert!(output2.as_ref().is_alive());
 
     // kill the output
     output.release();
 
     // dead proxies are never equal
     assert!(output != output2);
-    assert!(!output.as_proxy().is_alive());
-    assert!(!output2.as_proxy().is_alive());
+    assert!(!output.as_ref().is_alive());
+    assert!(!output2.as_ref().is_alive());
 }

--- a/tests/destructors.rs
+++ b/tests/destructors.rs
@@ -4,7 +4,7 @@ use helpers::{roundtrip, wayc, ways, TestClient, TestServer};
 
 use ways::protocol::wl_output::WlOutput as ServerOutput;
 
-use wayc::protocol::wl_output::{RequestsTrait, WlOutput};
+use wayc::protocol::wl_output::WlOutput;
 
 use std::sync::{Arc, Mutex};
 

--- a/tests/destructors.rs
+++ b/tests/destructors.rs
@@ -94,7 +94,7 @@ fn client_destructor_cleanup() {
         .create_global::<ServerOutput, _>(3, move |newo, _| {
             let destructor_called_resource = destructor_called_global.clone();
             let output = newo.implement_dummy();
-            let client = output.client().unwrap();
+            let client = output.as_ref().client().unwrap();
             client.add_destructor(move |_| {
                 *destructor_called_resource.lock().unwrap() = true;
             });

--- a/tests/globals.rs
+++ b/tests/globals.rs
@@ -125,11 +125,11 @@ fn auto_instantiate() {
     let compositor = manager
         .instantiate_auto::<WlCompositor, _>(|newp| newp.implement_dummy())
         .unwrap();
-    assert!(compositor.as_proxy().version() == 4);
+    assert!(compositor.as_ref().version() == 4);
     let shell = manager
         .instantiate_auto::<WlShell, _>(|newp| newp.implement_dummy())
         .unwrap();
-    assert!(shell.as_proxy().version() == 1);
+    assert!(shell.as_ref().version() == 1);
 
     assert!(
         manager.instantiate_exact::<WlCompositor, _>(5, |newp| newp.implement_dummy())

--- a/tests/globals.rs
+++ b/tests/globals.rs
@@ -125,11 +125,11 @@ fn auto_instantiate() {
     let compositor = manager
         .instantiate_auto::<WlCompositor, _>(|newp| newp.implement_dummy())
         .unwrap();
-    assert!(compositor.version() == 4);
+    assert!(compositor.as_proxy().version() == 4);
     let shell = manager
         .instantiate_auto::<WlShell, _>(|newp| newp.implement_dummy())
         .unwrap();
-    assert!(shell.version() == 1);
+    assert!(shell.as_proxy().version() == 1);
 
     assert!(
         manager.instantiate_exact::<WlCompositor, _>(5, |newp| newp.implement_dummy())
@@ -154,9 +154,7 @@ fn wrong_version_create_global() {
 #[test]
 #[cfg_attr(feature = "native_lib", ignore)]
 fn wrong_global() {
-    use wayc::protocol::wl_display::RequestsTrait as DisplayRequests;
     use wayc::protocol::wl_output::WlOutput;
-    use wayc::protocol::wl_registry::RequestsTrait as RegistryRequests;
 
     let mut server = TestServer::new();
     server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
@@ -180,8 +178,6 @@ fn wrong_global() {
 #[test]
 fn wrong_global_version() {
     use wayc::protocol::wl_compositor::WlCompositor;
-    use wayc::protocol::wl_display::RequestsTrait as DisplayRequests;
-    use wayc::protocol::wl_registry::RequestsTrait as RegistryRequests;
 
     let mut server = TestServer::new();
     server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
@@ -204,8 +200,6 @@ fn wrong_global_version() {
 #[test]
 fn invalid_global_version() {
     use wayc::protocol::wl_compositor::WlCompositor;
-    use wayc::protocol::wl_display::RequestsTrait as DisplayRequests;
-    use wayc::protocol::wl_registry::RequestsTrait as RegistryRequests;
 
     let mut server = TestServer::new();
     server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
@@ -228,8 +222,6 @@ fn invalid_global_version() {
 #[test]
 fn wrong_global_id() {
     use wayc::protocol::wl_compositor::WlCompositor;
-    use wayc::protocol::wl_display::RequestsTrait as DisplayRequests;
-    use wayc::protocol::wl_registry::RequestsTrait as RegistryRequests;
 
     let mut server = TestServer::new();
     server.display.create_global::<ServerCompositor, _>(1, |_, _| {});

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -82,7 +82,6 @@ impl TestClient {
 }
 
 pub fn roundtrip(client: &mut TestClient, server: &mut TestServer) -> io::Result<()> {
-    use self::wayc::protocol::wl_display::RequestsTrait;
     // send to the server
     let done = Rc::new(Cell::new(false));
     let done2 = done.clone();

--- a/tests/scanner_assets/c_interfaces.rs
+++ b/tests/scanner_assets/c_interfaces.rs
@@ -1,7 +1,10 @@
 use std::os::raw::{c_char, c_void};
 use wayland_sys::common::*;
 const NULLPTR: *const c_void = 0 as *const c_void;
-static mut types_null: [*const wl_interface; 5] = [
+static mut types_null: [*const wl_interface; 8] = [
+    NULLPTR as *const wl_interface,
+    NULLPTR as *const wl_interface,
+    NULLPTR as *const wl_interface,
     NULLPTR as *const wl_interface,
     NULLPTR as *const wl_interface,
     NULLPTR as *const wl_interface,
@@ -41,7 +44,7 @@ static mut wl_bar_requests_bar_delivery_types: [*const wl_interface; 4] = [
     NULLPTR as *const wl_interface,
     NULLPTR as *const wl_interface,
 ];
-pub static mut wl_bar_requests: [wl_message; 2] = [
+pub static mut wl_bar_requests: [wl_message; 3] = [
     wl_message {
         name: b"bar_delivery\0" as *const u8 as *const c_char,
         signature: b"2uoa?a\0" as *const u8 as *const c_char,
@@ -52,14 +55,24 @@ pub static mut wl_bar_requests: [wl_message; 2] = [
         signature: b"\0" as *const u8 as *const c_char,
         types: unsafe { &types_null as *const _ },
     },
+    wl_message {
+        name: b"self\0" as *const u8 as *const c_char,
+        signature: b"2uuuuuuuu\0" as *const u8 as *const c_char,
+        types: unsafe { &types_null as *const _ },
+    },
 ];
+pub static mut wl_bar_events: [wl_message; 1] = [wl_message {
+    name: b"self\0" as *const u8 as *const c_char,
+    signature: b"2uuuuuuuu\0" as *const u8 as *const c_char,
+    types: unsafe { &types_null as *const _ },
+}];
 pub static mut wl_bar_interface: wl_interface = wl_interface {
     name: b"wl_bar\0" as *const u8 as *const c_char,
     version: 1,
-    request_count: 2,
+    request_count: 3,
     requests: unsafe { &wl_bar_requests as *const _ },
-    event_count: 0,
-    events: NULLPTR as *const wl_message,
+    event_count: 1,
+    events: unsafe { &wl_bar_events as *const _ },
 };
 pub static mut wl_display_interface: wl_interface = wl_interface {
     name: b"wl_display\0" as *const u8 as *const c_char,

--- a/tests/scanner_assets/client_c_code.rs
+++ b/tests/scanner_assets/client_c_code.rs
@@ -298,9 +298,9 @@ pub mod wl_foo {
     }
     impl<T: EventHandler> HandledBy<T> for WlFoo {
         #[inline]
-        fn handle(handler: &mut T, event: Event, object: Self) {
+        fn handle(__handler: &mut T, event: Event, __object: Self) {
             match event {
-                Event::Cake { kind, amount } => handler.cake(object, kind, amount),
+                Event::Cake { kind, amount } => __handler.cake(__object, kind, amount),
             }
         }
     }
@@ -329,6 +329,17 @@ pub mod wl_bar {
         },
         #[doc = "release this bar\n\nNotify the compositor that you have finished using this bar.\n\nThis is a destructor, once sent this object cannot be used any longer."]
         Release,
+        #[doc = "ask for erronous bindings from wayland-scanner\n\nThis request tests argument names which can break wayland-scanner.\n\nOnly available since version 2 of the interface"]
+        _Self {
+            _self: u32,
+            _mut: u32,
+            object: u32,
+            ___object: u32,
+            handler: u32,
+            ___handler: u32,
+            request: u32,
+            event: u32,
+        },
     }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[
@@ -347,6 +358,20 @@ pub mod wl_bar {
                 since: 1,
                 signature: &[],
             },
+            super::MessageDesc {
+                name: "self",
+                since: 2,
+                signature: &[
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                ],
+            },
         ];
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
@@ -359,6 +384,7 @@ pub mod wl_bar {
             match *self {
                 Request::BarDelivery { .. } => 0,
                 Request::Release => 1,
+                Request::_Self { .. } => 2,
             }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
@@ -390,6 +416,29 @@ pub mod wl_bar {
                     sender_id: sender_id,
                     opcode: 1,
                     args: vec![],
+                },
+                Request::_Self {
+                    _self,
+                    _mut,
+                    object,
+                    ___object,
+                    handler,
+                    ___handler,
+                    request,
+                    event,
+                } => Message {
+                    sender_id: sender_id,
+                    opcode: 2,
+                    args: vec![
+                        Argument::Uint(_self),
+                        Argument::Uint(_mut),
+                        Argument::Uint(object),
+                        Argument::Uint(___object),
+                        Argument::Uint(handler),
+                        Argument::Uint(___handler),
+                        Argument::Uint(request),
+                        Argument::Uint(event),
+                    ],
                 },
             }
         }
@@ -435,18 +484,68 @@ pub mod wl_bar {
                     let mut _args_array: [wl_argument; 0] = unsafe { ::std::mem::zeroed() };
                     f(1, &mut _args_array)
                 }
+                Request::_Self {
+                    _self,
+                    _mut,
+                    object,
+                    ___object,
+                    handler,
+                    ___handler,
+                    request,
+                    event,
+                } => {
+                    let mut _args_array: [wl_argument; 8] = unsafe { ::std::mem::zeroed() };
+                    _args_array[0].u = _self;
+                    _args_array[1].u = _mut;
+                    _args_array[2].u = object;
+                    _args_array[3].u = ___object;
+                    _args_array[4].u = handler;
+                    _args_array[5].u = ___handler;
+                    _args_array[6].u = request;
+                    _args_array[7].u = event;
+                    f(2, &mut _args_array)
+                }
             }
         }
     }
-    pub enum Event {}
+    pub enum Event {
+        #[doc = "ask for erronous bindings from wayland-scanner\n\nThis event tests argument names which can break wayland-scanner.\n\nOnly available since version 2 of the interface"]
+        _Self {
+            _self: u32,
+            _mut: u32,
+            object: u32,
+            ___object: u32,
+            handler: u32,
+            ___handler: u32,
+            request: u32,
+            event: u32,
+        },
+    }
     impl super::MessageGroup for Event {
-        const MESSAGES: &'static [super::MessageDesc] = &[];
+        const MESSAGES: &'static [super::MessageDesc] = &[super::MessageDesc {
+            name: "self",
+            since: 2,
+            signature: &[
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+            ],
+        }];
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
-            match *self {}
+            match *self {
+                _ => false,
+            }
         }
         fn opcode(&self) -> u16 {
-            match *self {}
+            match *self {
+                Event::_Self { .. } => 0,
+            }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
@@ -455,6 +554,67 @@ pub mod wl_bar {
         }
         fn from_raw(msg: Message, map: &mut Self::Map) -> Result<Self, ()> {
             match msg.opcode {
+                0 => {
+                    let mut args = msg.args.into_iter();
+                    Ok(Event::_Self {
+                        _self: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        _mut: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        object: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        ___object: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        handler: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        ___handler: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        request: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        event: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                    })
+                }
                 _ => Err(()),
             }
         }
@@ -467,6 +627,19 @@ pub mod wl_bar {
             args: *const wl_argument,
         ) -> Result<Event, ()> {
             match opcode {
+                0 => {
+                    let _args = ::std::slice::from_raw_parts(args, 8);
+                    Ok(Event::_Self {
+                        _self: _args[0].u,
+                        _mut: _args[1].u,
+                        object: _args[2].u,
+                        ___object: _args[3].u,
+                        handler: _args[4].u,
+                        ___handler: _args[5].u,
+                        request: _args[6].u,
+                        event: _args[7].u,
+                    })
+                }
                 _ => return Err(()),
             }
         }
@@ -528,19 +701,75 @@ pub mod wl_bar {
             let msg = Request::Release;
             self.0.send(msg);
         }
+        #[doc = "ask for erronous bindings from wayland-scanner\n\nThis request tests argument names which can break wayland-scanner.\n\nOnly available since version 2 of the interface."]
+        pub fn _self(
+            &self,
+            _self: u32,
+            _mut: u32,
+            object: u32,
+            ___object: u32,
+            handler: u32,
+            ___handler: u32,
+            request: u32,
+            event: u32,
+        ) -> () {
+            let msg = Request::_Self {
+                _self: _self,
+                _mut: _mut,
+                object: object,
+                ___object: ___object,
+                handler: handler,
+                ___handler: ___handler,
+                request: request,
+                event: event,
+            };
+            self.0.send(msg);
+        }
     }
     #[doc = r" An interface for handling events."]
-    pub trait EventHandler {}
+    pub trait EventHandler {
+        #[doc = "ask for erronous bindings from wayland-scanner\n\nThis event tests argument names which can break wayland-scanner.\n\nOnly available since version 2 of the interface."]
+        fn _self(
+            &mut self,
+            object: WlBar,
+            _self: u32,
+            _mut: u32,
+            _object: u32,
+            ___object: u32,
+            handler: u32,
+            ___handler: u32,
+            request: u32,
+            event: u32,
+        ) {
+        }
+    }
     impl<T: EventHandler> HandledBy<T> for WlBar {
         #[inline]
-        fn handle(handler: &mut T, event: Event, object: Self) {
-            match event {}
+        fn handle(__handler: &mut T, event: Event, __object: Self) {
+            match event {
+                Event::_Self {
+                    _self,
+                    _mut,
+                    object,
+                    ___object,
+                    handler,
+                    ___handler,
+                    request,
+                    event,
+                } => __handler._self(
+                    __object, _self, _mut, object, ___object, handler, ___handler, request, event,
+                ),
+            }
         }
     }
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_BAR_DELIVERY_SINCE: u16 = 2u16;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_RELEASE_SINCE: u16 = 1u16;
+    #[doc = r" The minimal object version supporting this request"]
+    pub const REQ_SELF_SINCE: u16 = 2u16;
+    #[doc = r" The minimal object version supporting this event"]
+    pub const EVT_SELF_SINCE: u16 = 2u16;
 }
 #[doc = "core global object\n\nThis global is special and should only generate code client-side, not server-side."]
 pub mod wl_display {
@@ -658,7 +887,7 @@ pub mod wl_display {
     pub trait EventHandler {}
     impl<T: EventHandler> HandledBy<T> for WlDisplay {
         #[inline]
-        fn handle(handler: &mut T, event: Event, object: Self) {
+        fn handle(__handler: &mut T, event: Event, __object: Self) {
             match event {}
         }
     }
@@ -831,7 +1060,7 @@ pub mod wl_registry {
     pub trait EventHandler {}
     impl<T: EventHandler> HandledBy<T> for WlRegistry {
         #[inline]
-        fn handle(handler: &mut T, event: Event, object: Self) {
+        fn handle(__handler: &mut T, event: Event, __object: Self) {
             match event {}
         }
     }
@@ -986,9 +1215,9 @@ pub mod wl_callback {
     }
     impl<T: EventHandler> HandledBy<T> for WlCallback {
         #[inline]
-        fn handle(handler: &mut T, event: Event, object: Self) {
+        fn handle(__handler: &mut T, event: Event, __object: Self) {
             match event {
-                Event::Done { callback_data } => handler.done(object, callback_data),
+                Event::Done { callback_data } => __handler.done(__object, callback_data),
             }
         }
     }

--- a/tests/scanner_assets/client_c_code.rs
+++ b/tests/scanner_assets/client_c_code.rs
@@ -49,7 +49,7 @@ pub mod wl_foo {
             file: ::std::os::unix::io::RawFd,
         },
         #[doc = "create a bar\n\nCreate a bar which will do its bar job."]
-        CreateBar { id: Proxy<super::wl_bar::WlBar> },
+        CreateBar { id: super::wl_bar::WlBar },
     }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[
@@ -116,7 +116,7 @@ pub mod wl_foo {
                 Request::CreateBar { id } => Message {
                     sender_id: sender_id,
                     opcode: 1,
-                    args: vec![Argument::NewId(id.id())],
+                    args: vec![Argument::NewId(id.as_ref().id())],
                 },
             }
         }
@@ -150,7 +150,7 @@ pub mod wl_foo {
                 }
                 Request::CreateBar { id } => {
                     let mut _args_array: [wl_argument; 1] = unsafe { ::std::mem::zeroed() };
-                    _args_array[0].o = id.c_ptr() as *mut _;
+                    _args_array[0].o = id.as_ref().c_ptr() as *mut _;
                     f(1, &mut _args_array)
                 }
             }
@@ -232,7 +232,26 @@ pub mod wl_foo {
             panic!("Event::as_raw_c_in can not be used Client-side.")
         }
     }
-    pub struct WlFoo;
+    #[derive(Clone, Eq, PartialEq)]
+    pub struct WlFoo(Proxy<WlFoo>);
+    impl AsRef<Proxy<WlFoo>> for WlFoo {
+        #[inline]
+        fn as_ref(&self) -> &Proxy<Self> {
+            &self.0
+        }
+    }
+    impl From<Proxy<WlFoo>> for WlFoo {
+        #[inline]
+        fn from(value: Proxy<Self>) -> Self {
+            WlFoo(value)
+        }
+    }
+    impl From<WlFoo> for Proxy<WlFoo> {
+        #[inline]
+        fn from(value: WlFoo) -> Self {
+            value.0
+        }
+    }
     impl Interface for WlFoo {
         type Request = Request;
         type Event = Event;
@@ -242,23 +261,9 @@ pub mod wl_foo {
             unsafe { &super::super::c_interfaces::wl_foo_interface }
         }
     }
-    pub trait RequestsTrait {
+    impl WlFoo {
         #[doc = "do some foo\n\nThis will do some foo with its args."]
-        fn foo_it(
-            &self,
-            number: i32,
-            unumber: u32,
-            text: String,
-            float: f64,
-            file: ::std::os::unix::io::RawFd,
-        ) -> ();
-        #[doc = "create a bar\n\nCreate a bar which will do its bar job."]
-        fn create_bar<F>(&self, implementor: F) -> Result<Proxy<super::wl_bar::WlBar>, ()>
-        where
-            F: FnOnce(NewProxy<super::wl_bar::WlBar>) -> Proxy<super::wl_bar::WlBar>;
-    }
-    impl RequestsTrait for Proxy<WlFoo> {
-        fn foo_it(
+        pub fn foo_it(
             &self,
             number: i32,
             unumber: u32,
@@ -273,28 +278,29 @@ pub mod wl_foo {
                 float: float,
                 file: file,
             };
-            self.send(msg);
+            self.0.send(msg);
         }
-        fn create_bar<F>(&self, implementor: F) -> Result<Proxy<super::wl_bar::WlBar>, ()>
+        #[doc = "create a bar\n\nCreate a bar which will do its bar job."]
+        pub fn create_bar<F>(&self, implementor: F) -> Result<super::wl_bar::WlBar, ()>
         where
-            F: FnOnce(NewProxy<super::wl_bar::WlBar>) -> Proxy<super::wl_bar::WlBar>,
+            F: FnOnce(NewProxy<super::wl_bar::WlBar>) -> super::wl_bar::WlBar,
         {
             let msg = Request::CreateBar {
-                id: self.child_placeholder(),
+                id: self.0.child_placeholder(),
             };
-            self.send_constructor(msg, implementor, None)
+            self.0.send_constructor(msg, implementor, None)
         }
     }
     #[doc = r" An interface for handling events."]
     pub trait EventHandler {
         #[doc = "a cake is possible\n\nThe server advertises that a kind of cake is available\n\nOnly available since version 2 of the interface."]
-        fn cake(&mut self, proxy: Proxy<WlFoo>, kind: CakeKind, amount: u32) {}
+        fn cake(&mut self, object: WlFoo, kind: CakeKind, amount: u32) {}
     }
     impl<T: EventHandler> HandledBy<T> for WlFoo {
         #[inline]
-        fn handle(handler: &mut T, event: Event, proxy: Proxy<Self>) {
+        fn handle(handler: &mut T, event: Event, object: Self) {
             match event {
-                Event::Cake { kind, amount } => handler.cake(proxy, kind, amount),
+                Event::Cake { kind, amount } => handler.cake(object, kind, amount),
             }
         }
     }
@@ -317,7 +323,7 @@ pub mod wl_bar {
         #[doc = "ask for a bar delivery\n\nProceed to a bar delivery of given foo.\n\nOnly available since version 2 of the interface"]
         BarDelivery {
             kind: super::wl_foo::DeliveryKind,
-            target: Proxy<super::wl_foo::WlFoo>,
+            target: super::wl_foo::WlFoo,
             metadata: Vec<u8>,
             metametadata: Option<Vec<u8>>,
         },
@@ -375,7 +381,7 @@ pub mod wl_bar {
                     opcode: 0,
                     args: vec![
                         Argument::Uint(kind.to_raw()),
-                        Argument::Object(target.id()),
+                        Argument::Object(target.as_ref().id()),
                         Argument::Array(metadata),
                         Argument::Array(metametadata.unwrap_or_else(Vec::new)),
                     ],
@@ -407,7 +413,7 @@ pub mod wl_bar {
                 } => {
                     let mut _args_array: [wl_argument; 4] = unsafe { ::std::mem::zeroed() };
                     _args_array[0].u = kind.to_raw();
-                    _args_array[1].o = target.c_ptr() as *mut _;
+                    _args_array[1].o = target.as_ref().c_ptr() as *mut _;
                     let _arg_2 = wl_array {
                         size: metadata.len(),
                         alloc: metadata.capacity(),
@@ -471,7 +477,26 @@ pub mod wl_bar {
             panic!("Event::as_raw_c_in can not be used Client-side.")
         }
     }
-    pub struct WlBar;
+    #[derive(Clone, Eq, PartialEq)]
+    pub struct WlBar(Proxy<WlBar>);
+    impl AsRef<Proxy<WlBar>> for WlBar {
+        #[inline]
+        fn as_ref(&self) -> &Proxy<Self> {
+            &self.0
+        }
+    }
+    impl From<Proxy<WlBar>> for WlBar {
+        #[inline]
+        fn from(value: Proxy<Self>) -> Self {
+            WlBar(value)
+        }
+    }
+    impl From<WlBar> for Proxy<WlBar> {
+        #[inline]
+        fn from(value: WlBar) -> Self {
+            value.0
+        }
+    }
     impl Interface for WlBar {
         type Request = Request;
         type Event = Event;
@@ -481,23 +506,12 @@ pub mod wl_bar {
             unsafe { &super::super::c_interfaces::wl_bar_interface }
         }
     }
-    pub trait RequestsTrait {
+    impl WlBar {
         #[doc = "ask for a bar delivery\n\nProceed to a bar delivery of given foo.\n\nOnly available since version 2 of the interface."]
-        fn bar_delivery(
+        pub fn bar_delivery(
             &self,
             kind: super::wl_foo::DeliveryKind,
-            target: &Proxy<super::wl_foo::WlFoo>,
-            metadata: Vec<u8>,
-            metametadata: Option<Vec<u8>>,
-        ) -> ();
-        #[doc = "release this bar\n\nNotify the compositor that you have finished using this bar.\n\nThis is a destructor, you cannot send requests to this object any longer once this method is called."]
-        fn release(&self) -> ();
-    }
-    impl RequestsTrait for Proxy<WlBar> {
-        fn bar_delivery(
-            &self,
-            kind: super::wl_foo::DeliveryKind,
-            target: &Proxy<super::wl_foo::WlFoo>,
+            target: &super::wl_foo::WlFoo,
             metadata: Vec<u8>,
             metametadata: Option<Vec<u8>>,
         ) -> () {
@@ -507,18 +521,19 @@ pub mod wl_bar {
                 metadata: metadata,
                 metametadata: metametadata,
             };
-            self.send(msg);
+            self.0.send(msg);
         }
-        fn release(&self) -> () {
+        #[doc = "release this bar\n\nNotify the compositor that you have finished using this bar.\n\nThis is a destructor, you cannot send requests to this object any longer once this method is called."]
+        pub fn release(&self) -> () {
             let msg = Request::Release;
-            self.send(msg);
+            self.0.send(msg);
         }
     }
     #[doc = r" An interface for handling events."]
     pub trait EventHandler {}
     impl<T: EventHandler> HandledBy<T> for WlBar {
         #[inline]
-        fn handle(handler: &mut T, event: Event, proxy: Proxy<Self>) {
+        fn handle(handler: &mut T, event: Event, object: Self) {
             match event {}
         }
     }
@@ -609,7 +624,26 @@ pub mod wl_display {
             panic!("Event::as_raw_c_in can not be used Client-side.")
         }
     }
-    pub struct WlDisplay;
+    #[derive(Clone, Eq, PartialEq)]
+    pub struct WlDisplay(Proxy<WlDisplay>);
+    impl AsRef<Proxy<WlDisplay>> for WlDisplay {
+        #[inline]
+        fn as_ref(&self) -> &Proxy<Self> {
+            &self.0
+        }
+    }
+    impl From<Proxy<WlDisplay>> for WlDisplay {
+        #[inline]
+        fn from(value: Proxy<Self>) -> Self {
+            WlDisplay(value)
+        }
+    }
+    impl From<WlDisplay> for Proxy<WlDisplay> {
+        #[inline]
+        fn from(value: WlDisplay) -> Self {
+            value.0
+        }
+    }
     impl Interface for WlDisplay {
         type Request = Request;
         type Event = Event;
@@ -619,13 +653,12 @@ pub mod wl_display {
             unsafe { &super::super::c_interfaces::wl_display_interface }
         }
     }
-    pub trait RequestsTrait {}
-    impl RequestsTrait for Proxy<WlDisplay> {}
+    impl WlDisplay {}
     #[doc = r" An interface for handling events."]
     pub trait EventHandler {}
     impl<T: EventHandler> HandledBy<T> for WlDisplay {
         #[inline]
-        fn handle(handler: &mut T, event: Event, proxy: Proxy<Self>) {
+        fn handle(handler: &mut T, event: Event, object: Self) {
             match event {}
         }
     }
@@ -642,7 +675,7 @@ pub mod wl_registry {
         #[doc = "bind an object to the display\n\nThis request is a special code-path, as its new-id argument as no target type."]
         Bind {
             name: u32,
-            id: (String, u32, Proxy<AnonymousObject>),
+            id: (String, u32, AnonymousObject),
         },
     }
     impl super::MessageGroup for Request {
@@ -679,7 +712,7 @@ pub mod wl_registry {
                         Argument::Uint(name),
                         Argument::Str(unsafe { ::std::ffi::CString::from_vec_unchecked(id.0.into()) }),
                         Argument::Uint(id.1),
-                        Argument::NewId(id.2.id()),
+                        Argument::NewId(id.2.as_ref().id()),
                     ],
                 },
             }
@@ -747,7 +780,26 @@ pub mod wl_registry {
             panic!("Event::as_raw_c_in can not be used Client-side.")
         }
     }
-    pub struct WlRegistry;
+    #[derive(Clone, Eq, PartialEq)]
+    pub struct WlRegistry(Proxy<WlRegistry>);
+    impl AsRef<Proxy<WlRegistry>> for WlRegistry {
+        #[inline]
+        fn as_ref(&self) -> &Proxy<Self> {
+            &self.0
+        }
+    }
+    impl From<Proxy<WlRegistry>> for WlRegistry {
+        #[inline]
+        fn from(value: Proxy<Self>) -> Self {
+            WlRegistry(value)
+        }
+    }
+    impl From<WlRegistry> for Proxy<WlRegistry> {
+        #[inline]
+        fn from(value: WlRegistry) -> Self {
+            value.0
+        }
+    }
     impl Interface for WlRegistry {
         type Request = Request;
         type Event = Event;
@@ -757,29 +809,29 @@ pub mod wl_registry {
             unsafe { &super::super::c_interfaces::wl_registry_interface }
         }
     }
-    pub trait RequestsTrait {
+    impl WlRegistry {
         #[doc = "bind an object to the display\n\nThis request is a special code-path, as its new-id argument as no target type."]
-        fn bind<T: Interface, F>(&self, version: u32, name: u32, implementor: F) -> Result<Proxy<T>, ()>
+        pub fn bind<T: Interface + From<Proxy<T>>, F>(
+            &self,
+            version: u32,
+            name: u32,
+            implementor: F,
+        ) -> Result<T, ()>
         where
-            F: FnOnce(NewProxy<T>) -> Proxy<T>;
-    }
-    impl RequestsTrait for Proxy<WlRegistry> {
-        fn bind<T: Interface, F>(&self, version: u32, name: u32, implementor: F) -> Result<Proxy<T>, ()>
-        where
-            F: FnOnce(NewProxy<T>) -> Proxy<T>,
+            F: FnOnce(NewProxy<T>) -> T,
         {
             let msg = Request::Bind {
                 name: name,
-                id: (T::NAME.into(), version, self.child_placeholder()),
+                id: (T::NAME.into(), version, self.0.child_placeholder()),
             };
-            self.send_constructor(msg, implementor, Some(version))
+            self.0.send_constructor(msg, implementor, Some(version))
         }
     }
     #[doc = r" An interface for handling events."]
     pub trait EventHandler {}
     impl<T: EventHandler> HandledBy<T> for WlRegistry {
         #[inline]
-        fn handle(handler: &mut T, event: Event, proxy: Proxy<Self>) {
+        fn handle(handler: &mut T, event: Event, object: Self) {
             match event {}
         }
     }
@@ -897,7 +949,26 @@ pub mod wl_callback {
             panic!("Event::as_raw_c_in can not be used Client-side.")
         }
     }
-    pub struct WlCallback;
+    #[derive(Clone, Eq, PartialEq)]
+    pub struct WlCallback(Proxy<WlCallback>);
+    impl AsRef<Proxy<WlCallback>> for WlCallback {
+        #[inline]
+        fn as_ref(&self) -> &Proxy<Self> {
+            &self.0
+        }
+    }
+    impl From<Proxy<WlCallback>> for WlCallback {
+        #[inline]
+        fn from(value: Proxy<Self>) -> Self {
+            WlCallback(value)
+        }
+    }
+    impl From<WlCallback> for Proxy<WlCallback> {
+        #[inline]
+        fn from(value: WlCallback) -> Self {
+            value.0
+        }
+    }
     impl Interface for WlCallback {
         type Request = Request;
         type Event = Event;
@@ -907,18 +978,17 @@ pub mod wl_callback {
             unsafe { &super::super::c_interfaces::wl_callback_interface }
         }
     }
-    pub trait RequestsTrait {}
-    impl RequestsTrait for Proxy<WlCallback> {}
+    impl WlCallback {}
     #[doc = r" An interface for handling events."]
     pub trait EventHandler {
         #[doc = "done event\n\nThis event is actually a destructor, but the protocol XML has no way of specifying it.\nAs such, the scanner should consider wl_callback.done as a special case.\n\nThis is a destructor, you cannot send requests to this object any longer once this method is called."]
-        fn done(&mut self, proxy: Proxy<WlCallback>, callback_data: u32) {}
+        fn done(&mut self, object: WlCallback, callback_data: u32) {}
     }
     impl<T: EventHandler> HandledBy<T> for WlCallback {
         #[inline]
-        fn handle(handler: &mut T, event: Event, proxy: Proxy<Self>) {
+        fn handle(handler: &mut T, event: Event, object: Self) {
             match event {
-                Event::Done { callback_data } => handler.done(proxy, callback_data),
+                Event::Done { callback_data } => handler.done(object, callback_data),
             }
         }
     }

--- a/tests/scanner_assets/client_rust_code.rs
+++ b/tests/scanner_assets/client_rust_code.rs
@@ -236,9 +236,9 @@ pub mod wl_foo {
     }
     impl<T: EventHandler> HandledBy<T> for WlFoo {
         #[inline]
-        fn handle(handler: &mut T, event: Event, object: Self) {
+        fn handle(__handler: &mut T, event: Event, __object: Self) {
             match event {
-                Event::Cake { kind, amount } => handler.cake(object, kind, amount),
+                Event::Cake { kind, amount } => __handler.cake(__object, kind, amount),
             }
         }
     }
@@ -265,6 +265,17 @@ pub mod wl_bar {
         },
         #[doc = "release this bar\n\nNotify the compositor that you have finished using this bar.\n\nThis is a destructor, once sent this object cannot be used any longer."]
         Release,
+        #[doc = "ask for erronous bindings from wayland-scanner\n\nThis request tests argument names which can break wayland-scanner.\n\nOnly available since version 2 of the interface"]
+        _Self {
+            _self: u32,
+            _mut: u32,
+            object: u32,
+            ___object: u32,
+            handler: u32,
+            ___handler: u32,
+            request: u32,
+            event: u32,
+        },
     }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[
@@ -283,6 +294,20 @@ pub mod wl_bar {
                 since: 1,
                 signature: &[],
             },
+            super::MessageDesc {
+                name: "self",
+                since: 2,
+                signature: &[
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                ],
+            },
         ];
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
@@ -295,6 +320,7 @@ pub mod wl_bar {
             match *self {
                 Request::BarDelivery { .. } => 0,
                 Request::Release => 1,
+                Request::_Self { .. } => 2,
             }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
@@ -327,18 +353,70 @@ pub mod wl_bar {
                     opcode: 1,
                     args: vec![],
                 },
+                Request::_Self {
+                    _self,
+                    _mut,
+                    object,
+                    ___object,
+                    handler,
+                    ___handler,
+                    request,
+                    event,
+                } => Message {
+                    sender_id: sender_id,
+                    opcode: 2,
+                    args: vec![
+                        Argument::Uint(_self),
+                        Argument::Uint(_mut),
+                        Argument::Uint(object),
+                        Argument::Uint(___object),
+                        Argument::Uint(handler),
+                        Argument::Uint(___handler),
+                        Argument::Uint(request),
+                        Argument::Uint(event),
+                    ],
+                },
             }
         }
     }
-    pub enum Event {}
+    pub enum Event {
+        #[doc = "ask for erronous bindings from wayland-scanner\n\nThis event tests argument names which can break wayland-scanner.\n\nOnly available since version 2 of the interface"]
+        _Self {
+            _self: u32,
+            _mut: u32,
+            object: u32,
+            ___object: u32,
+            handler: u32,
+            ___handler: u32,
+            request: u32,
+            event: u32,
+        },
+    }
     impl super::MessageGroup for Event {
-        const MESSAGES: &'static [super::MessageDesc] = &[];
+        const MESSAGES: &'static [super::MessageDesc] = &[super::MessageDesc {
+            name: "self",
+            since: 2,
+            signature: &[
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+            ],
+        }];
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
-            match *self {}
+            match *self {
+                _ => false,
+            }
         }
         fn opcode(&self) -> u16 {
-            match *self {}
+            match *self {
+                Event::_Self { .. } => 0,
+            }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
@@ -347,6 +425,67 @@ pub mod wl_bar {
         }
         fn from_raw(msg: Message, map: &mut Self::Map) -> Result<Self, ()> {
             match msg.opcode {
+                0 => {
+                    let mut args = msg.args.into_iter();
+                    Ok(Event::_Self {
+                        _self: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        _mut: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        object: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        ___object: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        handler: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        ___handler: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        request: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        event: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                    })
+                }
                 _ => Err(()),
             }
         }
@@ -402,19 +541,75 @@ pub mod wl_bar {
             let msg = Request::Release;
             self.0.send(msg);
         }
+        #[doc = "ask for erronous bindings from wayland-scanner\n\nThis request tests argument names which can break wayland-scanner.\n\nOnly available since version 2 of the interface."]
+        pub fn _self(
+            &self,
+            _self: u32,
+            _mut: u32,
+            object: u32,
+            ___object: u32,
+            handler: u32,
+            ___handler: u32,
+            request: u32,
+            event: u32,
+        ) -> () {
+            let msg = Request::_Self {
+                _self: _self,
+                _mut: _mut,
+                object: object,
+                ___object: ___object,
+                handler: handler,
+                ___handler: ___handler,
+                request: request,
+                event: event,
+            };
+            self.0.send(msg);
+        }
     }
     #[doc = r" An interface for handling events."]
-    pub trait EventHandler {}
+    pub trait EventHandler {
+        #[doc = "ask for erronous bindings from wayland-scanner\n\nThis event tests argument names which can break wayland-scanner.\n\nOnly available since version 2 of the interface."]
+        fn _self(
+            &mut self,
+            object: WlBar,
+            _self: u32,
+            _mut: u32,
+            _object: u32,
+            ___object: u32,
+            handler: u32,
+            ___handler: u32,
+            request: u32,
+            event: u32,
+        ) {
+        }
+    }
     impl<T: EventHandler> HandledBy<T> for WlBar {
         #[inline]
-        fn handle(handler: &mut T, event: Event, object: Self) {
-            match event {}
+        fn handle(__handler: &mut T, event: Event, __object: Self) {
+            match event {
+                Event::_Self {
+                    _self,
+                    _mut,
+                    object,
+                    ___object,
+                    handler,
+                    ___handler,
+                    request,
+                    event,
+                } => __handler._self(
+                    __object, _self, _mut, object, ___object, handler, ___handler, request, event,
+                ),
+            }
         }
     }
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_BAR_DELIVERY_SINCE: u16 = 2u16;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_RELEASE_SINCE: u16 = 1u16;
+    #[doc = r" The minimal object version supporting this request"]
+    pub const REQ_SELF_SINCE: u16 = 2u16;
+    #[doc = r" The minimal object version supporting this event"]
+    pub const EVT_SELF_SINCE: u16 = 2u16;
 }
 #[doc = "core global object\n\nThis global is special and should only generate code client-side, not server-side."]
 pub mod wl_display {
@@ -499,7 +694,7 @@ pub mod wl_display {
     pub trait EventHandler {}
     impl<T: EventHandler> HandledBy<T> for WlDisplay {
         #[inline]
-        fn handle(handler: &mut T, event: Event, object: Self) {
+        fn handle(__handler: &mut T, event: Event, __object: Self) {
             match event {}
         }
     }
@@ -629,7 +824,7 @@ pub mod wl_registry {
     pub trait EventHandler {}
     impl<T: EventHandler> HandledBy<T> for WlRegistry {
         #[inline]
-        fn handle(handler: &mut T, event: Event, object: Self) {
+        fn handle(__handler: &mut T, event: Event, __object: Self) {
             match event {}
         }
     }
@@ -745,9 +940,9 @@ pub mod wl_callback {
     }
     impl<T: EventHandler> HandledBy<T> for WlCallback {
         #[inline]
-        fn handle(handler: &mut T, event: Event, object: Self) {
+        fn handle(__handler: &mut T, event: Event, __object: Self) {
             match event {
-                Event::Done { callback_data } => handler.done(object, callback_data),
+                Event::Done { callback_data } => __handler.done(__object, callback_data),
             }
         }
     }

--- a/tests/scanner_assets/protocol.xml
+++ b/tests/scanner_assets/protocol.xml
@@ -75,6 +75,34 @@
         Notify the compositor that you have finished using this bar.
       </description>
     </request>
+
+    <event name="self" since="2">
+      <description summary="ask for erronous bindings from wayland-scanner">
+        This event tests argument names which can break wayland-scanner.
+      </description>
+      <arg name="self" type="uint" summary="" />
+      <arg name="mut" type="uint" summary="" />
+      <arg name="object" type="uint" summary="" />
+      <arg name="__object" type="uint" summary="" />
+      <arg name="handler" type="uint" summary="" />
+      <arg name="__handler" type="uint" summary="" />
+      <arg name="request" type="uint" summary="" />
+      <arg name="event" type="uint" summary="" />
+    </event>
+
+    <request name="self" since="2">
+      <description summary="ask for erronous bindings from wayland-scanner">
+        This request tests argument names which can break wayland-scanner.
+      </description>
+      <arg name="self" type="uint" summary="" />
+      <arg name="mut" type="uint" summary="" />
+      <arg name="object" type="uint" summary="" />
+      <arg name="__object" type="uint" summary="" />
+      <arg name="handler" type="uint" summary="" />
+      <arg name="__handler" type="uint" summary="" />
+      <arg name="request" type="uint" summary="" />
+      <arg name="event" type="uint" summary="" />
+    </request>
   </interface>
 
   <!-- mimicking a few interfaces from the wayland protocol to trigger edge cases -->

--- a/tests/scanner_assets/server_c_code.rs
+++ b/tests/scanner_assets/server_c_code.rs
@@ -317,7 +317,7 @@ pub mod wl_foo {
     }
     impl<T: RequestHandler> HandledBy<T> for WlFoo {
         #[inline]
-        fn handle(handler: &mut T, request: Request, object: Self) {
+        fn handle(__handler: &mut T, request: Request, __object: Self) {
             match request {
                 Request::FooIt {
                     number,
@@ -325,8 +325,8 @@ pub mod wl_foo {
                     text,
                     float,
                     file,
-                } => handler.foo_it(object, number, unumber, text, float, file),
-                Request::CreateBar { id } => handler.create_bar(object, id),
+                } => __handler.foo_it(__object, number, unumber, text, float, file),
+                Request::CreateBar { id } => __handler.create_bar(__object, id),
             }
         }
     }
@@ -355,6 +355,17 @@ pub mod wl_bar {
         },
         #[doc = "release this bar\n\nNotify the compositor that you have finished using this bar.\n\nThis is a destructor, once received this object cannot be used any longer."]
         Release,
+        #[doc = "ask for erronous bindings from wayland-scanner\n\nThis request tests argument names which can break wayland-scanner.\n\nOnly available since version 2 of the interface"]
+        _Self {
+            _self: u32,
+            _mut: u32,
+            object: u32,
+            ___object: u32,
+            handler: u32,
+            ___handler: u32,
+            request: u32,
+            event: u32,
+        },
     }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[
@@ -373,6 +384,20 @@ pub mod wl_bar {
                 since: 1,
                 signature: &[],
             },
+            super::MessageDesc {
+                name: "self",
+                since: 2,
+                signature: &[
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                ],
+            },
         ];
         type Map = super::ResourceMap;
         fn is_destructor(&self) -> bool {
@@ -385,6 +410,7 @@ pub mod wl_bar {
             match *self {
                 Request::BarDelivery { .. } => 0,
                 Request::Release => 1,
+                Request::_Self { .. } => 2,
             }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
@@ -432,6 +458,67 @@ pub mod wl_bar {
                     })
                 }
                 1 => Ok(Request::Release),
+                2 => {
+                    let mut args = msg.args.into_iter();
+                    Ok(Request::_Self {
+                        _self: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        _mut: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        object: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        ___object: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        handler: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        ___handler: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        request: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        event: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                    })
+                }
                 _ => Err(()),
             }
         }
@@ -464,6 +551,19 @@ pub mod wl_bar {
                     })
                 }
                 1 => Ok(Request::Release),
+                2 => {
+                    let _args = ::std::slice::from_raw_parts(args, 8);
+                    Ok(Request::_Self {
+                        _self: _args[0].u,
+                        _mut: _args[1].u,
+                        object: _args[2].u,
+                        ___object: _args[3].u,
+                        handler: _args[4].u,
+                        ___handler: _args[5].u,
+                        request: _args[6].u,
+                        event: _args[7].u,
+                    })
+                }
                 _ => return Err(()),
             }
         }
@@ -474,15 +574,44 @@ pub mod wl_bar {
             panic!("Request::as_raw_c_in can not be used Server-side.")
         }
     }
-    pub enum Event {}
+    pub enum Event {
+        #[doc = "ask for erronous bindings from wayland-scanner\n\nThis event tests argument names which can break wayland-scanner.\n\nOnly available since version 2 of the interface"]
+        _Self {
+            _self: u32,
+            _mut: u32,
+            object: u32,
+            ___object: u32,
+            handler: u32,
+            ___handler: u32,
+            request: u32,
+            event: u32,
+        },
+    }
     impl super::MessageGroup for Event {
-        const MESSAGES: &'static [super::MessageDesc] = &[];
+        const MESSAGES: &'static [super::MessageDesc] = &[super::MessageDesc {
+            name: "self",
+            since: 2,
+            signature: &[
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+            ],
+        }];
         type Map = super::ResourceMap;
         fn is_destructor(&self) -> bool {
-            match *self {}
+            match *self {
+                _ => false,
+            }
         }
         fn opcode(&self) -> u16 {
-            match *self {}
+            match *self {
+                Event::_Self { .. } => 0,
+            }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
@@ -493,7 +622,31 @@ pub mod wl_bar {
             panic!("Event::from_raw can not be used Server-side.")
         }
         fn into_raw(self, sender_id: u32) -> Message {
-            match self {}
+            match self {
+                Event::_Self {
+                    _self,
+                    _mut,
+                    object,
+                    ___object,
+                    handler,
+                    ___handler,
+                    request,
+                    event,
+                } => Message {
+                    sender_id: sender_id,
+                    opcode: 0,
+                    args: vec![
+                        Argument::Uint(_self),
+                        Argument::Uint(_mut),
+                        Argument::Uint(object),
+                        Argument::Uint(___object),
+                        Argument::Uint(handler),
+                        Argument::Uint(___handler),
+                        Argument::Uint(request),
+                        Argument::Uint(event),
+                    ],
+                },
+            }
         }
         unsafe fn from_raw_c(
             obj: *mut ::std::os::raw::c_void,
@@ -506,7 +659,29 @@ pub mod wl_bar {
         where
             F: FnOnce(u32, &mut [wl_argument]) -> T,
         {
-            match self {}
+            match self {
+                Event::_Self {
+                    _self,
+                    _mut,
+                    object,
+                    ___object,
+                    handler,
+                    ___handler,
+                    request,
+                    event,
+                } => {
+                    let mut _args_array: [wl_argument; 8] = unsafe { ::std::mem::zeroed() };
+                    _args_array[0].u = _self;
+                    _args_array[1].u = _mut;
+                    _args_array[2].u = object;
+                    _args_array[3].u = ___object;
+                    _args_array[4].u = handler;
+                    _args_array[5].u = ___handler;
+                    _args_array[6].u = request;
+                    _args_array[7].u = event;
+                    f(0, &mut _args_array)
+                }
+            }
         }
     }
     #[derive(Clone, Eq, PartialEq)]
@@ -538,7 +713,32 @@ pub mod wl_bar {
             unsafe { &super::super::c_interfaces::wl_bar_interface }
         }
     }
-    impl WlBar {}
+    impl WlBar {
+        #[doc = "ask for erronous bindings from wayland-scanner\n\nThis event tests argument names which can break wayland-scanner.\n\nOnly available since version 2 of the interface."]
+        pub fn _self(
+            &self,
+            _self: u32,
+            _mut: u32,
+            object: u32,
+            ___object: u32,
+            handler: u32,
+            ___handler: u32,
+            request: u32,
+            event: u32,
+        ) -> () {
+            let msg = Event::_Self {
+                _self: _self,
+                _mut: _mut,
+                object: object,
+                ___object: ___object,
+                handler: handler,
+                ___handler: ___handler,
+                request: request,
+                event: event,
+            };
+            self.0.send(msg);
+        }
+    }
     #[doc = r" An interface for handling requests."]
     pub trait RequestHandler {
         #[doc = "ask for a bar delivery\n\nProceed to a bar delivery of given foo.\n\nOnly available since version 2 of the interface."]
@@ -553,18 +753,44 @@ pub mod wl_bar {
         }
         #[doc = "release this bar\n\nNotify the compositor that you have finished using this bar.\n\nThis is a destructor, you cannot send requests to this object any longer once this method is called."]
         fn release(&mut self, object: WlBar) {}
+        #[doc = "ask for erronous bindings from wayland-scanner\n\nThis request tests argument names which can break wayland-scanner.\n\nOnly available since version 2 of the interface."]
+        fn _self(
+            &mut self,
+            object: WlBar,
+            _self: u32,
+            _mut: u32,
+            _object: u32,
+            ___object: u32,
+            handler: u32,
+            ___handler: u32,
+            request: u32,
+            event: u32,
+        ) {
+        }
     }
     impl<T: RequestHandler> HandledBy<T> for WlBar {
         #[inline]
-        fn handle(handler: &mut T, request: Request, object: Self) {
+        fn handle(__handler: &mut T, request: Request, __object: Self) {
             match request {
                 Request::BarDelivery {
                     kind,
                     target,
                     metadata,
                     metametadata,
-                } => handler.bar_delivery(object, kind, target, metadata, metametadata),
-                Request::Release {} => handler.release(object),
+                } => __handler.bar_delivery(__object, kind, target, metadata, metametadata),
+                Request::Release {} => __handler.release(__object),
+                Request::_Self {
+                    _self,
+                    _mut,
+                    object,
+                    ___object,
+                    handler,
+                    ___handler,
+                    request,
+                    event,
+                } => __handler._self(
+                    __object, _self, _mut, object, ___object, handler, ___handler, request, event,
+                ),
             }
         }
     }
@@ -572,6 +798,10 @@ pub mod wl_bar {
     pub const REQ_BAR_DELIVERY_SINCE: u16 = 2u16;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_RELEASE_SINCE: u16 = 1u16;
+    #[doc = r" The minimal object version supporting this request"]
+    pub const REQ_SELF_SINCE: u16 = 2u16;
+    #[doc = r" The minimal object version supporting this event"]
+    pub const EVT_SELF_SINCE: u16 = 2u16;
 }
 #[doc = "callback object\n\nThis object has a special behavior regarding its destructor."]
 pub mod wl_callback {
@@ -720,7 +950,7 @@ pub mod wl_callback {
     pub trait RequestHandler {}
     impl<T: RequestHandler> HandledBy<T> for WlCallback {
         #[inline]
-        fn handle(handler: &mut T, request: Request, object: Self) {
+        fn handle(__handler: &mut T, request: Request, __object: Self) {
             match request {}
         }
     }

--- a/tests/scanner_assets/server_rust_code.rs
+++ b/tests/scanner_assets/server_rust_code.rs
@@ -245,7 +245,7 @@ pub mod wl_foo {
     }
     impl<T: RequestHandler> HandledBy<T> for WlFoo {
         #[inline]
-        fn handle(handler: &mut T, request: Request, object: Self) {
+        fn handle(__handler: &mut T, request: Request, __object: Self) {
             match request {
                 Request::FooIt {
                     number,
@@ -253,8 +253,8 @@ pub mod wl_foo {
                     text,
                     float,
                     file,
-                } => handler.foo_it(object, number, unumber, text, float, file),
-                Request::CreateBar { id } => handler.create_bar(object, id),
+                } => __handler.foo_it(__object, number, unumber, text, float, file),
+                Request::CreateBar { id } => __handler.create_bar(__object, id),
             }
         }
     }
@@ -281,6 +281,17 @@ pub mod wl_bar {
         },
         #[doc = "release this bar\n\nNotify the compositor that you have finished using this bar.\n\nThis is a destructor, once received this object cannot be used any longer."]
         Release,
+        #[doc = "ask for erronous bindings from wayland-scanner\n\nThis request tests argument names which can break wayland-scanner.\n\nOnly available since version 2 of the interface"]
+        _Self {
+            _self: u32,
+            _mut: u32,
+            object: u32,
+            ___object: u32,
+            handler: u32,
+            ___handler: u32,
+            request: u32,
+            event: u32,
+        },
     }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[
@@ -299,6 +310,20 @@ pub mod wl_bar {
                 since: 1,
                 signature: &[],
             },
+            super::MessageDesc {
+                name: "self",
+                since: 2,
+                signature: &[
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                    super::ArgumentType::Uint,
+                ],
+            },
         ];
         type Map = super::ResourceMap;
         fn is_destructor(&self) -> bool {
@@ -311,6 +336,7 @@ pub mod wl_bar {
             match *self {
                 Request::BarDelivery { .. } => 0,
                 Request::Release => 1,
+                Request::_Self { .. } => 2,
             }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
@@ -358,6 +384,67 @@ pub mod wl_bar {
                     })
                 }
                 1 => Ok(Request::Release),
+                2 => {
+                    let mut args = msg.args.into_iter();
+                    Ok(Request::_Self {
+                        _self: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        _mut: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        object: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        ___object: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        handler: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        ___handler: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        request: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                        event: {
+                            if let Some(Argument::Uint(val)) = args.next() {
+                                val
+                            } else {
+                                return Err(());
+                            }
+                        },
+                    })
+                }
                 _ => Err(()),
             }
         }
@@ -365,15 +452,44 @@ pub mod wl_bar {
             panic!("Request::into_raw can not be used Server-side.")
         }
     }
-    pub enum Event {}
+    pub enum Event {
+        #[doc = "ask for erronous bindings from wayland-scanner\n\nThis event tests argument names which can break wayland-scanner.\n\nOnly available since version 2 of the interface"]
+        _Self {
+            _self: u32,
+            _mut: u32,
+            object: u32,
+            ___object: u32,
+            handler: u32,
+            ___handler: u32,
+            request: u32,
+            event: u32,
+        },
+    }
     impl super::MessageGroup for Event {
-        const MESSAGES: &'static [super::MessageDesc] = &[];
+        const MESSAGES: &'static [super::MessageDesc] = &[super::MessageDesc {
+            name: "self",
+            since: 2,
+            signature: &[
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+                super::ArgumentType::Uint,
+            ],
+        }];
         type Map = super::ResourceMap;
         fn is_destructor(&self) -> bool {
-            match *self {}
+            match *self {
+                _ => false,
+            }
         }
         fn opcode(&self) -> u16 {
-            match *self {}
+            match *self {
+                Event::_Self { .. } => 0,
+            }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
@@ -384,7 +500,31 @@ pub mod wl_bar {
             panic!("Event::from_raw can not be used Server-side.")
         }
         fn into_raw(self, sender_id: u32) -> Message {
-            match self {}
+            match self {
+                Event::_Self {
+                    _self,
+                    _mut,
+                    object,
+                    ___object,
+                    handler,
+                    ___handler,
+                    request,
+                    event,
+                } => Message {
+                    sender_id: sender_id,
+                    opcode: 0,
+                    args: vec![
+                        Argument::Uint(_self),
+                        Argument::Uint(_mut),
+                        Argument::Uint(object),
+                        Argument::Uint(___object),
+                        Argument::Uint(handler),
+                        Argument::Uint(___handler),
+                        Argument::Uint(request),
+                        Argument::Uint(event),
+                    ],
+                },
+            }
         }
     }
     #[derive(Clone, Eq, PartialEq)]
@@ -413,7 +553,32 @@ pub mod wl_bar {
         const NAME: &'static str = "wl_bar";
         const VERSION: u32 = 1;
     }
-    impl WlBar {}
+    impl WlBar {
+        #[doc = "ask for erronous bindings from wayland-scanner\n\nThis event tests argument names which can break wayland-scanner.\n\nOnly available since version 2 of the interface."]
+        pub fn _self(
+            &self,
+            _self: u32,
+            _mut: u32,
+            object: u32,
+            ___object: u32,
+            handler: u32,
+            ___handler: u32,
+            request: u32,
+            event: u32,
+        ) -> () {
+            let msg = Event::_Self {
+                _self: _self,
+                _mut: _mut,
+                object: object,
+                ___object: ___object,
+                handler: handler,
+                ___handler: ___handler,
+                request: request,
+                event: event,
+            };
+            self.0.send(msg);
+        }
+    }
     #[doc = r" An interface for handling requests."]
     pub trait RequestHandler {
         #[doc = "ask for a bar delivery\n\nProceed to a bar delivery of given foo.\n\nOnly available since version 2 of the interface."]
@@ -428,18 +593,44 @@ pub mod wl_bar {
         }
         #[doc = "release this bar\n\nNotify the compositor that you have finished using this bar.\n\nThis is a destructor, you cannot send requests to this object any longer once this method is called."]
         fn release(&mut self, object: WlBar) {}
+        #[doc = "ask for erronous bindings from wayland-scanner\n\nThis request tests argument names which can break wayland-scanner.\n\nOnly available since version 2 of the interface."]
+        fn _self(
+            &mut self,
+            object: WlBar,
+            _self: u32,
+            _mut: u32,
+            _object: u32,
+            ___object: u32,
+            handler: u32,
+            ___handler: u32,
+            request: u32,
+            event: u32,
+        ) {
+        }
     }
     impl<T: RequestHandler> HandledBy<T> for WlBar {
         #[inline]
-        fn handle(handler: &mut T, request: Request, object: Self) {
+        fn handle(__handler: &mut T, request: Request, __object: Self) {
             match request {
                 Request::BarDelivery {
                     kind,
                     target,
                     metadata,
                     metametadata,
-                } => handler.bar_delivery(object, kind, target, metadata, metametadata),
-                Request::Release {} => handler.release(object),
+                } => __handler.bar_delivery(__object, kind, target, metadata, metametadata),
+                Request::Release {} => __handler.release(__object),
+                Request::_Self {
+                    _self,
+                    _mut,
+                    object,
+                    ___object,
+                    handler,
+                    ___handler,
+                    request,
+                    event,
+                } => __handler._self(
+                    __object, _self, _mut, object, ___object, handler, ___handler, request, event,
+                ),
             }
         }
     }
@@ -447,6 +638,10 @@ pub mod wl_bar {
     pub const REQ_BAR_DELIVERY_SINCE: u16 = 2u16;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_RELEASE_SINCE: u16 = 1u16;
+    #[doc = r" The minimal object version supporting this request"]
+    pub const REQ_SELF_SINCE: u16 = 2u16;
+    #[doc = r" The minimal object version supporting this event"]
+    pub const EVT_SELF_SINCE: u16 = 2u16;
 }
 #[doc = "callback object\n\nThis object has a special behavior regarding its destructor."]
 pub mod wl_callback {
@@ -556,7 +751,7 @@ pub mod wl_callback {
     pub trait RequestHandler {}
     impl<T: RequestHandler> HandledBy<T> for WlCallback {
         #[inline]
-        fn handle(handler: &mut T, request: Request, object: Self) {
+        fn handle(__handler: &mut T, request: Request, __object: Self) {
             match request {}
         }
     }

--- a/tests/server_clients.rs
+++ b/tests/server_clients.rs
@@ -21,7 +21,7 @@ fn client_user_data() {
         let clients = clients.clone();
         move |newo, _| {
             let output = newo.implement_dummy();
-            let client = output.client().unwrap();
+            let client = output.as_ref().client().unwrap();
             let ret = client.data_map().insert_if_missing(|| HasOutput);
             // the data should not be already here
             assert!(ret);
@@ -34,7 +34,7 @@ fn client_user_data() {
             let clients = clients.clone();
             move |newo, _| {
                 let compositor = newo.implement_dummy();
-                let client = compositor.client().unwrap();
+                let client = compositor.as_ref().client().unwrap();
                 let ret = client.data_map().insert_if_missing(|| HasCompositor);
                 // the data should not be already here
                 assert!(ret);

--- a/tests/server_created_object.rs
+++ b/tests/server_created_object.rs
@@ -16,11 +16,11 @@ use ways::{NewResource, Resource};
 use wayc::protocol::wl_data_device::{
     Event as CDDEvt, EventHandler as ClientDDHandler, WlDataDevice as ClientDD,
 };
-use wayc::protocol::wl_data_device_manager::{RequestsTrait, WlDataDeviceManager as ClientDDMgr};
+use wayc::protocol::wl_data_device_manager::WlDataDeviceManager as ClientDDMgr;
 use wayc::protocol::wl_data_offer::WlDataOffer as ClientDO;
 use wayc::protocol::wl_seat::WlSeat as ClientSeat;
 use wayc::protocol::wl_surface::WlSurface as ClientSurface;
-use wayc::{NewProxy, Proxy};
+use wayc::NewProxy;
 
 #[test]
 fn data_offer() {
@@ -73,6 +73,7 @@ fn data_offer() {
                 move |evt, _| match evt {
                     CDDEvt::DataOffer { id } => {
                         let doffer = id.implement_dummy();
+                        let doffer = doffer.as_proxy();
                         assert!(doffer.version() == 3);
                         // this must be the first server-side ID
                         assert_eq!(doffer.id(), 0xFF000000);
@@ -148,8 +149,9 @@ fn data_offer_trait_impls() {
     }
 
     impl ClientDDHandler for ClientHandler {
-        fn data_offer(&mut self, _proxy: Proxy<ClientDD>, id: NewProxy<ClientDO>) {
+        fn data_offer(&mut self, _dd: ClientDD, id: NewProxy<ClientDO>) {
             let doffer = id.implement_dummy();
+            let doffer = doffer.as_proxy();
             assert!(doffer.version() == 3);
             // this must be the first server-side ID
             assert_eq!(doffer.id(), 0xFF000000);
@@ -158,29 +160,29 @@ fn data_offer_trait_impls() {
 
         fn enter(
             &mut self,
-            _proxy: Proxy<ClientDD>,
+            _dd: ClientDD,
             _serial: u32,
-            _surface: Proxy<ClientSurface>,
+            _surface: ClientSurface,
             _x: f64,
             _y: f64,
-            _id: Option<Proxy<ClientDO>>,
+            _id: Option<ClientDO>,
         ) {
             unimplemented!()
         }
 
-        fn leave(&mut self, _proxy: Proxy<ClientDD>) {
+        fn leave(&mut self, _dd: ClientDD) {
             unimplemented!()
         }
 
-        fn motion(&mut self, _proxy: Proxy<ClientDD>, _time: u32, _x: f64, _y: f64) {
+        fn motion(&mut self, _dd: ClientDD, _time: u32, _x: f64, _y: f64) {
             unimplemented!()
         }
 
-        fn drop(&mut self, _proxy: Proxy<ClientDD>) {
+        fn drop(&mut self, _dd: ClientDD) {
             unimplemented!()
         }
 
-        fn selection(&mut self, _proxy: Proxy<ClientDD>, _id: Option<Proxy<ClientDO>>) {
+        fn selection(&mut self, _dd: ClientDD, _id: Option<ClientDO>) {
             unimplemented!()
         }
     }

--- a/tests/server_global_filter.rs
+++ b/tests/server_global_filter.rs
@@ -71,9 +71,7 @@ fn global_filter() {
 
 #[test]
 fn global_filter_try_force() {
-    use wayc::protocol::wl_display::RequestsTrait as DisplayRequests;
     use wayc::protocol::wl_output::WlOutput;
-    use wayc::protocol::wl_registry::RequestsTrait as RegistryRequests;
 
     use std::os::unix::io::IntoRawFd;
 

--- a/tests/server_resources.rs
+++ b/tests/server_resources.rs
@@ -44,7 +44,7 @@ fn resource_equals() {
     let cloned = outputs_lock[0].clone();
     assert!(outputs_lock[0] == cloned);
 
-    assert!(outputs_lock[0].same_client_as(&outputs_lock[1]));
+    assert!(outputs_lock[0].as_ref().same_client_as(outputs_lock[1].as_ref()));
 }
 
 #[test]
@@ -78,10 +78,10 @@ fn resource_user_data() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let outputs_lock = outputs.lock().unwrap();
-    assert!(outputs_lock[0].user_data::<usize>() == Some(&1000));
-    assert!(outputs_lock[1].user_data::<usize>() == Some(&1001));
+    assert!(outputs_lock[0].as_ref().user_data::<usize>() == Some(&1000));
+    assert!(outputs_lock[1].as_ref().user_data::<usize>() == Some(&1001));
     let cloned = outputs_lock[0].clone();
-    assert!(cloned.user_data::<usize>() == Some(&1000));
+    assert!(cloned.as_ref().user_data::<usize>() == Some(&1000));
 }
 
 #[cfg(not(feature = "native_lib"))]
@@ -114,11 +114,11 @@ fn resource_user_data_wrong_thread() {
     let output = outputs.lock().unwrap().take().unwrap();
 
     // we can access on the right thread
-    assert!(output.user_data::<usize>().is_some());
+    assert!(output.as_ref().user_data::<usize>().is_some());
 
     // but not in a new one
     ::std::thread::spawn(move || {
-        assert!(output.user_data::<usize>().is_none());
+        assert!(output.as_ref().user_data::<usize>().is_none());
     })
     .join()
     .unwrap();
@@ -171,9 +171,9 @@ fn dead_resources() {
 
     let cloned = {
         let outputs_lock = outputs.lock().unwrap();
-        assert!(outputs_lock[0].is_alive());
-        assert!(outputs_lock[1].is_alive());
-        outputs_lock[0].clone()
+        assert!(outputs_lock[0].as_ref().is_alive());
+        assert!(outputs_lock[1].as_ref().is_alive());
+        outputs_lock[0].as_ref().clone()
     };
 
     client_output1.release();
@@ -182,8 +182,8 @@ fn dead_resources() {
 
     {
         let outputs_lock = outputs.lock().unwrap();
-        assert!(!outputs_lock[0].is_alive());
-        assert!(outputs_lock[1].is_alive());
+        assert!(!outputs_lock[0].as_ref().is_alive());
+        assert!(outputs_lock[1].as_ref().is_alive());
         assert!(!cloned.is_alive());
     }
 }

--- a/tests/server_resources.rs
+++ b/tests/server_resources.rs
@@ -127,9 +127,9 @@ fn resource_user_data_wrong_thread() {
 #[cfg(not(feature = "native_lib"))]
 #[test]
 fn resource_implement_wrong_thread() {
-    let mut server = TestServer::new();
+    let server = TestServer::new();
 
-    let (s1, s2) = ::std::os::unix::net::UnixStream::pair().unwrap();
+    let (s1, _) = ::std::os::unix::net::UnixStream::pair().unwrap();
     let my_client = unsafe { server.display.create_client(s1.into_raw_fd()) };
 
     let ret = ::std::thread::spawn(move || {
@@ -144,7 +144,6 @@ fn resource_implement_wrong_thread() {
 
 #[test]
 fn dead_resources() {
-    use self::wayc::protocol::wl_output::RequestsTrait;
     let mut server = TestServer::new();
 
     let outputs = Arc::new(Mutex::new(Vec::new()));

--- a/wayland-client/examples/dynamic_globals.rs
+++ b/wayland-client/examples/dynamic_globals.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate wayland_client;
 
-use wayland_client::{Display, GlobalManager, Proxy};
+use wayland_client::{Display, GlobalManager};
 
 use wayland_client::protocol::wl_output::{Mode, Subpixel, Transform, WlOutput};
 use wayland_client::protocol::{wl_output, wl_seat};
@@ -22,7 +22,7 @@ struct OutputHandler {
 impl wl_output::EventHandler for OutputHandler {
     fn geometry(
         &mut self,
-        _proxy: Proxy<WlOutput>,
+        _output: WlOutput,
         x: i32,
         y: i32,
         physical_width: i32,
@@ -40,15 +40,15 @@ impl wl_output::EventHandler for OutputHandler {
         self.name = format!("{} ({})", make, model);
     }
 
-    fn mode(&mut self, _proxy: Proxy<WlOutput>, flags: Mode, width: i32, height: i32, refresh: i32) {
+    fn mode(&mut self, _output: WlOutput, flags: Mode, width: i32, height: i32, refresh: i32) {
         self.modes.push((flags, width, height, refresh));
     }
 
-    fn scale(&mut self, _proxy: Proxy<WlOutput>, factor: i32) {
+    fn scale(&mut self, _output: WlOutput, factor: i32) {
         self.scale = factor;
     }
 
-    fn done(&mut self, _proxy: Proxy<WlOutput>) {
+    fn done(&mut self, _output: WlOutput) {
         println!("Modesetting information for output \"{}\"", self.name);
         println!(" -> scaling factor: {}", self.scale);
         println!(" -> mode list:");

--- a/wayland-client/examples/simple_window.rs
+++ b/wayland-client/examples/simple_window.rs
@@ -8,14 +8,8 @@ use std::os::unix::io::AsRawFd;
 
 use byteorder::{NativeEndian, WriteBytesExt};
 
-use wayland_client::protocol::wl_compositor::RequestsTrait as CompositorRequests;
-use wayland_client::protocol::wl_shell::RequestsTrait as ShellRequests;
-use wayland_client::protocol::wl_shell_surface::RequestsTrait as ShellSurfaceRequests;
-use wayland_client::protocol::wl_shm::RequestsTrait as ShmRequests;
-use wayland_client::protocol::wl_shm_pool::RequestsTrait as PoolRequests;
-use wayland_client::protocol::wl_surface::RequestsTrait as SurfaceRequests;
-use wayland_client::protocol::{wl_compositor, wl_seat, wl_shell, wl_shell_surface, wl_shm};
-use wayland_client::{Display, GlobalManager, Proxy};
+use wayland_client::protocol::{wl_compositor, wl_seat, wl_shell, wl_shm};
+use wayland_client::{Display, GlobalManager};
 
 fn main() {
     let (display, mut event_queue) = Display::connect_to_env().unwrap();
@@ -91,8 +85,8 @@ fn main() {
     let shell_surface = shell
         .get_shell_surface(&surface, |shellsurface| {
             shellsurface.implement_closure(
-                |event, shell_surface: Proxy<wl_shell_surface::WlShellSurface>| {
-                    use wayland_client::protocol::wl_shell_surface::{Event, RequestsTrait};
+                |event, shell_surface| {
+                    use wayland_client::protocol::wl_shell_surface::Event;
                     // This ping/pong mechanism is used by the wayland server to detect
                     // unresponsive applications
                     if let Event::Ping { serial } = event {
@@ -117,14 +111,12 @@ fn main() {
     let mut pointer_created = false;
     globals.instantiate_auto::<wl_seat::WlSeat, _>(|seat| {
         seat.implement_closure(
-            move |event, seat: Proxy<wl_seat::WlSeat>| {
+            move |event, seat| {
                 // The capabilities of a seat are known at runtime and we retrieve
                 // them via an events. 3 capabilities exists: pointer, keyboard, and touch
                 // we are only interested in pointer here
                 use wayland_client::protocol::wl_pointer::Event as PointerEvent;
-                use wayland_client::protocol::wl_seat::{
-                    Capability, Event as SeatEvent, RequestsTrait as SeatRequests,
-                };
+                use wayland_client::protocol::wl_seat::{Capability, Event as SeatEvent};
 
                 if let SeatEvent::Capabilities { capabilities } = event {
                     if !pointer_created && capabilities.contains(Capability::Pointer) {

--- a/wayland-client/src/display.rs
+++ b/wayland-client/src/display.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use nix::fcntl;
 
-use {EventQueue, Proxy};
+use EventQueue;
 
 use imp::DisplayInner;
 
@@ -186,8 +186,8 @@ impl Display {
 }
 
 impl Deref for Display {
-    type Target = Proxy<::protocol::wl_display::WlDisplay>;
-    fn deref(&self) -> &Proxy<::protocol::wl_display::WlDisplay> {
+    type Target = ::protocol::wl_display::WlDisplay;
+    fn deref(&self) -> &::protocol::wl_display::WlDisplay {
         self.inner.get_proxy()
     }
 }

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -150,7 +150,8 @@ pub mod cursor;
 #[cfg(feature = "egl")]
 pub mod egl;
 
-pub use wayland_commons::{AnonymousObject, Interface, MessageGroup, NoMessage};
+pub use anonymous_object::AnonymousObject;
+pub use wayland_commons::{Interface, MessageGroup, NoMessage};
 
 // rust implementation
 #[cfg(not(feature = "native_lib"))]
@@ -192,18 +193,59 @@ mod generated {
     pub mod c_api {
         pub(crate) use wayland_commons::map::{Object, ObjectMetadata};
         pub(crate) use wayland_commons::wire::{Argument, ArgumentType, Message, MessageDesc};
-        pub(crate) use wayland_commons::{AnonymousObject, Interface, MessageGroup};
+        pub(crate) use wayland_commons::{Interface, MessageGroup};
         pub(crate) use wayland_sys as sys;
-        pub(crate) use {HandledBy, NewProxy, Proxy, ProxyMap};
+        pub(crate) use {AnonymousObject, HandledBy, NewProxy, Proxy, ProxyMap};
         include!(concat!(env!("OUT_DIR"), "/wayland_c_api.rs"));
     }
     #[cfg(not(feature = "native_lib"))]
     pub mod rust_api {
         pub(crate) use wayland_commons::map::{Object, ObjectMetadata};
         pub(crate) use wayland_commons::wire::{Argument, ArgumentType, Message, MessageDesc};
-        pub(crate) use wayland_commons::{AnonymousObject, Interface, MessageGroup};
-        pub(crate) use {HandledBy, NewProxy, Proxy, ProxyMap};
+        pub(crate) use wayland_commons::{Interface, MessageGroup};
+        pub(crate) use {AnonymousObject, HandledBy, NewProxy, Proxy, ProxyMap};
         include!(concat!(env!("OUT_DIR"), "/wayland_rust_api.rs"));
+    }
+}
+
+mod anonymous_object {
+    use super::{Interface, NoMessage, Proxy};
+
+    /// Anonymous interface
+    ///
+    /// A special Interface implementation representing an
+    /// handle to an object for which the interface is not known.
+    #[derive(Clone, Eq, PartialEq)]
+    pub struct AnonymousObject(Proxy<AnonymousObject>);
+
+    impl Interface for AnonymousObject {
+        type Request = NoMessage;
+        type Event = NoMessage;
+        const NAME: &'static str = "<anonymous>";
+        const VERSION: u32 = 0;
+        #[cfg(feature = "native_lib")]
+        fn c_interface() -> *const ::sys::common::wl_interface {
+            ::std::ptr::null()
+        }
+    }
+
+    impl AsRef<Proxy<AnonymousObject>> for AnonymousObject {
+        #[inline]
+        fn as_ref(&self) -> &Proxy<Self> {
+            &self.0
+        }
+    }
+    impl From<Proxy<AnonymousObject>> for AnonymousObject {
+        #[inline]
+        fn from(proxy: Proxy<Self>) -> Self {
+            AnonymousObject(proxy)
+        }
+    }
+    impl From<AnonymousObject> for Proxy<AnonymousObject> {
+        #[inline]
+        fn from(value: AnonymousObject) -> Self {
+            value.0
+        }
     }
 }
 

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -3,10 +3,10 @@
 //! ## Overview
 //!
 //! This crate provides the interfaces and machinery to safely create
-//! client applications for the wayland protocol. It is a rust wrapper
+//! client applications for the Wayland protocol. It is a rust wrapper
 //! around the `libwayland-client.so` C library.
 //!
-//! The wayland protocol revolves around the creation of various objects
+//! The Wayland protocol revolves around the creation of various objects
 //! and the exchange of messages associated to these objects. The initial
 //! object is always the `Display`, that you get at initialization of the
 //! connection, exposed by this crate as `Display::connect_to_env()`.
@@ -14,65 +14,63 @@
 //! ## Protocol and messages handling model
 //!
 //! The protocol being bi-directional, you can send and receive messages.
-//! Sending messages is done via methods of `Proxy<_>` objects, receiving
-//! and handling them is done by providing implementations.
+//! Sending messages is done via methods of Rust objects corresponding to the wayland protocol
+//! objects, receiving and handling them is done by providing implementations.
 //!
 //! ### Proxies
 //!
-//! Wayland protocol objects are represented in this crate by `Proxy<I>`
-//! objects, where `I` is a type representing the interface of the considered
-//! object. And object's interface (think "class" in an object-oriented context)
-//! defines which messages it can send and receive.
+//! The underlying representation of Wayland protocol objects in this crate is `Proxy<I>`,
+//! where `I` is the type of the considered Rust object. An object's interface (think "class"
+//! in an object-oriented context) defines which messages it can send and receive.
 //!
-//! These proxies are used to send messages to the server (in the wayland context,
-//! these are called "requests"). To do so, you need to import the appropriate
-//! extension trait adding these methods. For example, to use a `Proxy<WlSurface>`,
-//! you need to import `protocol::wl_surface::RequestsTrait` from this crate.
+//! These proxies are used to send messages to the server (in the Wayland context,
+//! these are called "requests"). You usually don't use them directly, and instead call
+//! methods on the Rust objects themselves, which invoke the appropriate `Proxy` methods.
 //! It is also possible to directly use the `Proxy::<I>::send(..)` method, but
 //! this should only be done carefully: using it improperly can mess the protocol
 //! state and cause protocol errors, which are fatal to the connection (the server
 //! will kill you).
 //!
-//! There is not a 1 to 1 mapping between `Proxy<I>` instances and protocol
-//! objects. Rather, you can think of `Proxy<I>` as an `Rc`-like handle to a
-//! wayland object. Multiple instances of it can exist referring to the same
+//! There is not a 1 to 1 mapping between Rust object instances and protocol
+//! objects. Rather, you can think of the Rust objects as `Rc`-like handles to a
+//! Wayland object. Multiple instances of a Rust object can exist referring to the same
 //! protocol object.
 //!
-//! Similarly, the lifetimes of the protocol objects and the `Proxy<I>` are
+//! Similarly, the lifetimes of the protocol objects and the Rust objects are
 //! not tightly tied. As protocol objects are created and destroyed by protocol
 //! messages, it can happen that an object gets destroyed while one or more
-//! `Proxy<I>` still refers to it. In such case, these proxies will be disabled
-//! and their `alive()` method will start to return `false`. Trying to send messages
-//! with them will also fail.
+//! Rust objects still refer to it. In such case, these Rust objects will be disabled
+//! and the `alive()` method on the underlying `Proxy<I>` will start to return `false`.
+//! Trying to send messages with them will also fail.
 //!
 //! ### Implementations
 //!
-//! To receive and process messages from the server to you (in wayland context they are
-//! called "events"), you need to provide an `Implementation` for each wayland object
+//! To receive and process messages from the server to you (in Wayland context they are
+//! called "events"), you need to provide an `Implementation` for each Wayland object
 //! created in the protocol session. Whenever a new protocol object is created, you will
 //! receive a `NewProxy<I>` object. Providing an implementation via its `implement()` method
-//! will turn it into a regular `Proxy<I>` object.
+//! will turn it into a regular Rust object.
 //!
 //! **All objects must be implemented**, even if it is an implementation doing nothing.
 //! Failure to do so (by dropping the `NewProxy<I>` for example) can cause future fatal
 //! errors if the server tries to send an event to this object.
 //!
 //! An implementation is a struct implementing the `EventHandler` trait for the interface
-//! of the considered object. Alternatively, an `FnMut(I::Event, Proxy<I>)` closure can be
+//! of the considered object. Alternatively, an `FnMut(I::Event, I)` closure can be
 //! used with the `implement_closure()` method, where `I` is the interface
 //! of the considered object.
 //!
 //! ## Event Queues
 //!
-//! The wayland client machinery provides the possibility to have one or more event queues
-//! handling the processing of received messages. All wayland objects are associated to an
+//! The Wayland client machinery provides the possibility to have one or more event queues
+//! handling the processing of received messages. All Wayland objects are associated to an
 //! event queue, which controls when its events are dispatched.
 //!
 //! Events received from the server are stored in an internal buffer, and processed (by calling
 //! the appropriate implementations) when the associated event queue is dispatched.
 //!
 //! A default event queue is created at the same time as the initial `Display`, and by default
-//! whenever a wayland object is created, it inherits the queue of its parent (the object that sent
+//! whenever a Wayland object is created, it inherits the queue of its parent (the object that sent
 //! or receive the message that created the new object). It means that if you only plan to use the
 //! default event queue, you don't need to worry about assigning objects to their queues.
 //!
@@ -82,7 +80,7 @@
 //!
 //! ## Dynamic linking with `libwayland-client.so`
 //!
-//! If you need to gracefully handle the case of a system on which wayland is not installed (by
+//! If you need to gracefully handle the case of a system on which Wayland is not installed (by
 //! fallbacking to X11 for example), you can do so by activating the `dlopen` cargo feature.
 //!
 //! When this is done, the library will be loaded a runtime rather than directly linked. And trying
@@ -96,7 +94,7 @@
 //! - the `cursor` feature will try to load `libwayland-cursor.so`, a library helping with loading
 //!   system themed cursor textures, to integrate your app in the system theme.
 //! - the `egl` feature will try to load `libwayland-egl.so`, a library allowing the creation of
-//!   OpenGL surface from wayland surfaces.
+//!   OpenGL surface from Wayland surfaces.
 //!
 //! Both of them will also be loaded at runtime if the `dlopen` feature was provided. See their
 //! respective submodules for details about their use.

--- a/wayland-client/src/proxy.rs
+++ b/wayland-client/src/proxy.rs
@@ -21,9 +21,9 @@ use ProxyMap;
 /// tied to the lifetime of these handles, but rather to sending or
 /// receiving destroying messages.
 ///
-/// These handles are notably used to send requests to the server. To do
-/// you need to import the associated `RequestsTrait` trait from the module
-/// of this interface.
+/// These handles are notably used to send requests to the server. To do this
+/// you need to convert them to the corresponding Rust object (using `.into()`)
+/// and use methods on the Rust object.
 pub struct Proxy<I: Interface> {
     _i: ::std::marker::PhantomData<&'static I>,
     pub(crate) inner: ProxyInner,
@@ -58,7 +58,7 @@ impl<I: Interface> Proxy<I> {
     ///
     /// **Warning:** This method is mostly intended to be used by code generated
     /// by `wayland-scanner`, and you should probably never need to use it directly,
-    /// but rather use the appropriate `RequestsTrait` for your proxy.
+    /// but rather use the appropriate methods on the Rust object.
     ///
     /// This is the generic method to send requests.
     ///
@@ -71,7 +71,7 @@ impl<I: Interface> Proxy<I> {
     ///
     /// **Warning:** This method is mostly intended to be used by code generated
     /// by `wayland-scanner`, and you should probably never need to use it directly,
-    /// but rather use the appropriate `RequestsTrait` for your proxy.
+    /// but rather use the appropriate methods on the Rust object.
     ///
     /// This is the generic method to send requests that create objects
     ///
@@ -139,7 +139,7 @@ impl<I: Interface> Proxy<I> {
     ///
     /// **Warning:** This method is mostly intended to be used by code generated
     /// by `wayland-scanner`, and you should probably never need to use it directly,
-    /// but rather use the appropriate `RequestsTrait` for your proxy.
+    /// but rather use the appropriate methods on the Rust object.
     ///
     /// This creates a new wayland object, considered as a
     /// child of this object. It will notably inherit its interface
@@ -191,7 +191,7 @@ impl<I: Interface> Proxy<I> {
     ///
     /// **Warning:** This method is mostly intended to be used by code generated
     /// by `wayland-scanner`, and you should probably never need to use it directly,
-    /// but rather use the appropriate `RequestsTrait` for your proxy.
+    /// but rather use the appropriate methods on the Rust object.
     pub fn child_placeholder<J: Interface + From<Proxy<J>>>(&self) -> J {
         Proxy::wrap(self.inner.child_placeholder()).into()
     }
@@ -263,7 +263,7 @@ impl Proxy<::protocol::wl_display::WlDisplay> {
 /// receive it as a `NewProxy`. You then have to provide an
 /// implementation for it, in order to process the incoming
 /// events it may receive. Once this done you will be able
-/// to use it as a regular `Proxy`.
+/// to use it as a regular Rust object.
 ///
 /// Implementations are structs implementing the appropriate
 /// variant of the `Implementation` trait. They can also be

--- a/wayland-client/src/rust_imp/display.rs
+++ b/wayland-client/src/rust_imp/display.rs
@@ -15,7 +15,7 @@ use super::EventQueueInner;
 
 pub(crate) struct DisplayInner {
     connection: Arc<Mutex<Connection>>,
-    proxy: Proxy<WlDisplay>,
+    proxy: WlDisplay,
 }
 
 impl DisplayInner {
@@ -45,8 +45,8 @@ impl DisplayInner {
                     eprintln!(
                         "[wayland-client] Protocol error {} on object {}@{}: {}",
                         code,
-                        object_id.inner.object.interface,
-                        object_id.id(),
+                        object_id.as_ref().inner.object.interface,
+                        object_id.as_ref().id(),
                         message
                     );
                     *impl_last_error.lock().unwrap() = Some(super::connection::Error::Protocol);
@@ -71,7 +71,7 @@ impl DisplayInner {
         let default_event_queue = EventQueueInner::new(connection.clone(), None);
 
         let display = DisplayInner {
-            proxy: Proxy::wrap(display_proxy.make_wrapper(&default_event_queue).unwrap()),
+            proxy: Proxy::wrap(display_proxy.make_wrapper(&default_event_queue).unwrap()).into(),
             connection,
         };
 
@@ -90,7 +90,7 @@ impl DisplayInner {
         EventQueueInner::new(me.connection.clone(), None)
     }
 
-    pub(crate) fn get_proxy(&self) -> &Proxy<WlDisplay> {
+    pub(crate) fn get_proxy(&self) -> &WlDisplay {
         &self.proxy
     }
 }

--- a/wayland-client/src/rust_imp/proxy.rs
+++ b/wayland-client/src/rust_imp/proxy.rs
@@ -300,7 +300,8 @@ impl NewProxyInner {
         user_data: UserData,
     ) -> ProxyInner
     where
-        F: FnMut(I::Event, Proxy<I>) + 'static,
+        F: FnMut(I::Event, I) + 'static,
+        I: From<Proxy<I>>,
         I::Event: MessageGroup<Map = super::ProxyMap>,
     {
         let object = self.map.lock().unwrap().with(self.id, |obj| {

--- a/wayland-client/src/rust_imp/queues.rs
+++ b/wayland-client/src/rust_imp/queues.rs
@@ -154,15 +154,16 @@ impl EventQueueInner {
 
     pub(crate) fn sync_roundtrip(&self) -> io::Result<u32> {
         use protocol::wl_callback::{Event as CbEvent, WlCallback};
-        use protocol::wl_display::{RequestsTrait as DisplayRequests, WlDisplay};
+        use protocol::wl_display::WlDisplay;
         use Proxy;
         // first retrieve the display and make a wrapper for it in this event queue
-        let display: Proxy<WlDisplay> = Proxy::wrap(
+        let display: WlDisplay = Proxy::wrap(
             ProxyInner::from_id(1, self.map.clone(), self.connection.clone())
                 .unwrap()
                 .make_wrapper(self)
                 .unwrap(),
-        );
+        )
+        .into();
 
         let done = Rc::new(Cell::new(false));
         let ret = display.sync(|np| {
@@ -175,6 +176,7 @@ impl EventQueueInner {
                     UserData::empty(),
                 )
             })
+            .into()
         });
 
         if let Err(()) = ret {

--- a/wayland-commons/src/lib.rs
+++ b/wayland-commons/src/lib.rs
@@ -93,25 +93,8 @@ pub trait Interface: 'static {
     fn c_interface() -> *const ::syscom::wl_interface;
 }
 
-/// Anonymous interface
-///
-/// A special Interface implementation representing an
-/// handle to an object for which the interface is not known.
-pub struct AnonymousObject;
-
 /// An empty enum representing a MessageGroup with no messages
 pub enum NoMessage {}
-
-impl Interface for AnonymousObject {
-    type Request = NoMessage;
-    type Event = NoMessage;
-    const NAME: &'static str = "<anonymous>";
-    const VERSION: u32 = 0;
-    #[cfg(feature = "native_lib")]
-    fn c_interface() -> *const ::syscom::wl_interface {
-        ::std::ptr::null()
-    }
-}
 
 #[cfg_attr(tarpaulin, skip)]
 impl MessageGroup for NoMessage {

--- a/wayland-protocols/src/protocol_macro.rs
+++ b/wayland-protocols/src/protocol_macro.rs
@@ -19,9 +19,9 @@ macro_rules! wayland_protocol(
             #[cfg(feature = "client")]
             pub mod client {
                 //! Client-side API of this protocol
-                pub(crate) use wayland_client::{NewProxy, Proxy, ProxyMap, HandledBy};
+                pub(crate) use wayland_client::{NewProxy, Proxy, ProxyMap, HandledBy, AnonymousObject};
                 pub(crate) use wayland_commons::map::{Object, ObjectMetadata};
-                pub(crate) use wayland_commons::{AnonymousObject, Interface, MessageGroup};
+                pub(crate) use wayland_commons::{Interface, MessageGroup};
                 pub(crate) use wayland_commons::wire::{Argument, MessageDesc, ArgumentType, Message};
                 pub(crate) use wayland_client::protocol::{$($import),*};
                 $(
@@ -33,9 +33,9 @@ macro_rules! wayland_protocol(
             #[cfg(feature = "server")]
             pub mod server {
                 //! Server-side API of this protocol
-                pub(crate) use wayland_server::{NewResource, Resource, ResourceMap, HandledBy};
+                pub(crate) use wayland_server::{AnonymousObject, NewResource, Resource, ResourceMap, HandledBy};
                 pub(crate) use wayland_commons::map::{Object, ObjectMetadata};
-                pub(crate) use wayland_commons::{AnonymousObject, Interface, MessageGroup};
+                pub(crate) use wayland_commons::{Interface, MessageGroup};
                 pub(crate) use wayland_commons::wire::{Argument, MessageDesc, ArgumentType, Message};
                 pub(crate) use wayland_server::protocol::{$($import),*};
                 $(
@@ -68,9 +68,9 @@ macro_rules! wayland_protocol(
             #[cfg(feature = "client")]
             pub mod client {
                 //! Client-side API of this protocol
-                pub(crate) use wayland_client::{NewProxy, Proxy, ProxyMap, HandledBy};
+                pub(crate) use wayland_client::{NewProxy, Proxy, ProxyMap, HandledBy, AnonymousObject};
                 pub(crate) use wayland_commons::map::{Object, ObjectMetadata};
-                pub(crate) use wayland_commons::{AnonymousObject, Interface, MessageGroup};
+                pub(crate) use wayland_commons::{Interface, MessageGroup};
                 pub(crate) use wayland_commons::wire::{Argument, MessageDesc, ArgumentType, Message};
                 pub(crate) use wayland_sys as sys;
                 pub(crate) use wayland_client::protocol::{$($import),*};
@@ -83,9 +83,9 @@ macro_rules! wayland_protocol(
             #[cfg(feature = "server")]
             pub mod server {
                 //! Server-side API of this protocol
-                pub(crate) use wayland_server::{NewResource, Resource, ResourceMap, HandledBy};
+                pub(crate) use wayland_server::{AnonymousObject, NewResource, Resource, ResourceMap, HandledBy};
                 pub(crate) use wayland_commons::map::{Object, ObjectMetadata};
-                pub(crate) use wayland_commons::{AnonymousObject, Interface, MessageGroup};
+                pub(crate) use wayland_commons::{Interface, MessageGroup};
                 pub(crate) use wayland_commons::wire::{Argument, MessageDesc, ArgumentType, Message};
                 pub(crate) use wayland_sys as sys;
                 pub(crate) use wayland_server::protocol::{$($import),*};

--- a/wayland-scanner/src/c_code_gen.rs
+++ b/wayland-scanner/src/c_code_gen.rs
@@ -154,7 +154,10 @@ fn messagegroup_c_addon(name: &Ident, side: Side, receiver: bool, messages: &[Me
                     let len = Literal::usize_unsuffixed(msg.args.len());
 
                     let fields = msg.args.iter().enumerate().map(|(j, arg)| {
-                        let field_name = Ident::new(&arg.name, Span::call_site());
+                let field_name = Ident::new(
+                    &format!("{}{}", if is_keyword(&arg.name) { "_" } else { "" }, arg.name),
+                    Span::call_site(),
+                );
 
                         let idx = Literal::usize_unsuffixed(j);
                         let field_value = match arg.typ {
@@ -333,10 +336,12 @@ fn messagegroup_c_addon(name: &Ident, side: Side, receiver: bool, messages: &[Me
             let pattern = if msg.args.is_empty() {
                 quote!(#name::#msg_name)
             } else {
-                let fields = msg
-                    .args
-                    .iter()
-                    .map(|arg| Ident::new(&arg.name, Span::call_site()));
+                let fields = msg.args.iter().map(|arg| {
+                    Ident::new(
+                        &format!("{}{}", if is_keyword(&arg.name) { "_" } else { "" }, arg.name),
+                        Span::call_site(),
+                    )
+                });
 
                 quote!(#name::#msg_name { #(#fields),* })
             };
@@ -353,7 +358,10 @@ fn messagegroup_c_addon(name: &Ident, side: Side, receiver: bool, messages: &[Me
             let mut j = 0;
             let args_array_init_stmts = msg.args.iter().map(|arg| {
                 let idx = Literal::usize_unsuffixed(j);
-                let arg_name = Ident::new(&arg.name, Span::call_site());
+                let arg_name = Ident::new(
+                    &format!("{}{}", if is_keyword(&arg.name) { "_" } else { "" }, arg.name),
+                    Span::call_site(),
+                );
 
                 let res = match arg.typ {
                     Type::Uint => {

--- a/wayland-scanner/src/c_code_gen.rs
+++ b/wayland-scanner/src/c_code_gen.rs
@@ -38,6 +38,7 @@ pub(crate) fn generate_protocol_client(protocol: Protocol) -> TokenStream {
             &iface.name,
             iface.version,
             Some(interface_c_addon(&iface.name)),
+            Side::Client,
         );
 
         let client_methods = gen_client_methods(&iface_name, &iface.requests);
@@ -106,6 +107,7 @@ pub(crate) fn generate_protocol_server(protocol: Protocol) -> TokenStream {
                 &iface.name,
                 iface.version,
                 Some(interface_c_addon(&iface.name)),
+                Side::Server,
             );
             let event_handler_trait = gen_event_handler_trait(&iface_name, &iface.requests, Side::Server);
             let sinces = gen_since_constants(&iface.requests, &iface.events);

--- a/wayland-scanner/src/common_gen.rs
+++ b/wayland-scanner/src/common_gen.rs
@@ -626,11 +626,35 @@ pub(crate) fn gen_interface(
     low_name: &str,
     version: u32,
     addon: Option<TokenStream>,
+    side: Side,
 ) -> TokenStream {
+    let object_type = side.object_name();
     let version_lit = Literal::u32_unsuffixed(version);
 
     quote! {
-        pub struct #name;
+        #[derive(Clone, Eq, PartialEq)]
+        pub struct #name(#object_type<#name>);
+
+        impl AsRef<#object_type<#name>> for #name {
+            #[inline]
+            fn as_ref(&self) -> &#object_type<Self> {
+                &self.0
+            }
+        }
+
+        impl From<#object_type<#name>> for #name {
+            #[inline]
+            fn from(value: #object_type<Self>) -> Self {
+                #name(value)
+            }
+        }
+
+        impl From<#name> for #object_type<#name> {
+            #[inline]
+            fn from(value: #name) -> Self {
+                value.0
+            }
+        }
 
         impl Interface for #name {
             type Request = Request;

--- a/wayland-scanner/src/rust_code_gen.rs
+++ b/wayland-scanner/src/rust_code_gen.rs
@@ -31,6 +31,7 @@ pub(crate) fn generate_protocol_client(protocol: Protocol) -> TokenStream {
             &iface.name,
             iface.version,
             None,
+            Side::Client,
         );
         let client_methods = gen_client_methods(&iface_name, &iface.requests);
         let event_handler_trait = gen_event_handler_trait(
@@ -92,6 +93,7 @@ pub(crate) fn generate_protocol_server(protocol: Protocol) -> TokenStream {
                 &iface.name,
                 iface.version,
                 None,
+                Side::Server,
             );
             let request_handler_trait = gen_event_handler_trait(&iface_name, &iface.requests, Side::Server);
             let sinces = gen_since_constants(&iface.requests, &iface.events);

--- a/wayland-scanner/src/rust_code_gen.rs
+++ b/wayland-scanner/src/rust_code_gen.rs
@@ -33,7 +33,7 @@ pub(crate) fn generate_protocol_client(protocol: Protocol) -> TokenStream {
             None,
             Side::Client,
         );
-        let client_methods = gen_client_methods(&iface_name, &iface.requests);
+        let object_methods = gen_object_methods(&iface_name, &iface.requests, Side::Client);
         let event_handler_trait = gen_event_handler_trait(
             &iface_name, &iface.events, Side::Client);
         let sinces = gen_since_constants(&iface.requests, &iface.events);
@@ -50,7 +50,7 @@ pub(crate) fn generate_protocol_client(protocol: Protocol) -> TokenStream {
                 #requests
                 #events
                 #interface
-                #client_methods
+                #object_methods
                 #event_handler_trait
                 #sinces
             }
@@ -95,6 +95,7 @@ pub(crate) fn generate_protocol_server(protocol: Protocol) -> TokenStream {
                 None,
                 Side::Server,
             );
+            let object_methods = gen_object_methods(&iface_name, &iface.events, Side::Server);
             let request_handler_trait = gen_event_handler_trait(&iface_name, &iface.requests, Side::Server);
             let sinces = gen_since_constants(&iface.requests, &iface.events);
 
@@ -110,6 +111,7 @@ pub(crate) fn generate_protocol_server(protocol: Protocol) -> TokenStream {
                     #requests
                     #events
                     #interface
+                    #object_methods
                     #request_handler_trait
                     #sinces
                 }

--- a/wayland-scanner/src/util.rs
+++ b/wayland-scanner/src/util.rs
@@ -12,13 +12,20 @@ pub fn is_keyword(txt: &str) -> bool {
         | "let" | "loop" | "macro" | "match" | "mod" | "move" | "mut" | "offsetof" | "override" | "priv"
         | "proc" | "pub" | "pure" | "ref" | "return" | "Self" | "self" | "sizeof" | "static" | "struct"
         | "super" | "trait" | "true" | "type" | "typeof" | "unsafe" | "unsized" | "use" | "virtual"
-        | "where" | "while" | "yield" => true,
+        | "where" | "while" | "yield" | "__handler" | "__object" => true,
+        _ => false,
+    }
+}
+
+pub fn is_camel_keyword(txt: &str) -> bool {
+    match txt {
+        "Self" => true,
         _ => false,
     }
 }
 
 pub fn snake_to_camel(input: &str) -> String {
-    input
+    let result = input
         .split('_')
         .flat_map(|s| {
             let mut first = true;
@@ -31,7 +38,13 @@ pub fn snake_to_camel(input: &str) -> String {
                 }
             })
         })
-        .collect()
+        .collect::<String>();
+
+    if is_camel_keyword(&result) {
+        format!("_{}", &result)
+    } else {
+        result
+    }
 }
 
 pub fn dotted_to_relname(input: &str) -> TokenStream {

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -94,8 +94,9 @@ pub use display::Display;
 pub use globals::Global;
 pub use resource::{HandledBy, NewResource, Resource};
 
+pub use anonymous_object::AnonymousObject;
 pub use wayland_commons::utils::UserDataMap;
-pub use wayland_commons::{AnonymousObject, Interface, MessageGroup, NoMessage};
+pub use wayland_commons::{Interface, MessageGroup, NoMessage};
 
 #[cfg(feature = "native_lib")]
 /// C-associated types
@@ -139,18 +140,59 @@ mod generated {
     pub mod c_api {
         pub(crate) use wayland_commons::map::{Object, ObjectMetadata};
         pub(crate) use wayland_commons::wire::{Argument, ArgumentType, Message, MessageDesc};
-        pub(crate) use wayland_commons::{AnonymousObject, Interface, MessageGroup};
+        pub(crate) use wayland_commons::{Interface, MessageGroup};
         pub(crate) use wayland_sys as sys;
-        pub(crate) use {HandledBy, NewResource, Resource, ResourceMap};
+        pub(crate) use {AnonymousObject, HandledBy, NewResource, Resource, ResourceMap};
         include!(concat!(env!("OUT_DIR"), "/wayland_c_api.rs"));
     }
     #[cfg(not(feature = "native_lib"))]
     pub mod rust_api {
         pub(crate) use wayland_commons::map::{Object, ObjectMetadata};
         pub(crate) use wayland_commons::wire::{Argument, ArgumentType, Message, MessageDesc};
-        pub(crate) use wayland_commons::{AnonymousObject, Interface, MessageGroup};
-        pub(crate) use {HandledBy, NewResource, Resource, ResourceMap};
+        pub(crate) use wayland_commons::{Interface, MessageGroup};
+        pub(crate) use {AnonymousObject, HandledBy, NewResource, Resource, ResourceMap};
         include!(concat!(env!("OUT_DIR"), "/wayland_rust_api.rs"));
+    }
+}
+
+mod anonymous_object {
+    use super::{Interface, NoMessage, Resource};
+
+    /// Anonymous interface
+    ///
+    /// A special Interface implementation representing an
+    /// handle to an object for which the interface is not known.
+    #[derive(Clone, Eq, PartialEq)]
+    pub struct AnonymousObject(Resource<AnonymousObject>);
+
+    impl Interface for AnonymousObject {
+        type Request = NoMessage;
+        type Event = NoMessage;
+        const NAME: &'static str = "<anonymous>";
+        const VERSION: u32 = 0;
+        #[cfg(feature = "native_lib")]
+        fn c_interface() -> *const ::sys::common::wl_interface {
+            ::std::ptr::null()
+        }
+    }
+
+    impl AsRef<Resource<AnonymousObject>> for AnonymousObject {
+        #[inline]
+        fn as_ref(&self) -> &Resource<Self> {
+            &self.0
+        }
+    }
+    impl From<Resource<AnonymousObject>> for AnonymousObject {
+        #[inline]
+        fn from(resource: Resource<Self>) -> Self {
+            AnonymousObject(resource)
+        }
+    }
+    impl From<AnonymousObject> for Resource<AnonymousObject> {
+        #[inline]
+        fn from(value: AnonymousObject) -> Self {
+            value.0
+        }
     }
 }
 

--- a/wayland-server/src/resource.rs
+++ b/wayland-server/src/resource.rs
@@ -18,7 +18,9 @@ use imp::{NewResourceInner, ResourceInner};
 /// receiving destroying messages.
 ///
 /// These handles are notably used to send events to the associated client,
-/// via the `send` method.
+/// via the `send` method, although you're encouraged to use methods on the
+/// corresponding Rust objects instead. To convert a `Resource<I>` into the
+/// `I` Rust object, use the `.into()` method.
 pub struct Resource<I: Interface> {
     _i: ::std::marker::PhantomData<&'static I>,
     inner: ResourceInner,
@@ -168,7 +170,7 @@ impl<I: Interface> Resource<I> {
 /// receive it as a `NewResource`. You then have to provide an
 /// implementation for it, in order to process the incoming
 /// events it may receive. Once this done you will be able
-/// to use it as a regular `Resource`.
+/// to use it as a regular Rust object.
 ///
 /// Implementations are structs implementing the appropriate
 /// variant of the `Implementation` trait. They can also be

--- a/wayland-server/src/rust_imp/clients.rs
+++ b/wayland-server/src/rust_imp/clients.rs
@@ -557,7 +557,7 @@ impl super::Dispatcher for DisplayDispatcher {
                     if let Some(cb) = map.get_new::<wl_callback::WlCallback>(new_id) {
                         let cb = cb.implement_dummy();
                         // TODO: send a more meaningful serial ?
-                        cb.send(wl_callback::Event::Done { callback_data: 0 });
+                        cb.as_ref().send(wl_callback::Event::Done { callback_data: 0 });
                     } else {
                         return Err(());
                     }

--- a/wayland-server/src/rust_imp/resources.rs
+++ b/wayland-server/src/rust_imp/resources.rs
@@ -164,15 +164,16 @@ impl NewResourceInner {
         self.client.loop_thread == ::std::thread::current().id()
     }
 
-    pub(crate) unsafe fn implement<I: Interface, F, Dest>(
+    pub(crate) unsafe fn implement<I: Interface + From<Resource<I>>, F, Dest>(
         self,
         implementation: F,
         destructor: Option<Dest>,
         user_data: UserData,
     ) -> ResourceInner
     where
-        F: FnMut(I::Request, Resource<I>) + 'static,
-        Dest: FnMut(Resource<I>) + 'static,
+        F: FnMut(I::Request, I) + 'static,
+        Dest: FnMut(I) + 'static,
+        I: From<Resource<I>>,
         I::Request: MessageGroup<Map = super::ResourceMap>,
     {
         let object = self.map.lock().unwrap().with(self.id, |obj| {


### PR DESCRIPTION
As proposed in https://github.com/Smithay/wayland-rs/issues/228#issuecomment-456297566.

This refactor removes `RequestsTrait`s and moves their methods onto the interface objects themselves. The interface objects contain the corresponding proxies. The end results are:
- It is no longer needed to use `RequestsTrait`s of all objects that requests are sent from, thus lots of boilerplate and renaming (all `RequestsTrait`s clash with each other) is avoided.
- A lot of `Proxy<Interface>` types in the client code are replaced with simply `Interface` which makes the types less complex and easier to understand.

Update of examples and tests is separated into its own commit, check it to see the client code changes.

TODO: update top-level docs on `wayland-client` and the changelog.