### PR TITLE
client: Display is Clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   that occured.
 - [client] Don't try to connect to `wayland-0` if `WAYLAND_DISPLAY` is not set, this is a
   bad legacy practice which can cause clients to spawn in the wrong environment.
+- [client] `Display` can now be cloned and sent accross threads as nothing prevents it
 
 ## 0.22.0 -- 2019-01-31
 

--- a/wayland-client/src/display.rs
+++ b/wayland-client/src/display.rs
@@ -98,6 +98,7 @@ impl ::std::fmt::Display for ProtocolError {
 /// primary `WlDisplay` wayland object, from which you can create all
 /// your need objects. The inner `Proxy<WlDisplay>` can be accessed via
 /// `Deref`.
+#[derive(Clone)]
 pub struct Display {
     pub(crate) inner: Arc<DisplayInner>,
 }


### PR DESCRIPTION
There was no real reason to prevent client-side `Display` from being clone.