### PR TITLE
Introduce event iterators & sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
   or method names in the protocol were Rust keywords.
 - [commons] Properly close FDs we dup-ed after sending them to the server, to avoid leaking
   open FDs.
+- [commons/client] Introduce message iterators and message sinks, allowing to opt-in into an
+  iterator-based handling of messages.
 
 ## 0.21.11 -- 2019-01-19
 

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -148,6 +148,8 @@ pub mod cursor;
 #[cfg(feature = "egl")]
 pub mod egl;
 
+pub mod sinks;
+
 pub use anonymous_object::AnonymousObject;
 pub use wayland_commons::{Interface, MessageGroup, NoMessage};
 

--- a/wayland-client/src/sinks.rs
+++ b/wayland-client/src/sinks.rs
@@ -1,0 +1,165 @@
+//! Message sinks
+//!
+//! The Wayland model naturally uses callbacks to handle the message you receive from the server.
+//! However in some contexts, an iterator-based interface may be more practical to use, this is
+//! what this module provides.
+//!
+//! The `message_iterator` function allows you to create a new message iterator. It is just a
+//! regular MPSC, however its sending end (the `Sink<T>`) can be directly used as an implementation
+//! for Wayland objects. This just requires that `T: From<(I::Event, I)>` (where `I` is the
+//! interface of the object you're trying to implement). The `event_enum!` macro is provided to
+//! easily generate an appropriate type joining events from different interfaces into a single
+//! iterator.
+//!
+//! The `blocking_message_iterator` function is very similar, except the created message iterator
+//! will be linked to an event queue, and will block on it rather than returning `None`, and is
+//! thus able to drive an event loop.
+
+use std::rc::Rc;
+
+use wayland_commons::Interface;
+
+use imp::EventQueueInner;
+use {HandledBy, QueueToken};
+
+pub use wayland_commons::sinks::{message_iterator, MsgIter, Sink};
+
+impl<M, I> HandledBy<Sink<M>> for I
+where
+    I: Interface,
+    M: From<(I::Event, I)>,
+{
+    fn handle(sink: &mut Sink<M>, event: I::Event, proxy: I) {
+        sink.push((event, proxy));
+    }
+}
+
+/// A message iterator linked to an event queue
+///
+/// Like a `MsgIter<T>`, but it is linked with an event queue, and
+/// will `dispatch()` and block instead of returning `None` if no
+/// events are pending.
+pub struct BlockingMsgIter<T> {
+    evt_queue: Rc<EventQueueInner>,
+    iter: MsgIter<T>,
+}
+
+impl<T> Iterator for BlockingMsgIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        loop {
+            match self.iter.next() {
+                Some(msg) => return Some(msg),
+                None => {
+                    self.evt_queue
+                        .dispatch()
+                        .expect("Connection to the wayland server lost.");
+                }
+            }
+        }
+    }
+}
+
+/// Create a blokcing message iterator
+///
+/// Contrarily to `message_iterator`, this one will block on the event queue
+/// represented by the provided token rather than returning `None` if no event is available.
+pub fn blocking_message_iterator<T>(token: QueueToken) -> (Sink<T>, BlockingMsgIter<T>) {
+    let (sink, iter) = message_iterator();
+    (
+        sink,
+        BlockingMsgIter {
+            iter,
+            evt_queue: token.inner,
+        },
+    )
+}
+
+/// Generate an enum joining several objects events
+///
+/// This macro allows you to easily create a enum type for use with your message iterators. It is
+/// used like so:
+///
+/// ```ignore
+/// event_enum!(
+///     MyEnum |
+///     Pointer => WlPointer,
+///     Keyboard => WlKeyboard,
+///     Surface => WlSurface
+/// );
+/// ```
+///
+/// This will generate the following enum, unifying the events from each of the provided interface:
+///
+/// ```ignore
+/// pub enum MyEnum {
+///     Pointer { event: WlPointer::Event, object: WlPointer },
+///     Keyboard { event: WlKeyboard::Event, object: WlKeyboard },
+///     Surface { event: WlSurface::Event, object: WlSurface }
+/// }
+/// ```
+///
+/// It will also generate the appropriate `From<_>` implementation so that a `Sink<MyEnum>` can be
+/// used as an implementation for `WlPointer`, `WlKeyboard` and `WlSurface`.
+///
+/// If you want to add custom messages to the enum, the macro also supports it:
+///
+/// ```ignore
+/// event_enum!(
+///     MyEnum |
+///     Pointer => WlPointer,
+///     Keyboard => WlKeyboard,
+///     Surface => WlSurface |
+///     MyMessage => SomeType,
+///     OtherMessage => OtherType
+/// );
+/// ```
+///
+/// will generate the following enum:
+///
+/// ```ignore
+/// pub enum MyEnum {
+///     Pointer { event: WlPointer::Event, object: WlPointer },
+///     Keyboard { event: WlKeyboard::Event, object: WlKeyboard },
+///     Surface { event: WlSurface::Event, object: WlSurface },
+///     MyMessage(SomeType),
+///     OtherMessage(OtherType)
+/// }
+/// ```
+///
+/// as well as implementations of `From<SomeType>` and `From<OtherType>`, so that these types can
+/// directly be provided into a `Sink<MyEnum>`.
+
+#[macro_export]
+macro_rules! event_enum(
+    ($enu:ident | $($evt_name:ident => $iface:ty),*) => {
+        event_enum!($enu | $($evt_name => $iface),* | );
+    };
+    ($enu:ident | $($evt_name:ident => $iface:ty),* | $($name:ident => $value:ty),*) => {
+        pub enum $enu {
+            $(
+                $evt_name { event: <$iface as $crate::Interface>::Event, object: $iface },
+            )*
+            $(
+                $name($value)
+            )*
+        }
+
+        $(
+            impl From<(<$iface as $crate::Interface>::Event, $iface)> for $enu {
+                fn from((event, object): (<$iface as $crate::Interface>::Event, $iface)) -> $enu {
+                    $enu::$evt_name { event, object }
+                }
+            }
+        )*
+
+        $(
+            impl From<$value> for $enu {
+                fn from(value: $value) -> $enu {
+                    $enu::$name(value)
+                }
+            }
+        )*
+    };
+);

