### PR TITLE
client: don't fallback on wayland-0 at connect time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   for it have already been queued in the event queue
 - [client] Expose `Display::protocol_error()` to get the details of a protocol error
   that occured.
+- [client] Don't try to connect to `wayland-0` if `WAYLAND_DISPLAY` is not set, this is a
+  bad legacy practice which can cause clients to spawn in the wrong environment.
 
 ## 0.22.0 -- 2019-01-31
 

--- a/tests/client_connect_to_env.rs
+++ b/tests/client_connect_to_env.rs
@@ -8,6 +8,8 @@ fn main() {
     let mut server = TestServer::new();
     server.display.create_global::<ServerOutput, _>(1, |_, _| {});
 
+    assert!(wayc::Display::connect_to_env().is_err());
+
     ::std::env::set_var("WAYLAND_DISPLAY", &server.socket_name);
 
     let mut client = TestClient::new_auto();

--- a/wayland-client/src/display.rs
+++ b/wayland-client/src/display.rs
@@ -108,8 +108,8 @@ impl Display {
     /// First of all, if the `WAYLAND_SOCKET` environment variable is set, it'll try to interpret
     /// it as a FD number to use
     ///
-    /// If the `WAYLAND_DISPLAY` variable is set, it will try to connect to the socket it points
-    /// to. Otherwise, it will default to `wayland-0`.
+    /// Otherwise, it will try to connect to the socket name defined in the `WAYLAND_DISPLAY`
+    /// environment variable, and error if it is not set.
     ///
     /// On success, you are given the `Display` object as well as the main `EventQueue` hosting
     /// the `WlDisplay` wayland object.
@@ -139,7 +139,7 @@ impl Display {
             let mut socket_path = env::var_os("XDG_RUNTIME_DIR")
                 .map(Into::<PathBuf>::into)
                 .ok_or(ConnectError::XdgRuntimeDirNotSet)?;
-            socket_path.push(env::var_os("WAYLAND_DISPLAY").unwrap_or_else(|| "wayland-0".into()));
+            socket_path.push(env::var_os("WAYLAND_DISPLAY").ok_or(ConnectError::NoCompositorListening)?);
 
             let socket = UnixStream::connect(socket_path).map_err(|_| ConnectError::NoCompositorListening)?;
             unsafe { Display::from_fd(socket.into_raw_fd()) }


### PR DESCRIPTION
The fallback to `wayland-0` if `WAYLAND_DISPLAY` is not set is a legacy practice that should no longer be followed, as it can cause clients to connect to the wrong compositor, and all compositors should set up the environment correctly.