### PR TITLE
Future proof protocol updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
   start).
 - [scanner] Generate `__nonexaustive` variants to protocol enums to match semver guarantees of protocols
 - [client] replace `GlobalManager::instantiate_auto` with `GlobalManager::instanciate_range`
+- [client/server] Check that versions of messages are correctly respected on objects
 
 ## 0.21.11 -- 2019-01-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
   macro. This gets rid of the warning when using `global_filter!()`.
 - [client/server] `WAYLAND_DEBUG` output will now be directed to stderr (as it should have been from the
   start).
+- [scanner] Generate `__nonexaustive` variants to protocol enums to match semver guarantees of protocols
+- [client] replace `GlobalManager::instantiate_auto` with `GlobalManager::instanciate_range`
 
 ## 0.21.11 -- 2019-01-19
 

--- a/tests/client_proxies.rs
+++ b/tests/client_proxies.rs
@@ -20,11 +20,11 @@ fn proxy_equals() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let compositor1 = manager
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<wl_compositor::WlCompositor, _>(1, |newp| newp.implement_dummy())
         .unwrap();
 
     let compositor2 = manager
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<wl_compositor::WlCompositor, _>(1, |newp| newp.implement_dummy())
         .unwrap();
 
     let compositor3 = compositor1.clone();