--- a/wayland-commons/src/lib.rs
+++ b/wayland-commons/src/lib.rs
@@ -24,6 +24,7 @@ use std::os::raw::c_void;
 use wayland_sys::common as syscom;
 
 pub mod map;
+pub mod sinks;
 pub mod socket;
 pub mod utils;
 pub mod wire;

--- a/wayland-commons/src/sinks.rs
+++ b/wayland-commons/src/sinks.rs
@@ -1,0 +1,67 @@
+//! Message sinks
+//!
+//! This is a common implementation re-used by wayland-client and wayland-server. See
+//! their respective documentation for their use.
+
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::rc::{Rc, Weak};
+
+/// The sink end of an message iterator.
+///
+/// This sink can be cloned and provided as implementation for wayland objects
+/// as long as `T: From<I::Event>` or `T: From<I::Request>` (depending on whether
+/// you are client-side or server-side).
+pub struct Sink<T> {
+    queue: Weak<RefCell<VecDeque<T>>>,
+}
+
+impl<T> Sink<T> {
+    /// Push a new message to the associated message iterator
+    ///
+    /// If the iterator was dropped (and is thus no longer capable of
+    /// retrieving it), the message will be silently dropped instead.
+    pub fn push<U: Into<T>>(&self, msg: U) {
+        if let Some(queue) = self.queue.upgrade() {
+            queue.borrow_mut().push_back(msg.into())
+        }
+    }
+}
+
+impl<T> Clone for Sink<T> {
+    fn clone(&self) -> Sink<T> {
+        Sink {
+            queue: self.queue.clone(),
+        }
+    }
+}
+
+/// A message iterator
+///
+/// It yields the various messages that have been pushed to it from its associated
+/// sinks, in a MPSC fashion.
+///
+/// It returning `None` via the `Iterator` trait only means that no message is
+/// pending. It may start yielding new messages afterwards. It never blocks.
+pub struct MsgIter<T> {
+    queue: Rc<RefCell<VecDeque<T>>>,
+}
+
+impl<T> Iterator for MsgIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        self.queue.borrow_mut().pop_front()
+    }
+}
+
+/// Create a new message iterator and an associated sink.
+pub fn message_iterator<T>() -> (Sink<T>, MsgIter<T>) {
+    let queue = Rc::new(RefCell::new(VecDeque::new()));
+    (
+        Sink {
+            queue: Rc::downgrade(&queue),
+        },
+        MsgIter { queue },
+    )
+}


### PR DESCRIPTION
This is the last outstanding point of #228 , this allows downstream users to opt-in to an iterator-based event handling for some of their Wayland objects.

Also introduces an adapter in wayland-client that links an event iterator to an event queue, so that it will block on it if there are no pending events.