### PR TITLE
GlobalManager updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@
   which could cause `wayland-client` to unexpectedly panic.
 - **Breaking** [client/server] Update the core protocol to 1.16
 - [protocols] Introduce misc/gtk-primary-selection
+- **Breaking** [client] Lifted the thread-safety bound on `GlobalManager`. This
+  means that the closure given to `GlobalManager::new_with_cb()` no longer
+  needs to be `Send`.
 
 ## 0.21.11 -- 2019-01-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
 - **Breaking** [client] Lifted the thread-safety bound on `GlobalManager`. This
   means that the closure given to `GlobalManager::new_with_cb()` no longer
   needs to be `Send`.
+- [client] Added an explicit `.expect()` to binding in the `global_filter!()`
+  macro. This gets rid of the warning when using `global_filter!()`.
 
 ## 0.21.11 -- 2019-01-19
 

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -325,7 +325,8 @@ macro_rules! global_filter {
                                 version,
                                 id,
                                 |newp| GlobalImplementor::<$interface>::new_global(&mut cb, newp)
-                            );
+                            )
+                            .expect("wl_registry died unexpectedly");
                         }
                     }) as Box<_>
                 ));


### PR DESCRIPTION
- drop the `Send` bounds,
- fix the warning in `global_filter!()`.