### PR TITLE
travis: run tarpaulin on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
   include:
     - rust: stable
       env: BUILD_FMT=1
-    - rust: nightly
+    - rust: stable
       env: TARPAULIN=1
       sudo: true
     - rust: stable
@@ -97,9 +97,9 @@ script:
         cargo fmt --all -- --check
         rustfmt --check tests/scanner_assets/*.rs
       elif [ -n "$TARPAULIN" ]; then
-        cargo tarpaulin --all --features "nothread" --ignore-tests --out Xml
+        cargo tarpaulin --all --features "" --ignore-tests --out Xml
         bash <(curl -s https://codecov.io/bash) -cF rust_impl
-        cargo tarpaulin --all --features "nothread native_lib" --ignore-tests --out Xml
+        cargo tarpaulin --all --features "native_lib" --ignore-tests --out Xml
         bash <(curl -s https://codecov.io/bash) -cF native_lib
       elif [ -n "$CLIPPY" ]; then
         # - renamed_and_removed and deprecared_cfg_attr are necessary because rust 1.21.0 cannot parse

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ members = [ "wayland-sys", "wayland-scanner", "wayland-client", "wayland-server"
 
 [features]
 native_lib = ["wayland-client/dlopen", "wayland-server/dlopen", "wayland-protocols/native_lib", "wayland-commons/native_lib", "wayland-sys"]
-nothread = [] # for testing purposes
 
 # Manual list of the tests, required because some need `harness = false`
 

--- a/tests/client_dispatch.rs
+++ b/tests/client_dispatch.rs
@@ -8,7 +8,6 @@ use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-#[cfg(not(feature = "nothread"))]
 #[test]
 fn client_sync_roundtrip() {
     let socket_name = "wayland-client-sync-roundtrip";
@@ -44,7 +43,6 @@ fn client_sync_roundtrip() {
     server_thread.join().unwrap();
 }
 
-#[cfg(not(feature = "nothread"))]
 #[test]
 fn client_dispatch() {
     let socket_name = "wayland-client-dispatch";

--- a/tests/client_proxies.rs
+++ b/tests/client_proxies.rs
@@ -66,7 +66,6 @@ fn proxy_user_data() {
     assert!(compositor1.user_data::<u32>() == None);
 }
 
-#[cfg(not(feature = "nothread"))]
 #[test]
 fn proxy_user_data_wrong_thread() {
     let mut server = TestServer::new();
@@ -120,7 +119,6 @@ fn proxy_wrapper() {
     assert!(manager.list().len() == 1);
 }
 
-#[cfg(not(feature = "nothread"))]
 #[test]
 fn proxy_implement_wrong_thread() {
     let mut server = TestServer::new();
@@ -147,7 +145,6 @@ fn proxy_implement_wrong_thread() {
     assert!(ret.is_err())
 }
 
-#[cfg(not(feature = "nothread"))]
 #[test]
 fn proxy_implement_wrapper_threaded() {
     let mut server = TestServer::new();
@@ -176,7 +173,6 @@ fn proxy_implement_wrapper_threaded() {
     .unwrap();
 }
 
-#[cfg(not(feature = "nothread"))]
 #[test]
 fn proxy_implement_threadsafe_wrong_thread() {
     let mut server = TestServer::new();

--- a/tests/server_resources.rs
+++ b/tests/server_resources.rs
@@ -84,7 +84,6 @@ fn resource_user_data() {
     assert!(cloned.as_ref().user_data::<usize>() == Some(&1000));
 }
 
-#[cfg(not(feature = "nothread"))]
 #[cfg(not(feature = "native_lib"))]
 #[test]
 fn resource_user_data_wrong_thread() {
@@ -125,7 +124,6 @@ fn resource_user_data_wrong_thread() {
     .unwrap();
 }
 
-#[cfg(not(feature = "nothread"))]
 #[cfg(not(feature = "native_lib"))]
 #[test]
 fn resource_implement_wrong_thread() {


### PR DESCRIPTION
tarpaulin can now again be compiled on stable, and when run on stable it
does not yet show the multithreading bug.

see https://github.com/xd009642/tarpaulin/issues/190#issuecomment-460054663