@@ -45,14 +45,14 @@ fn proxy_user_data() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let compositor1 = manager
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| {
+        .instantiate_exact::<wl_compositor::WlCompositor, _>(1, |newp| {
             newp.implement_closure(|_, _| {}, 0xDEADBEEFusize)
         })
         .unwrap();
     let compositor1 = compositor1.as_ref();
 
     let compositor2 = manager
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| {
+        .instantiate_exact::<wl_compositor::WlCompositor, _>(1, |newp| {
             newp.implement_closure(|_, _| {}, 0xBADC0FFEusize)
         })
         .unwrap();
@@ -78,7 +78,7 @@ fn proxy_user_data_wrong_thread() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let compositor: Proxy<_> = manager
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| {
+        .instantiate_exact::<wl_compositor::WlCompositor, _>(1, |newp| {
             newp.implement_closure(|_, _| {}, 0xDEADBEEFusize)
         })
         .unwrap()
@@ -133,7 +133,7 @@ fn proxy_implement_wrong_thread() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let compositor = manager
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<wl_compositor::WlCompositor, _>(1, |newp| newp.implement_dummy())
         .unwrap();
 
     let ret = ::std::thread::spawn(move || {
@@ -160,7 +160,7 @@ fn proxy_implement_wrapper_threaded() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let compositor = manager
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<wl_compositor::WlCompositor, _>(1, |newp| newp.implement_dummy())
         .unwrap();
 
     let display2 = client.display.clone();
@@ -189,7 +189,7 @@ fn proxy_implement_threadsafe_wrong_thread() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let compositor = manager
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<wl_compositor::WlCompositor, _>(1, |newp| newp.implement_dummy())
         .unwrap();
 
     ::std::thread::spawn(move || {
@@ -212,7 +212,7 @@ fn dead_proxies() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let output = manager
-        .instantiate_auto::<wl_output::WlOutput, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<wl_output::WlOutput, _>(1, |newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();

--- a/tests/client_proxies.rs
+++ b/tests/client_proxies.rs
@@ -212,7 +212,7 @@ fn dead_proxies() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let output = manager
-        .instantiate_exact::<wl_output::WlOutput, _>(1, |newp| newp.implement_dummy())
+        .instantiate_exact::<wl_output::WlOutput, _>(3, |newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();

--- a/tests/destructors.rs
+++ b/tests/destructors.rs
@@ -33,7 +33,7 @@ fn resource_destructor() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let output = manager
-        .instantiate_auto::<WlOutput, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<WlOutput, _>(3, |newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();
@@ -70,7 +70,7 @@ fn resource_destructor_cleanup() {
     roundtrip(&mut client, &mut server).unwrap();
 
     manager
-        .instantiate_auto::<WlOutput, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<WlOutput, _>(3, |newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();
@@ -106,7 +106,7 @@ fn client_destructor_cleanup() {
     roundtrip(&mut client, &mut server).unwrap();
 
     manager
-        .instantiate_auto::<WlOutput, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<WlOutput, _>(3, |newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();

--- a/tests/globals.rs
+++ b/tests/globals.rs
@@ -107,7 +107,7 @@ fn global_manager_cb() {
 }
 
 #[test]
-fn auto_instantiate() {
+fn range_instantiate() {
     use wayc::protocol::wl_compositor::WlCompositor;
     use wayc::protocol::wl_output::WlOutput;
     use wayc::protocol::wl_shell::WlShell;
@@ -123,11 +123,11 @@ fn auto_instantiate() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let compositor = manager
-        .instantiate_auto::<WlCompositor, _>(|newp| newp.implement_dummy())
+        .instantiate_range::<WlCompositor, _>(1, 4, |newp| newp.implement_dummy())
         .unwrap();
     assert!(compositor.as_ref().version() == 4);
     let shell = manager
-        .instantiate_auto::<WlShell, _>(|newp| newp.implement_dummy())
+        .instantiate_range::<WlShell, _>(1, 3, |newp| newp.implement_dummy())
         .unwrap();
     assert!(shell.as_ref().version() == 1);
 
@@ -140,7 +140,8 @@ fn auto_instantiate() {
             == Err(GlobalError::Missing)
     );
     assert!(
-        manager.instantiate_auto::<WlOutput, _>(|newp| newp.implement_dummy()) == Err(GlobalError::Missing)
+        manager.instantiate_range::<WlOutput, _>(1, 3, |newp| newp.implement_dummy())
+            == Err(GlobalError::Missing)
     );
 }
 
@@ -260,11 +261,11 @@ fn two_step_binding() {
     roundtrip(&mut client, &mut server).unwrap();
 
     manager
-        .instantiate_auto::<WlCompositor, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<WlCompositor, _>(1, |newp| newp.implement_dummy())
         .unwrap();
 
     manager
-        .instantiate_auto::<WlOutput, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<WlOutput, _>(1, |newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();

--- a/tests/scanner.rs
+++ b/tests/scanner.rs
@@ -97,7 +97,7 @@ fn run_codegen_test(generated_file_path: &Path, expected_output: &str) {
             let mut actual_output = String::new();
             file.read_to_string(&mut actual_output).unwrap();
 
-            let changeset = Changeset::new(&actual_output, expected_output, "\n");
+            let changeset = Changeset::new(expected_output, &actual_output, "\n");
             if changeset.distance != 0 {
                 print_diff(&changeset.diffs);
                 panic!(

--- a/tests/scanner_assets/client_c_code.rs
+++ b/tests/scanner_assets/client_c_code.rs
@@ -88,6 +88,13 @@ pub mod wl_foo {
                 Request::CreateBar { .. } => 1,
             }
         }
+        fn since(&self) -> u32 {
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+                Request::FooIt { .. } => 1,
+                Request::CreateBar { .. } => 1,
+            }
+        }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
                 1 => Some(Object::from_interface::<super::wl_bar::WlBar>(
@@ -187,6 +194,12 @@ pub mod wl_foo {
             match *self {
                 Event::__nonexhaustive => unreachable!(),
                 Event::Cake { .. } => 0,
+            }
+        }
+        fn since(&self) -> u32 {
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+                Event::Cake { .. } => 2,
             }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
@@ -318,11 +331,11 @@ pub mod wl_foo {
         }
     }
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_FOO_IT_SINCE: u16 = 1u16;
+    pub const REQ_FOO_IT_SINCE: u32 = 1u32;
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_CREATE_BAR_SINCE: u16 = 1u16;
+    pub const REQ_CREATE_BAR_SINCE: u32 = 1u32;
     #[doc = r" The minimal object version supporting this event"]
-    pub const EVT_CAKE_SINCE: u16 = 2u16;
+    pub const EVT_CAKE_SINCE: u32 = 2u32;
 }
 #[doc = "Interface for bars\n\nThis interface allows you to bar your foos."]
 pub mod wl_bar {
@@ -400,6 +413,14 @@ pub mod wl_bar {
             match *self {
                 Request::__nonexhaustive => unreachable!(),
                 Request::BarDelivery { .. } => 0,
+                Request::Release => 1,
+                Request::_Self { .. } => 2,
+            }
+        }
+        fn since(&self) -> u32 {
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+                Request::BarDelivery { .. } => 2,
                 Request::Release => 1,
                 Request::_Self { .. } => 2,
             }
@@ -568,6 +589,12 @@ pub mod wl_bar {
             match *self {
                 Event::__nonexhaustive => unreachable!(),
                 Event::_Self { .. } => 0,
+            }
+        }
+        fn since(&self) -> u32 {
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+                Event::_Self { .. } => 2,
             }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
@@ -787,13 +814,13 @@ pub mod wl_bar {
         }
     }
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_BAR_DELIVERY_SINCE: u16 = 2u16;
+    pub const REQ_BAR_DELIVERY_SINCE: u32 = 2u32;
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_RELEASE_SINCE: u16 = 1u16;
+    pub const REQ_RELEASE_SINCE: u32 = 1u32;
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_SELF_SINCE: u16 = 2u16;
+    pub const REQ_SELF_SINCE: u32 = 2u32;
     #[doc = r" The minimal object version supporting this event"]
-    pub const EVT_SELF_SINCE: u16 = 2u16;
+    pub const EVT_SELF_SINCE: u32 = 2u32;
 }
 #[doc = "core global object\n\nThis global is special and should only generate code client-side, not server-side."]
 pub mod wl_display {
@@ -816,6 +843,11 @@ pub mod wl_display {
             }
         }
         fn opcode(&self) -> u16 {
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+            }
+        }
+        fn since(&self) -> u32 {
             match *self {
                 Request::__nonexhaustive => unreachable!(),
             }
@@ -862,6 +894,11 @@ pub mod wl_display {
             }
         }
         fn opcode(&self) -> u16 {
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+            }
+        }
+        fn since(&self) -> u32 {
             match *self {
                 Event::__nonexhaustive => unreachable!(),
             }
@@ -972,6 +1009,12 @@ pub mod wl_registry {
                 Request::Bind { .. } => 0,
             }
         }
+        fn since(&self) -> u32 {
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+                Request::Bind { .. } => 1,
+            }
+        }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
                 _ => None,
@@ -1033,6 +1076,11 @@ pub mod wl_registry {
             }
         }
         fn opcode(&self) -> u16 {
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+            }
+        }
+        fn since(&self) -> u32 {
             match *self {
                 Event::__nonexhaustive => unreachable!(),
             }
@@ -1124,7 +1172,7 @@ pub mod wl_registry {
         }
     }
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_BIND_SINCE: u16 = 1u16;
+    pub const REQ_BIND_SINCE: u32 = 1u32;
 }
 #[doc = "callback object\n\nThis object has a special behavior regarding its destructor."]
 pub mod wl_callback {
@@ -1147,6 +1195,11 @@ pub mod wl_callback {
             }
         }
         fn opcode(&self) -> u16 {
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+            }
+        }
+        fn since(&self) -> u32 {
             match *self {
                 Request::__nonexhaustive => unreachable!(),
             }
@@ -1203,6 +1256,12 @@ pub mod wl_callback {
             match *self {
                 Event::__nonexhaustive => unreachable!(),
                 Event::Done { .. } => 0,
+            }
+        }
+        fn since(&self) -> u32 {
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+                Event::Done { .. } => 1,
             }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
@@ -1297,5 +1356,5 @@ pub mod wl_callback {
         }
     }
     #[doc = r" The minimal object version supporting this event"]
-    pub const EVT_DONE_SINCE: u16 = 1u16;
+    pub const EVT_DONE_SINCE: u32 = 1u32;
 }

--- a/tests/scanner_assets/client_c_code.rs
+++ b/tests/scanner_assets/client_c_code.rs
@@ -16,6 +16,8 @@ pub mod wl_foo {
         Spicy = 1,
         #[doc = "fruity cake to get vitamins"]
         Fruity = 2,
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl CakeKind {
         pub fn from_raw(n: u32) -> Option<CakeKind> {
@@ -50,6 +52,8 @@ pub mod wl_foo {
         },
         #[doc = "create a bar\n\nCreate a bar which will do its bar job."]
         CreateBar { id: super::wl_bar::WlBar },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[
@@ -73,11 +77,13 @@ pub mod wl_foo {
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 _ => false,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::FooIt { .. } => 0,
                 Request::CreateBar { .. } => 1,
             }
@@ -96,6 +102,7 @@ pub mod wl_foo {
         }
         fn into_raw(self, sender_id: u32) -> Message {
             match self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::FooIt {
                     number,
                     unumber,
@@ -132,6 +139,7 @@ pub mod wl_foo {
             F: FnOnce(u32, &mut [wl_argument]) -> T,
         {
             match self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::FooIt {
                     number,
                     unumber,
@@ -159,6 +167,8 @@ pub mod wl_foo {
     pub enum Event {
         #[doc = "a cake is possible\n\nThe server advertises that a kind of cake is available\n\nOnly available since version 2 of the interface"]
         Cake { kind: CakeKind, amount: u32 },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Event {
         const MESSAGES: &'static [super::MessageDesc] = &[super::MessageDesc {
@@ -169,11 +179,13 @@ pub mod wl_foo {
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 _ => false,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::Cake { .. } => 0,
             }
         }
@@ -301,6 +313,7 @@ pub mod wl_foo {
         fn handle(__handler: &mut T, event: Event, __object: Self) {
             match event {
                 Event::Cake { kind, amount } => __handler.cake(__object, kind, amount),
+                Event::__nonexhaustive => unreachable!(),
             }
         }
     }
@@ -340,6 +353,8 @@ pub mod wl_bar {
             request: u32,
             event: u32,
         },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[
@@ -376,12 +391,14 @@ pub mod wl_bar {
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::Release => true,
                 _ => false,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::BarDelivery { .. } => 0,
                 Request::Release => 1,
                 Request::_Self { .. } => 2,
@@ -397,6 +414,7 @@ pub mod wl_bar {
         }
         fn into_raw(self, sender_id: u32) -> Message {
             match self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::BarDelivery {
                     kind,
                     target,
@@ -454,6 +472,7 @@ pub mod wl_bar {
             F: FnOnce(u32, &mut [wl_argument]) -> T,
         {
             match self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::BarDelivery {
                     kind,
                     target,
@@ -520,6 +539,8 @@ pub mod wl_bar {
             request: u32,
             event: u32,
         },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Event {
         const MESSAGES: &'static [super::MessageDesc] = &[super::MessageDesc {
@@ -539,11 +560,13 @@ pub mod wl_bar {
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 _ => false,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::_Self { .. } => 0,
             }
         }
@@ -759,6 +782,7 @@ pub mod wl_bar {
                 } => __handler._self(
                     __object, _self, _mut, object, ___object, handler, ___handler, request, event,
                 ),
+                Event::__nonexhaustive => unreachable!(),
             }
         }
     }
@@ -779,15 +803,22 @@ pub mod wl_display {
         AnonymousObject, Argument, ArgumentType, HandledBy, Interface, Message, MessageDesc, MessageGroup,
         NewProxy, Object, ObjectMetadata, Proxy,
     };
-    pub enum Request {}
+    pub enum Request {
+        #[doc(hidden)]
+        __nonexhaustive,
+    }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[];
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
-            match *self {}
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
         fn opcode(&self) -> u16 {
-            match *self {}
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
@@ -798,7 +829,9 @@ pub mod wl_display {
             panic!("Request::from_raw can not be used Client-side.")
         }
         fn into_raw(self, sender_id: u32) -> Message {
-            match self {}
+            match self {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
         unsafe fn from_raw_c(
             obj: *mut ::std::os::raw::c_void,
@@ -811,18 +844,27 @@ pub mod wl_display {
         where
             F: FnOnce(u32, &mut [wl_argument]) -> T,
         {
-            match self {}
+            match self {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
     }
-    pub enum Event {}
+    pub enum Event {
+        #[doc(hidden)]
+        __nonexhaustive,
+    }
     impl super::MessageGroup for Event {
         const MESSAGES: &'static [super::MessageDesc] = &[];
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
-            match *self {}
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+            }
         }
         fn opcode(&self) -> u16 {
-            match *self {}
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+            }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
@@ -888,7 +930,9 @@ pub mod wl_display {
     impl<T: EventHandler> HandledBy<T> for WlDisplay {
         #[inline]
         fn handle(__handler: &mut T, event: Event, __object: Self) {
-            match event {}
+            match event {
+                Event::__nonexhaustive => unreachable!(),
+            }
         }
     }
 }
@@ -906,6 +950,8 @@ pub mod wl_registry {
             name: u32,
             id: (String, u32, AnonymousObject),
         },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[super::MessageDesc {
@@ -916,11 +962,13 @@ pub mod wl_registry {
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 _ => false,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::Bind { .. } => 0,
             }
         }
@@ -934,6 +982,7 @@ pub mod wl_registry {
         }
         fn into_raw(self, sender_id: u32) -> Message {
             match self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::Bind { name, id } => Message {
                     sender_id: sender_id,
                     opcode: 0,
@@ -958,6 +1007,7 @@ pub mod wl_registry {
             F: FnOnce(u32, &mut [wl_argument]) -> T,
         {
             match self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::Bind { name, id } => {
                     let mut _args_array: [wl_argument; 4] = unsafe { ::std::mem::zeroed() };
                     _args_array[0].u = name;
@@ -970,15 +1020,22 @@ pub mod wl_registry {
             }
         }
     }
-    pub enum Event {}
+    pub enum Event {
+        #[doc(hidden)]
+        __nonexhaustive,
+    }
     impl super::MessageGroup for Event {
         const MESSAGES: &'static [super::MessageDesc] = &[];
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
-            match *self {}
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+            }
         }
         fn opcode(&self) -> u16 {
-            match *self {}
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+            }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
@@ -1061,7 +1118,9 @@ pub mod wl_registry {
     impl<T: EventHandler> HandledBy<T> for WlRegistry {
         #[inline]
         fn handle(__handler: &mut T, event: Event, __object: Self) {
-            match event {}
+            match event {
+                Event::__nonexhaustive => unreachable!(),
+            }
         }
     }
     #[doc = r" The minimal object version supporting this request"]
@@ -1075,15 +1134,22 @@ pub mod wl_callback {
         AnonymousObject, Argument, ArgumentType, HandledBy, Interface, Message, MessageDesc, MessageGroup,
         NewProxy, Object, ObjectMetadata, Proxy,
     };
-    pub enum Request {}
+    pub enum Request {
+        #[doc(hidden)]
+        __nonexhaustive,
+    }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[];
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
-            match *self {}
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
         fn opcode(&self) -> u16 {
-            match *self {}
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
@@ -1094,7 +1160,9 @@ pub mod wl_callback {
             panic!("Request::from_raw can not be used Client-side.")
         }
         fn into_raw(self, sender_id: u32) -> Message {
-            match self {}
+            match self {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
         unsafe fn from_raw_c(
             obj: *mut ::std::os::raw::c_void,
@@ -1107,12 +1175,16 @@ pub mod wl_callback {
         where
             F: FnOnce(u32, &mut [wl_argument]) -> T,
         {
-            match self {}
+            match self {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
     }
     pub enum Event {
         #[doc = "done event\n\nThis event is actually a destructor, but the protocol XML has no way of specifying it.\nAs such, the scanner should consider wl_callback.done as a special case.\n\nThis is a destructor, once received this object cannot be used any longer."]
         Done { callback_data: u32 },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Event {
         const MESSAGES: &'static [super::MessageDesc] = &[super::MessageDesc {
@@ -1123,11 +1195,13 @@ pub mod wl_callback {
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::Done { .. } => true,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::Done { .. } => 0,
             }
         }
@@ -1218,6 +1292,7 @@ pub mod wl_callback {
         fn handle(__handler: &mut T, event: Event, __object: Self) {
             match event {
                 Event::Done { callback_data } => __handler.done(__object, callback_data),
+                Event::__nonexhaustive => unreachable!(),
             }
         }
     }

--- a/tests/scanner_assets/client_rust_code.rs
+++ b/tests/scanner_assets/client_rust_code.rs
@@ -14,6 +14,8 @@ pub mod wl_foo {
         Spicy = 1,
         #[doc = "fruity cake to get vitamins"]
         Fruity = 2,
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl CakeKind {
         pub fn from_raw(n: u32) -> Option<CakeKind> {
@@ -48,6 +50,8 @@ pub mod wl_foo {
         },
         #[doc = "create a bar\n\nCreate a bar which will do its bar job."]
         CreateBar { id: super::wl_bar::WlBar },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[
@@ -71,11 +75,13 @@ pub mod wl_foo {
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 _ => false,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::FooIt { .. } => 0,
                 Request::CreateBar { .. } => 1,
             }
@@ -94,6 +100,7 @@ pub mod wl_foo {
         }
         fn into_raw(self, sender_id: u32) -> Message {
             match self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::FooIt {
                     number,
                     unumber,
@@ -122,6 +129,8 @@ pub mod wl_foo {
     pub enum Event {
         #[doc = "a cake is possible\n\nThe server advertises that a kind of cake is available\n\nOnly available since version 2 of the interface"]
         Cake { kind: CakeKind, amount: u32 },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Event {
         const MESSAGES: &'static [super::MessageDesc] = &[super::MessageDesc {
@@ -132,11 +141,13 @@ pub mod wl_foo {
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 _ => false,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::Cake { .. } => 0,
             }
         }
@@ -239,6 +250,7 @@ pub mod wl_foo {
         fn handle(__handler: &mut T, event: Event, __object: Self) {
             match event {
                 Event::Cake { kind, amount } => __handler.cake(__object, kind, amount),
+                Event::__nonexhaustive => unreachable!(),
             }
         }
     }
@@ -276,6 +288,8 @@ pub mod wl_bar {
             request: u32,
             event: u32,
         },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[
@@ -312,12 +326,14 @@ pub mod wl_bar {
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::Release => true,
                 _ => false,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::BarDelivery { .. } => 0,
                 Request::Release => 1,
                 Request::_Self { .. } => 2,
@@ -333,6 +349,7 @@ pub mod wl_bar {
         }
         fn into_raw(self, sender_id: u32) -> Message {
             match self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::BarDelivery {
                     kind,
                     target,
@@ -391,6 +408,8 @@ pub mod wl_bar {
             request: u32,
             event: u32,
         },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Event {
         const MESSAGES: &'static [super::MessageDesc] = &[super::MessageDesc {
@@ -410,11 +429,13 @@ pub mod wl_bar {
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 _ => false,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::_Self { .. } => 0,
             }
         }
@@ -599,6 +620,7 @@ pub mod wl_bar {
                 } => __handler._self(
                     __object, _self, _mut, object, ___object, handler, ___handler, request, event,
                 ),
+                Event::__nonexhaustive => unreachable!(),
             }
         }
     }
@@ -617,15 +639,22 @@ pub mod wl_display {
         AnonymousObject, Argument, ArgumentType, HandledBy, Interface, Message, MessageDesc, MessageGroup,
         NewProxy, Object, ObjectMetadata, Proxy,
     };
-    pub enum Request {}
+    pub enum Request {
+        #[doc(hidden)]
+        __nonexhaustive,
+    }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[];
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
-            match *self {}
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
         fn opcode(&self) -> u16 {
-            match *self {}
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
@@ -636,18 +665,27 @@ pub mod wl_display {
             panic!("Request::from_raw can not be used Client-side.")
         }
         fn into_raw(self, sender_id: u32) -> Message {
-            match self {}
+            match self {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
     }
-    pub enum Event {}
+    pub enum Event {
+        #[doc(hidden)]
+        __nonexhaustive,
+    }
     impl super::MessageGroup for Event {
         const MESSAGES: &'static [super::MessageDesc] = &[];
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
-            match *self {}
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+            }
         }
         fn opcode(&self) -> u16 {
-            match *self {}
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+            }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
@@ -695,7 +733,9 @@ pub mod wl_display {
     impl<T: EventHandler> HandledBy<T> for WlDisplay {
         #[inline]
         fn handle(__handler: &mut T, event: Event, __object: Self) {
-            match event {}
+            match event {
+                Event::__nonexhaustive => unreachable!(),
+            }
         }
     }
 }
@@ -711,6 +751,8 @@ pub mod wl_registry {
             name: u32,
             id: (String, u32, AnonymousObject),
         },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[super::MessageDesc {
@@ -721,11 +763,13 @@ pub mod wl_registry {
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 _ => false,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::Bind { .. } => 0,
             }
         }
@@ -739,6 +783,7 @@ pub mod wl_registry {
         }
         fn into_raw(self, sender_id: u32) -> Message {
             match self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::Bind { name, id } => Message {
                     sender_id: sender_id,
                     opcode: 0,
@@ -752,15 +797,22 @@ pub mod wl_registry {
             }
         }
     }
-    pub enum Event {}
+    pub enum Event {
+        #[doc(hidden)]
+        __nonexhaustive,
+    }
     impl super::MessageGroup for Event {
         const MESSAGES: &'static [super::MessageDesc] = &[];
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
-            match *self {}
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+            }
         }
         fn opcode(&self) -> u16 {
-            match *self {}
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+            }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
@@ -825,7 +877,9 @@ pub mod wl_registry {
     impl<T: EventHandler> HandledBy<T> for WlRegistry {
         #[inline]
         fn handle(__handler: &mut T, event: Event, __object: Self) {
-            match event {}
+            match event {
+                Event::__nonexhaustive => unreachable!(),
+            }
         }
     }
     #[doc = r" The minimal object version supporting this request"]
@@ -837,15 +891,22 @@ pub mod wl_callback {
         AnonymousObject, Argument, ArgumentType, HandledBy, Interface, Message, MessageDesc, MessageGroup,
         NewProxy, Object, ObjectMetadata, Proxy,
     };
-    pub enum Request {}
+    pub enum Request {
+        #[doc(hidden)]
+        __nonexhaustive,
+    }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[];
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
-            match *self {}
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
         fn opcode(&self) -> u16 {
-            match *self {}
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
@@ -856,12 +917,16 @@ pub mod wl_callback {
             panic!("Request::from_raw can not be used Client-side.")
         }
         fn into_raw(self, sender_id: u32) -> Message {
-            match self {}
+            match self {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
     }
     pub enum Event {
         #[doc = "done event\n\nThis event is actually a destructor, but the protocol XML has no way of specifying it.\nAs such, the scanner should consider wl_callback.done as a special case.\n\nThis is a destructor, once received this object cannot be used any longer."]
         Done { callback_data: u32 },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Event {
         const MESSAGES: &'static [super::MessageDesc] = &[super::MessageDesc {
@@ -872,11 +937,13 @@ pub mod wl_callback {
         type Map = super::ProxyMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::Done { .. } => true,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::Done { .. } => 0,
             }
         }
@@ -943,6 +1010,7 @@ pub mod wl_callback {
         fn handle(__handler: &mut T, event: Event, __object: Self) {
             match event {
                 Event::Done { callback_data } => __handler.done(__object, callback_data),
+                Event::__nonexhaustive => unreachable!(),
             }
         }
     }

--- a/tests/scanner_assets/client_rust_code.rs
+++ b/tests/scanner_assets/client_rust_code.rs
@@ -86,6 +86,13 @@ pub mod wl_foo {
                 Request::CreateBar { .. } => 1,
             }
         }
+        fn since(&self) -> u32 {
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+                Request::FooIt { .. } => 1,
+                Request::CreateBar { .. } => 1,
+            }
+        }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
                 1 => Some(Object::from_interface::<super::wl_bar::WlBar>(
@@ -149,6 +156,12 @@ pub mod wl_foo {
             match *self {
                 Event::__nonexhaustive => unreachable!(),
                 Event::Cake { .. } => 0,
+            }
+        }
+        fn since(&self) -> u32 {
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+                Event::Cake { .. } => 2,
             }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
@@ -255,11 +268,11 @@ pub mod wl_foo {
         }
     }
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_FOO_IT_SINCE: u16 = 1u16;
+    pub const REQ_FOO_IT_SINCE: u32 = 1u32;
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_CREATE_BAR_SINCE: u16 = 1u16;
+    pub const REQ_CREATE_BAR_SINCE: u32 = 1u32;
     #[doc = r" The minimal object version supporting this event"]
-    pub const EVT_CAKE_SINCE: u16 = 2u16;
+    pub const EVT_CAKE_SINCE: u32 = 2u32;
 }
 #[doc = "Interface for bars\n\nThis interface allows you to bar your foos."]
 pub mod wl_bar {
@@ -335,6 +348,14 @@ pub mod wl_bar {
             match *self {
                 Request::__nonexhaustive => unreachable!(),
                 Request::BarDelivery { .. } => 0,
+                Request::Release => 1,
+                Request::_Self { .. } => 2,
+            }
+        }
+        fn since(&self) -> u32 {
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+                Request::BarDelivery { .. } => 2,
                 Request::Release => 1,
                 Request::_Self { .. } => 2,
             }
@@ -437,6 +458,12 @@ pub mod wl_bar {
             match *self {
                 Event::__nonexhaustive => unreachable!(),
                 Event::_Self { .. } => 0,
+            }
+        }
+        fn since(&self) -> u32 {
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+                Event::_Self { .. } => 2,
             }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
@@ -625,13 +652,13 @@ pub mod wl_bar {
         }
     }
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_BAR_DELIVERY_SINCE: u16 = 2u16;
+    pub const REQ_BAR_DELIVERY_SINCE: u32 = 2u32;
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_RELEASE_SINCE: u16 = 1u16;
+    pub const REQ_RELEASE_SINCE: u32 = 1u32;
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_SELF_SINCE: u16 = 2u16;
+    pub const REQ_SELF_SINCE: u32 = 2u32;
     #[doc = r" The minimal object version supporting this event"]
-    pub const EVT_SELF_SINCE: u16 = 2u16;
+    pub const EVT_SELF_SINCE: u32 = 2u32;
 }
 #[doc = "core global object\n\nThis global is special and should only generate code client-side, not server-side."]
 pub mod wl_display {
@@ -652,6 +679,11 @@ pub mod wl_display {
             }
         }
         fn opcode(&self) -> u16 {
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+            }
+        }
+        fn since(&self) -> u32 {
             match *self {
                 Request::__nonexhaustive => unreachable!(),
             }
@@ -683,6 +715,11 @@ pub mod wl_display {
             }
         }
         fn opcode(&self) -> u16 {
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+            }
+        }
+        fn since(&self) -> u32 {
             match *self {
                 Event::__nonexhaustive => unreachable!(),
             }
@@ -773,6 +810,12 @@ pub mod wl_registry {
                 Request::Bind { .. } => 0,
             }
         }
+        fn since(&self) -> u32 {
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+                Request::Bind { .. } => 1,
+            }
+        }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
                 _ => None,
@@ -810,6 +853,11 @@ pub mod wl_registry {
             }
         }
         fn opcode(&self) -> u16 {
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+            }
+        }
+        fn since(&self) -> u32 {
             match *self {
                 Event::__nonexhaustive => unreachable!(),
             }
@@ -883,7 +931,7 @@ pub mod wl_registry {
         }
     }
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_BIND_SINCE: u16 = 1u16;
+    pub const REQ_BIND_SINCE: u32 = 1u32;
 }
 #[doc = "callback object\n\nThis object has a special behavior regarding its destructor."]
 pub mod wl_callback {
@@ -904,6 +952,11 @@ pub mod wl_callback {
             }
         }
         fn opcode(&self) -> u16 {
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+            }
+        }
+        fn since(&self) -> u32 {
             match *self {
                 Request::__nonexhaustive => unreachable!(),
             }
@@ -945,6 +998,12 @@ pub mod wl_callback {
             match *self {
                 Event::__nonexhaustive => unreachable!(),
                 Event::Done { .. } => 0,
+            }
+        }
+        fn since(&self) -> u32 {
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+                Event::Done { .. } => 1,
             }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
@@ -1015,5 +1074,5 @@ pub mod wl_callback {
         }
     }
     #[doc = r" The minimal object version supporting this event"]
-    pub const EVT_DONE_SINCE: u16 = 1u16;
+    pub const EVT_DONE_SINCE: u32 = 1u32;
 }

--- a/tests/scanner_assets/server_c_code.rs
+++ b/tests/scanner_assets/server_c_code.rs
@@ -16,6 +16,8 @@ pub mod wl_foo {
         Spicy = 1,
         #[doc = "fruity cake to get vitamins"]
         Fruity = 2,
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl CakeKind {
         pub fn from_raw(n: u32) -> Option<CakeKind> {
@@ -50,6 +52,8 @@ pub mod wl_foo {
         },
         #[doc = "create a bar\n\nCreate a bar which will do its bar job."]
         CreateBar { id: NewResource<super::wl_bar::WlBar> },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[
@@ -73,11 +77,13 @@ pub mod wl_foo {
         type Map = super::ResourceMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 _ => false,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::FooIt { .. } => 0,
                 Request::CreateBar { .. } => 1,
             }
@@ -204,6 +210,8 @@ pub mod wl_foo {
     pub enum Event {
         #[doc = "a cake is possible\n\nThe server advertises that a kind of cake is available\n\nOnly available since version 2 of the interface"]
         Cake { kind: CakeKind, amount: u32 },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Event {
         const MESSAGES: &'static [super::MessageDesc] = &[super::MessageDesc {
@@ -214,11 +222,13 @@ pub mod wl_foo {
         type Map = super::ResourceMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 _ => false,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::Cake { .. } => 0,
             }
         }
@@ -232,6 +242,7 @@ pub mod wl_foo {
         }
         fn into_raw(self, sender_id: u32) -> Message {
             match self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::Cake { kind, amount } => Message {
                     sender_id: sender_id,
                     opcode: 0,
@@ -251,6 +262,7 @@ pub mod wl_foo {
             F: FnOnce(u32, &mut [wl_argument]) -> T,
         {
             match self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::Cake { kind, amount } => {
                     let mut _args_array: [wl_argument; 2] = unsafe { ::std::mem::zeroed() };
                     _args_array[0].u = kind.to_raw();
@@ -327,6 +339,7 @@ pub mod wl_foo {
                     file,
                 } => __handler.foo_it(__object, number, unumber, text, float, file),
                 Request::CreateBar { id } => __handler.create_bar(__object, id),
+                Request::__nonexhaustive => unreachable!(),
             }
         }
     }
@@ -366,6 +379,8 @@ pub mod wl_bar {
             request: u32,
             event: u32,
         },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[
@@ -402,12 +417,14 @@ pub mod wl_bar {
         type Map = super::ResourceMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::Release => true,
                 _ => false,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::BarDelivery { .. } => 0,
                 Request::Release => 1,
                 Request::_Self { .. } => 2,
@@ -586,6 +603,8 @@ pub mod wl_bar {
             request: u32,
             event: u32,
         },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Event {
         const MESSAGES: &'static [super::MessageDesc] = &[super::MessageDesc {
@@ -605,11 +624,13 @@ pub mod wl_bar {
         type Map = super::ResourceMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 _ => false,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::_Self { .. } => 0,
             }
         }
@@ -623,6 +644,7 @@ pub mod wl_bar {
         }
         fn into_raw(self, sender_id: u32) -> Message {
             match self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::_Self {
                     _self,
                     _mut,
@@ -660,6 +682,7 @@ pub mod wl_bar {
             F: FnOnce(u32, &mut [wl_argument]) -> T,
         {
             match self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::_Self {
                     _self,
                     _mut,
@@ -791,6 +814,7 @@ pub mod wl_bar {
                 } => __handler._self(
                     __object, _self, _mut, object, ___object, handler, ___handler, request, event,
                 ),
+                Request::__nonexhaustive => unreachable!(),
             }
         }
     }
@@ -811,15 +835,22 @@ pub mod wl_callback {
         AnonymousObject, Argument, ArgumentType, HandledBy, Interface, Message, MessageDesc, MessageGroup,
         NewResource, Object, ObjectMetadata, Resource,
     };
-    pub enum Request {}
+    pub enum Request {
+        #[doc(hidden)]
+        __nonexhaustive,
+    }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[];
         type Map = super::ResourceMap;
         fn is_destructor(&self) -> bool {
-            match *self {}
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
         fn opcode(&self) -> u16 {
-            match *self {}
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
@@ -853,6 +884,8 @@ pub mod wl_callback {
     pub enum Event {
         #[doc = "done event\n\nThis event is actually a destructor, but the protocol XML has no way of specifying it.\nAs such, the scanner should consider wl_callback.done as a special case.\n\nThis is a destructor, once sent this object cannot be used any longer."]
         Done { callback_data: u32 },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Event {
         const MESSAGES: &'static [super::MessageDesc] = &[super::MessageDesc {
@@ -863,11 +896,13 @@ pub mod wl_callback {
         type Map = super::ResourceMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::Done { .. } => true,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::Done { .. } => 0,
             }
         }
@@ -881,6 +916,7 @@ pub mod wl_callback {
         }
         fn into_raw(self, sender_id: u32) -> Message {
             match self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::Done { callback_data } => Message {
                     sender_id: sender_id,
                     opcode: 0,
@@ -900,6 +936,7 @@ pub mod wl_callback {
             F: FnOnce(u32, &mut [wl_argument]) -> T,
         {
             match self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::Done { callback_data } => {
                     let mut _args_array: [wl_argument; 1] = unsafe { ::std::mem::zeroed() };
                     _args_array[0].u = callback_data;
@@ -951,7 +988,9 @@ pub mod wl_callback {
     impl<T: RequestHandler> HandledBy<T> for WlCallback {
         #[inline]
         fn handle(__handler: &mut T, request: Request, __object: Self) {
-            match request {}
+            match request {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
     }
     #[doc = r" The minimal object version supporting this event"]

--- a/tests/scanner_assets/server_c_code.rs
+++ b/tests/scanner_assets/server_c_code.rs
@@ -88,6 +88,13 @@ pub mod wl_foo {
                 Request::CreateBar { .. } => 1,
             }
         }
+        fn since(&self) -> u32 {
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+                Request::FooIt { .. } => 1,
+                Request::CreateBar { .. } => 1,
+            }
+        }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
                 1 => Some(Object::from_interface::<super::wl_bar::WlBar>(
@@ -232,6 +239,12 @@ pub mod wl_foo {
                 Event::Cake { .. } => 0,
             }
         }
+        fn since(&self) -> u32 {
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+                Event::Cake { .. } => 2,
+            }
+        }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
                 _ => None,
@@ -344,11 +357,11 @@ pub mod wl_foo {
         }
     }
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_FOO_IT_SINCE: u16 = 1u16;
+    pub const REQ_FOO_IT_SINCE: u32 = 1u32;
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_CREATE_BAR_SINCE: u16 = 1u16;
+    pub const REQ_CREATE_BAR_SINCE: u32 = 1u32;
     #[doc = r" The minimal object version supporting this event"]
-    pub const EVT_CAKE_SINCE: u16 = 2u16;
+    pub const EVT_CAKE_SINCE: u32 = 2u32;
 }
 #[doc = "Interface for bars\n\nThis interface allows you to bar your foos."]
 pub mod wl_bar {
@@ -426,6 +439,14 @@ pub mod wl_bar {
             match *self {
                 Request::__nonexhaustive => unreachable!(),
                 Request::BarDelivery { .. } => 0,
+                Request::Release => 1,
+                Request::_Self { .. } => 2,
+            }
+        }
+        fn since(&self) -> u32 {
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+                Request::BarDelivery { .. } => 2,
                 Request::Release => 1,
                 Request::_Self { .. } => 2,
             }
@@ -634,6 +655,12 @@ pub mod wl_bar {
                 Event::_Self { .. } => 0,
             }
         }
+        fn since(&self) -> u32 {
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+                Event::_Self { .. } => 2,
+            }
+        }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
                 _ => None,
@@ -819,13 +846,13 @@ pub mod wl_bar {
         }
     }
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_BAR_DELIVERY_SINCE: u16 = 2u16;
+    pub const REQ_BAR_DELIVERY_SINCE: u32 = 2u32;
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_RELEASE_SINCE: u16 = 1u16;
+    pub const REQ_RELEASE_SINCE: u32 = 1u32;
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_SELF_SINCE: u16 = 2u16;
+    pub const REQ_SELF_SINCE: u32 = 2u32;
     #[doc = r" The minimal object version supporting this event"]
-    pub const EVT_SELF_SINCE: u16 = 2u16;
+    pub const EVT_SELF_SINCE: u32 = 2u32;
 }
 #[doc = "callback object\n\nThis object has a special behavior regarding its destructor."]
 pub mod wl_callback {
@@ -848,6 +875,11 @@ pub mod wl_callback {
             }
         }
         fn opcode(&self) -> u16 {
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+            }
+        }
+        fn since(&self) -> u32 {
             match *self {
                 Request::__nonexhaustive => unreachable!(),
             }
@@ -904,6 +936,12 @@ pub mod wl_callback {
             match *self {
                 Event::__nonexhaustive => unreachable!(),
                 Event::Done { .. } => 0,
+            }
+        }
+        fn since(&self) -> u32 {
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+                Event::Done { .. } => 1,
             }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
@@ -994,5 +1032,5 @@ pub mod wl_callback {
         }
     }
     #[doc = r" The minimal object version supporting this event"]
-    pub const EVT_DONE_SINCE: u16 = 1u16;
+    pub const EVT_DONE_SINCE: u32 = 1u32;
 }

--- a/tests/scanner_assets/server_rust_code.rs
+++ b/tests/scanner_assets/server_rust_code.rs
@@ -14,6 +14,8 @@ pub mod wl_foo {
         Spicy = 1,
         #[doc = "fruity cake to get vitamins"]
         Fruity = 2,
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl CakeKind {
         pub fn from_raw(n: u32) -> Option<CakeKind> {
@@ -48,6 +50,8 @@ pub mod wl_foo {
         },
         #[doc = "create a bar\n\nCreate a bar which will do its bar job."]
         CreateBar { id: NewResource<super::wl_bar::WlBar> },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[
@@ -71,11 +75,13 @@ pub mod wl_foo {
         type Map = super::ResourceMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 _ => false,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::FooIt { .. } => 0,
                 Request::CreateBar { .. } => 1,
             }
@@ -155,6 +161,8 @@ pub mod wl_foo {
     pub enum Event {
         #[doc = "a cake is possible\n\nThe server advertises that a kind of cake is available\n\nOnly available since version 2 of the interface"]
         Cake { kind: CakeKind, amount: u32 },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Event {
         const MESSAGES: &'static [super::MessageDesc] = &[super::MessageDesc {
@@ -165,11 +173,13 @@ pub mod wl_foo {
         type Map = super::ResourceMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 _ => false,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::Cake { .. } => 0,
             }
         }
@@ -183,6 +193,7 @@ pub mod wl_foo {
         }
         fn into_raw(self, sender_id: u32) -> Message {
             match self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::Cake { kind, amount } => Message {
                     sender_id: sender_id,
                     opcode: 0,
@@ -255,6 +266,7 @@ pub mod wl_foo {
                     file,
                 } => __handler.foo_it(__object, number, unumber, text, float, file),
                 Request::CreateBar { id } => __handler.create_bar(__object, id),
+                Request::__nonexhaustive => unreachable!(),
             }
         }
     }
@@ -292,6 +304,8 @@ pub mod wl_bar {
             request: u32,
             event: u32,
         },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[
@@ -328,12 +342,14 @@ pub mod wl_bar {
         type Map = super::ResourceMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::Release => true,
                 _ => false,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Request::__nonexhaustive => unreachable!(),
                 Request::BarDelivery { .. } => 0,
                 Request::Release => 1,
                 Request::_Self { .. } => 2,
@@ -464,6 +480,8 @@ pub mod wl_bar {
             request: u32,
             event: u32,
         },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Event {
         const MESSAGES: &'static [super::MessageDesc] = &[super::MessageDesc {
@@ -483,11 +501,13 @@ pub mod wl_bar {
         type Map = super::ResourceMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 _ => false,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::_Self { .. } => 0,
             }
         }
@@ -501,6 +521,7 @@ pub mod wl_bar {
         }
         fn into_raw(self, sender_id: u32) -> Message {
             match self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::_Self {
                     _self,
                     _mut,
@@ -631,6 +652,7 @@ pub mod wl_bar {
                 } => __handler._self(
                     __object, _self, _mut, object, ___object, handler, ___handler, request, event,
                 ),
+                Request::__nonexhaustive => unreachable!(),
             }
         }
     }
@@ -649,15 +671,22 @@ pub mod wl_callback {
         AnonymousObject, Argument, ArgumentType, HandledBy, Interface, Message, MessageDesc, MessageGroup,
         NewResource, Object, ObjectMetadata, Resource,
     };
-    pub enum Request {}
+    pub enum Request {
+        #[doc(hidden)]
+        __nonexhaustive,
+    }
     impl super::MessageGroup for Request {
         const MESSAGES: &'static [super::MessageDesc] = &[];
         type Map = super::ResourceMap;
         fn is_destructor(&self) -> bool {
-            match *self {}
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
         fn opcode(&self) -> u16 {
-            match *self {}
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
@@ -676,6 +705,8 @@ pub mod wl_callback {
     pub enum Event {
         #[doc = "done event\n\nThis event is actually a destructor, but the protocol XML has no way of specifying it.\nAs such, the scanner should consider wl_callback.done as a special case.\n\nThis is a destructor, once sent this object cannot be used any longer."]
         Done { callback_data: u32 },
+        #[doc(hidden)]
+        __nonexhaustive,
     }
     impl super::MessageGroup for Event {
         const MESSAGES: &'static [super::MessageDesc] = &[super::MessageDesc {
@@ -686,11 +717,13 @@ pub mod wl_callback {
         type Map = super::ResourceMap;
         fn is_destructor(&self) -> bool {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::Done { .. } => true,
             }
         }
         fn opcode(&self) -> u16 {
             match *self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::Done { .. } => 0,
             }
         }
@@ -704,6 +737,7 @@ pub mod wl_callback {
         }
         fn into_raw(self, sender_id: u32) -> Message {
             match self {
+                Event::__nonexhaustive => unreachable!(),
                 Event::Done { callback_data } => Message {
                     sender_id: sender_id,
                     opcode: 0,
@@ -752,7 +786,9 @@ pub mod wl_callback {
     impl<T: RequestHandler> HandledBy<T> for WlCallback {
         #[inline]
         fn handle(__handler: &mut T, request: Request, __object: Self) {
-            match request {}
+            match request {
+                Request::__nonexhaustive => unreachable!(),
+            }
         }
     }
     #[doc = r" The minimal object version supporting this event"]

--- a/tests/scanner_assets/server_rust_code.rs
+++ b/tests/scanner_assets/server_rust_code.rs
@@ -86,6 +86,13 @@ pub mod wl_foo {
                 Request::CreateBar { .. } => 1,
             }
         }
+        fn since(&self) -> u32 {
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+                Request::FooIt { .. } => 1,
+                Request::CreateBar { .. } => 1,
+            }
+        }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
                 1 => Some(Object::from_interface::<super::wl_bar::WlBar>(
@@ -183,6 +190,12 @@ pub mod wl_foo {
                 Event::Cake { .. } => 0,
             }
         }
+        fn since(&self) -> u32 {
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+                Event::Cake { .. } => 2,
+            }
+        }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
                 _ => None,
@@ -271,11 +284,11 @@ pub mod wl_foo {
         }
     }
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_FOO_IT_SINCE: u16 = 1u16;
+    pub const REQ_FOO_IT_SINCE: u32 = 1u32;
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_CREATE_BAR_SINCE: u16 = 1u16;
+    pub const REQ_CREATE_BAR_SINCE: u32 = 1u32;
     #[doc = r" The minimal object version supporting this event"]
-    pub const EVT_CAKE_SINCE: u16 = 2u16;
+    pub const EVT_CAKE_SINCE: u32 = 2u32;
 }
 #[doc = "Interface for bars\n\nThis interface allows you to bar your foos."]
 pub mod wl_bar {
@@ -351,6 +364,14 @@ pub mod wl_bar {
             match *self {
                 Request::__nonexhaustive => unreachable!(),
                 Request::BarDelivery { .. } => 0,
+                Request::Release => 1,
+                Request::_Self { .. } => 2,
+            }
+        }
+        fn since(&self) -> u32 {
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+                Request::BarDelivery { .. } => 2,
                 Request::Release => 1,
                 Request::_Self { .. } => 2,
             }
@@ -511,6 +532,12 @@ pub mod wl_bar {
                 Event::_Self { .. } => 0,
             }
         }
+        fn since(&self) -> u32 {
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+                Event::_Self { .. } => 2,
+            }
+        }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
             match opcode {
                 _ => None,
@@ -657,13 +684,13 @@ pub mod wl_bar {
         }
     }
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_BAR_DELIVERY_SINCE: u16 = 2u16;
+    pub const REQ_BAR_DELIVERY_SINCE: u32 = 2u32;
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_RELEASE_SINCE: u16 = 1u16;
+    pub const REQ_RELEASE_SINCE: u32 = 1u32;
     #[doc = r" The minimal object version supporting this request"]
-    pub const REQ_SELF_SINCE: u16 = 2u16;
+    pub const REQ_SELF_SINCE: u32 = 2u32;
     #[doc = r" The minimal object version supporting this event"]
-    pub const EVT_SELF_SINCE: u16 = 2u16;
+    pub const EVT_SELF_SINCE: u32 = 2u32;
 }
 #[doc = "callback object\n\nThis object has a special behavior regarding its destructor."]
 pub mod wl_callback {
@@ -684,6 +711,11 @@ pub mod wl_callback {
             }
         }
         fn opcode(&self) -> u16 {
+            match *self {
+                Request::__nonexhaustive => unreachable!(),
+            }
+        }
+        fn since(&self) -> u32 {
             match *self {
                 Request::__nonexhaustive => unreachable!(),
             }
@@ -725,6 +757,12 @@ pub mod wl_callback {
             match *self {
                 Event::__nonexhaustive => unreachable!(),
                 Event::Done { .. } => 0,
+            }
+        }
+        fn since(&self) -> u32 {
+            match *self {
+                Event::__nonexhaustive => unreachable!(),
+                Event::Done { .. } => 1,
             }
         }
         fn child<Meta: ObjectMetadata>(opcode: u16, version: u32, meta: &Meta) -> Option<Object<Meta>> {
@@ -792,5 +830,5 @@ pub mod wl_callback {
         }
     }
     #[doc = r" The minimal object version supporting this event"]
-    pub const EVT_DONE_SINCE: u16 = 1u16;
+    pub const EVT_DONE_SINCE: u32 = 1u32;
 }

--- a/tests/server_clients.rs
+++ b/tests/server_clients.rs
@@ -49,7 +49,7 @@ fn client_user_data() {
 
     // Instantiate the globals
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<ClientOutput, _>(1, |newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();
@@ -63,7 +63,7 @@ fn client_user_data() {
     }
 
     manager
-        .instantiate_auto::<ClientCompositor, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<ClientCompositor, _>(1, |newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();

--- a/tests/server_created_object.rs
+++ b/tests/server_created_object.rs
@@ -61,10 +61,10 @@ fn data_offer() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let seat = manager
-        .instantiate_auto::<ClientSeat, _>(|newseat| newseat.implement_dummy())
+        .instantiate_exact::<ClientSeat, _>(1, |newseat| newseat.implement_dummy())
         .unwrap();
     let ddmgr = manager
-        .instantiate_auto::<ClientDDMgr, _>(|newddmgr| newddmgr.implement_dummy())
+        .instantiate_exact::<ClientDDMgr, _>(3, |newddmgr| newddmgr.implement_dummy())
         .unwrap();
 
     let received = Arc::new(Mutex::new(false));
@@ -134,10 +134,10 @@ fn data_offer_trait_impls() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let seat = manager
-        .instantiate_auto::<ClientSeat, _>(|newseat| newseat.implement_dummy())
+        .instantiate_exact::<ClientSeat, _>(1, |newseat| newseat.implement_dummy())
         .unwrap();
     let ddmgr = manager
-        .instantiate_auto::<ClientDDMgr, _>(|newddmgr| newddmgr.implement_dummy())
+        .instantiate_exact::<ClientDDMgr, _>(3, |newddmgr| newddmgr.implement_dummy())
         .unwrap();
 
     let received = Arc::new(Mutex::new(false));
@@ -225,10 +225,10 @@ fn server_id_reuse() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let seat = manager
-        .instantiate_auto::<ClientSeat, _>(|newseat| newseat.implement_dummy())
+        .instantiate_exact::<ClientSeat, _>(1, |newseat| newseat.implement_dummy())
         .unwrap();
     let ddmgr = manager
-        .instantiate_auto::<ClientDDMgr, _>(|newddmgr| newddmgr.implement_dummy())
+        .instantiate_exact::<ClientDDMgr, _>(3, |newddmgr| newddmgr.implement_dummy())
         .unwrap();
 
     let offer = Rc::new(RefCell::new(None));
@@ -336,10 +336,10 @@ fn server_created_race() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let seat = manager
-        .instantiate_auto::<ClientSeat, _>(|newseat| newseat.implement_dummy())
+        .instantiate_exact::<ClientSeat, _>(1, |newseat| newseat.implement_dummy())
         .unwrap();
     let ddmgr = manager
-        .instantiate_auto::<ClientDDMgr, _>(|newddmgr| newddmgr.implement_dummy())
+        .instantiate_exact::<ClientDDMgr, _>(3, |newddmgr| newddmgr.implement_dummy())
         .unwrap();
 
     let offer = Rc::new(RefCell::new(None));
@@ -420,10 +420,10 @@ fn creation_destruction_race() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let seat = manager
-        .instantiate_auto::<ClientSeat, _>(|newseat| newseat.implement_dummy())
+        .instantiate_exact::<ClientSeat, _>(1, |newseat| newseat.implement_dummy())
         .unwrap();
     let ddmgr = manager
-        .instantiate_auto::<ClientDDMgr, _>(|newddmgr| newddmgr.implement_dummy())
+        .instantiate_exact::<ClientDDMgr, _>(3, |newddmgr| newddmgr.implement_dummy())
         .unwrap();
 
     let client_dd: Vec<_> = (0..2)

--- a/tests/server_resources.rs
+++ b/tests/server_resources.rs
@@ -29,10 +29,10 @@ fn resource_equals() {
 
     // create two outputs
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<ClientOutput, _>(1, |newp| newp.implement_dummy())
         .unwrap();
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<ClientOutput, _>(1, |newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();
@@ -69,10 +69,10 @@ fn resource_user_data() {
 
     // create two outputs
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<ClientOutput, _>(1, |newp| newp.implement_dummy())
         .unwrap();
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<ClientOutput, _>(1, |newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();
@@ -107,7 +107,7 @@ fn resource_user_data_wrong_thread() {
     roundtrip(&mut client, &mut server).unwrap();
 
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<ClientOutput, _>(1, |newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();
@@ -163,10 +163,10 @@ fn dead_resources() {
     roundtrip(&mut client, &mut server).unwrap();
 
     let client_output1 = manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<ClientOutput, _>(3, |newp| newp.implement_dummy())
         .unwrap();
     manager
-        .instantiate_auto::<ClientOutput, _>(|newp| newp.implement_dummy())
+        .instantiate_exact::<ClientOutput, _>(3, |newp| newp.implement_dummy())
         .unwrap();
 
     roundtrip(&mut client, &mut server).unwrap();

--- a/wayland-client/examples/dynamic_globals.rs
+++ b/wayland-client/examples/dynamic_globals.rs
@@ -94,6 +94,7 @@ fn main() {
                                 // We *should* have received the "name" event first
                                 caps = Some(capabilities);
                             }
+                            _ => {}
                         }
                     },
                     (),

--- a/wayland-client/examples/simple_window.rs
+++ b/wayland-client/examples/simple_window.rs
@@ -54,7 +54,7 @@ fn main() {
 
     // The compositor allows us to creates surfaces
     let compositor = globals
-        .instantiate_auto::<wl_compositor::WlCompositor, _>(|comp| comp.implement_dummy())
+        .instantiate_exact::<wl_compositor::WlCompositor, _>(1, |comp| comp.implement_dummy())
         .unwrap();
     let surface = compositor
         .create_surface(|surface| surface.implement_dummy())
@@ -63,7 +63,7 @@ fn main() {
     // The SHM allows us to share memory with the server, and create buffers
     // on this shared memory to paint our surfaces
     let shm = globals
-        .instantiate_auto::<wl_shm::WlShm, _>(|shm| shm.implement_dummy())
+        .instantiate_exact::<wl_shm::WlShm, _>(1, |shm| shm.implement_dummy())
         .unwrap();
     let pool = shm
         .create_pool(
@@ -89,7 +89,7 @@ fn main() {
     // NOTE: the wl_shell interface is actually deprecated in favour of the xdg_shell
     // protocol, available in wayland-protocols. But this will do for this example.
     let shell = globals
-        .instantiate_auto::<wl_shell::WlShell, _>(|shell| shell.implement_dummy())
+        .instantiate_exact::<wl_shell::WlShell, _>(1, |shell| shell.implement_dummy())
         .unwrap();
     let shell_surface = shell
         .get_shell_surface(&surface, |shellsurface| {
@@ -122,7 +122,7 @@ fn main() {
     // seat, so we'll keep it simple here
     let mut pointer_created = false;
     let mut keyboard_created = false;
-    globals.instantiate_auto::<wl_seat::WlSeat, _>(|seat| {
+    globals.instantiate_exact::<wl_seat::WlSeat, _>(1, |seat| {
         seat.implement_closure(
             move |event, seat| {
                 // The capabilities of a seat are known at runtime and we retrieve

--- a/wayland-client/src/native_lib/proxy.rs
+++ b/wayland-client/src/native_lib/proxy.rs
@@ -55,7 +55,13 @@ impl ProxyInner {
         if !self.is_alive() {
             return 0;
         }
-        unsafe { ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_proxy_get_version, self.ptr) as u32 }
+        let version = unsafe { ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_proxy_get_version, self.ptr) as u32 };
+        if version == 0 {
+            // For backcompat reasons the C libs return 0 as a version for the wl_display
+            // So override it
+            return 1;
+        }
+        version
     }
 
     pub(crate) fn id(&self) -> u32 {

--- a/wayland-client/src/proxy.rs
+++ b/wayland-client/src/proxy.rs
@@ -64,6 +64,17 @@ impl<I: Interface> Proxy<I> {
     ///
     /// If your request needs to create an object, use `send_constructor`.
     pub fn send(&self, msg: I::Request) {
+        if msg.since() > self.version() {
+            let opcode = msg.opcode() as usize;
+            panic!(
+                "Cannot send request {} which requires version >= {} on proxy {}@{} which is version {}.",
+                I::Request::MESSAGES[opcode].name,
+                msg.since(),
+                I::NAME,
+                self.id(),
+                self.version()
+            );
+        }
         self.inner.send::<I>(msg)
     }
 
@@ -87,6 +98,17 @@ impl<I: Interface> Proxy<I> {
         J: Interface + From<Proxy<J>>,
         F: FnOnce(NewProxy<J>) -> J,
     {
+        if msg.since() > self.version() {
+            let opcode = msg.opcode() as usize;
+            panic!(
+                "Cannot send request {} which requires version >= {} on proxy {}@{} which is version {}.",
+                I::Request::MESSAGES[opcode].name,
+                msg.since(),
+                I::NAME,
+                self.id(),
+                self.version()
+            );
+        }
         self.inner
             .send_constructor::<I, J>(msg, version)
             .map(NewProxy::wrap)

--- a/wayland-client/src/rust_imp/display.rs
+++ b/wayland-client/src/rust_imp/display.rs
@@ -64,6 +64,7 @@ impl DisplayInner {
                         map.remove(id);
                     }
                 }
+                _ => {}
             },
             UserData::empty(),
         );

--- a/wayland-client/src/rust_imp/queues.rs
+++ b/wayland-client/src/rust_imp/queues.rs
@@ -170,8 +170,10 @@ impl EventQueueInner {
             Proxy::wrap(unsafe {
                 let done2 = done.clone();
                 np.inner.implement::<WlCallback, _>(
-                    move |CbEvent::Done { .. }, _| {
-                        done2.set(true);
+                    move |evt, _| {
+                        if let CbEvent::Done { .. } = evt {
+                            done2.set(true);
+                        }
                     },
                     UserData::empty(),
                 )

--- a/wayland-commons/src/lib.rs
+++ b/wayland-commons/src/lib.rs
@@ -48,6 +48,8 @@ pub trait MessageGroup: Sized {
     ///
     /// If it is, once send or receive the associated object cannot be used any more.
     fn is_destructor(&self) -> bool;
+    /// The minimal object version for which this message exists
+    fn since(&self) -> u32;
     /// Retrieve the child `Object` associated with this message if any
     fn child<Meta: self::map::ObjectMetadata>(
         opcode: u16,
@@ -113,6 +115,9 @@ impl MessageGroup for NoMessage {
         match *self {}
     }
     fn opcode(&self) -> u16 {
+        match *self {}
+    }
+    fn since(&self) -> u32 {
         match *self {}
     }
     fn child<M: self::map::ObjectMetadata>(_: u16, _: u32, _: &M) -> Option<::map::Object<M>> {

--- a/wayland-commons/src/lib.rs
+++ b/wayland-commons/src/lib.rs
@@ -88,6 +88,14 @@ pub trait Interface: 'static {
     /// Name of this interface
     const NAME: &'static str;
     /// Maximum supported version of this interface
+    ///
+    /// This is the maximum version supported by the protocol specification currently
+    /// used by this library, and should not be used as-is in your code, as a version
+    /// change can subtly change the behavior of some objects.
+    ///
+    /// Server are supposed to be able to handle all versions from 1 to the one they
+    /// advertise through the registry, and clients can choose any version among the
+    /// ones the server supports.
     const VERSION: u32;
     #[cfg(feature = "native_lib")]
     /// Pointer to the C representation of this interface

--- a/wayland-scanner/src/c_code_gen.rs
+++ b/wayland-scanner/src/c_code_gen.rs
@@ -494,6 +494,7 @@ fn messagegroup_c_addon(name: &Ident, side: Side, receiver: bool, messages: &[Me
 
         quote! {
             match self {
+                #name::__nonexhaustive => unreachable!(),
                 #(#match_arms,)*
             }
         }

--- a/wayland-scanner/src/common_gen.rs
+++ b/wayland-scanner/src/common_gen.rs
@@ -110,6 +110,8 @@ impl ToTokens for Enum {
                 #[derive(Copy, Clone, Debug, PartialEq)]
                 pub enum #ident {
                     #(#variants,)*
+                    #[doc(hidden)]
+                    __nonexhaustive,
                 }
             };
 
@@ -596,6 +598,7 @@ pub(crate) fn gen_messagegroup(
 
         quote! {
             match self {
+                #name::__nonexhaustive => unreachable!(),
                 #(#match_arms,)*
             }
         }
@@ -604,6 +607,7 @@ pub(crate) fn gen_messagegroup(
     quote! {
         pub enum #name {
             #(#variants,)*
+            #[doc(hidden)] __nonexhaustive,
         }
 
         impl super::MessageGroup for #name {
@@ -615,12 +619,14 @@ pub(crate) fn gen_messagegroup(
 
             fn is_destructor(&self) -> bool {
                 match *self {
+                    #name::__nonexhaustive => unreachable!(),
                     #(#is_destructor_match_arms,)*
                 }
             }
 
             fn opcode(&self) -> u16 {
                 match *self {
+                    #name::__nonexhaustive => unreachable!(),
                     #(#opcode_match_arms,)*
                 }
             }
@@ -1030,6 +1036,7 @@ pub(crate) fn gen_event_handler_trait(iname: &Ident, messages: &[Message], side:
                 fn handle(__handler: &mut T, event: Event, __object: Self) {
                     match event {
                         #(#method_patterns)*
+                        Event::__nonexhaustive => unreachable!(),
                     }
                 }
             }
@@ -1045,6 +1052,7 @@ pub(crate) fn gen_event_handler_trait(iname: &Ident, messages: &[Message], side:
                 fn handle(__handler: &mut T, request: Request, __object: Self) {
                     match request {
                         #(#method_patterns)*
+                        Request::__nonexhaustive => unreachable!(),
                     }
                 }
             }

--- a/wayland-scanner/src/protocol.rs
+++ b/wayland-scanner/src/protocol.rs
@@ -46,7 +46,7 @@ impl Interface {
 pub struct Message {
     pub name: String,
     pub typ: Option<Type>,
-    pub since: u16,
+    pub since: u32,
     pub description: Option<(String, String)>,
     pub args: Vec<Arg>,
     pub type_index: usize,

--- a/wayland-server/src/resource.rs
+++ b/wayland-server/src/resource.rs
@@ -48,6 +48,17 @@ impl<I: Interface> Resource<I> {
     /// The event will be send to the client associated to this
     /// object.
     pub fn send(&self, msg: I::Event) {
+        if msg.since() > self.version() {
+            let opcode = msg.opcode() as usize;
+            panic!(
+                "Cannot send event {} which requires version >= {} on resource {}@{} which is version {}.",
+                I::Event::MESSAGES[opcode].name,
+                msg.since(),
+                I::NAME,
+                self.id(),
+                self.version()
+            );
+        }
         self.inner.send::<I>(msg)
     }
 

--- a/wayland-server/src/rust_imp/clients.rs
+++ b/wayland-server/src/rust_imp/clients.rs
@@ -618,9 +618,7 @@ impl super::Dispatcher for RegistryDispatcher {
         if ::std::env::var_os("WAYLAND_DEBUG").is_some() {
             eprintln!(
                 " <- wl_registry@{}: {} {:?}",
-                resource.id,
-                REGISTRY_REQUESTS[msg.opcode as usize].name,
-                msg.args
+                resource.id, REGISTRY_REQUESTS[msg.opcode as usize].name, msg.args
             );
         }
 


### PR DESCRIPTION
- Future-proof protocol enums by adding a `#[doc(hidden)] __nonexhaustive` variant. Should be migrated to https://github.com/rust-lang/rust/issues/44109 once it is stabilized. This makes updating the protocols a non-breaking change.
- Remove `GlobalManager::instantiate_auto` which was way too error prone, and replace it with `GlobalManager::instanciate_range`. Also improve the docs regarding to interface versioning.
- Actually check that the versions of messages sent and received over the wire are correct wrt to their supported version, and trigger protocol errors if they aren't (as the C lib does).