### PR TITLE
scanner: allow configuration of destructor events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+#### Additions
+
+- [scanner] Added `generate_code_with_destructor_events` allowing to patch the protocol file by specifying
+  that some events are destructors.
+
 ## 0.23.3 -- 2019-04-26
 
 #### Additions

--- a/tests/scanner.rs
+++ b/tests/scanner.rs
@@ -112,13 +112,23 @@ fn run_codegen_test(generated_file_path: &Path, expected_output: &str) {
 #[test]
 fn client_code_generation() {
     let mut tempfile = tempfile::NamedTempFile::new().unwrap();
-    wayland_scanner::generate_code_streams(Cursor::new(PROTOCOL.as_bytes()), &mut tempfile, Side::Client);
+    wayland_scanner::generate_code_streams_with_destructor_events(
+        Cursor::new(PROTOCOL.as_bytes()),
+        &mut tempfile,
+        Side::Client,
+        &[("wl_callback", "done")],
+    );
     run_codegen_test(tempfile.path(), CLIENT_CODE_TARGET);
 }
 
 #[test]
 fn server_code_generation() {
     let mut tempfile = tempfile::NamedTempFile::new().unwrap();
-    wayland_scanner::generate_code_streams(Cursor::new(PROTOCOL.as_bytes()), &mut tempfile, Side::Server);
+    wayland_scanner::generate_code_streams_with_destructor_events(
+        Cursor::new(PROTOCOL.as_bytes()),
+        &mut tempfile,
+        Side::Server,
+        &[("wl_callback", "done")],
+    );
     run_codegen_test(tempfile.path(), SERVER_CODE_TARGET);
 }

--- a/wayland-client/build.rs
+++ b/wayland-client/build.rs
@@ -11,5 +11,10 @@ fn main() {
     let out_dir = Path::new(&out_dir_str);
 
     println!("cargo:rerun-if-changed={}", protocol_file);
-    generate_code(protocol_file, out_dir.join("wayland_api.rs"), Side::Client);
+    generate_code_with_destructor_events(
+        protocol_file,
+        out_dir.join("wayland_api.rs"),
+        Side::Client,
+        &[("wl_callback", "done")],
+    );
 }

--- a/wayland-protocols/build.rs
+++ b/wayland-protocols/build.rs
@@ -4,56 +4,78 @@ use std::env::var;
 use std::path::Path;
 use wayland_scanner::*;
 
-static STABLE_PROTOCOLS: &[&str] = &["presentation-time", "viewporter", "xdg-shell"];
-
-static UNSTABLE_PROTOCOLS: &[(&str, &[&str])] = &[
-    ("fullscreen-shell", &["v1"]),
-    ("idle-inhibit", &["v1"]),
-    ("input-method", &["v1"]),
-    ("input-timestamps", &["v1"]),
-    ("keyboard-shortcuts-inhibit", &["v1"]),
-    ("linux-dmabuf", &["v1"]),
-    ("linux-explicit-synchronization", &["v1"]),
-    ("pointer-constraints", &["v1"]),
-    ("pointer-gestures", &["v1"]),
-    ("primary-selection", &["v1"]),
-    ("relative-pointer", &["v1"]),
-    ("tablet", &["v1", "v2"]),
-    ("text-input", &["v1", "v3"]),
-    ("xdg-decoration", &["v1"]),
-    ("xdg-foreign", &["v1", "v2"]),
-    ("xdg-output", &["v1"]),
-    ("xdg-shell", &["v5", "v6"]),
-    ("xwayland-keyboard-grab", &["v1"]),
+static STABLE_PROTOCOLS: &[(&str, &[(&str, &str)])] = &[
+    ("presentation-time", &[]),
+    ("viewporter", &[]),
+    ("xdg-shell", &[]),
 ];
 
-static WLR_UNSTABLE_PROTOCOLS: &[(&str, &[&str])] = &[
-    ("wlr-data-control", &["v1"]),
-    ("wlr-export-dmabuf", &["v1"]),
-    ("wlr-foreign-toplevel-management", &["v1"]),
-    ("wlr-gamma-control", &["v1"]),
-    ("wlr-input-inhibitor", &["v1"]),
-    ("wlr-layer-shell", &["v1"]),
-    ("wlr-screencopy", &["v1"]),
+static UNSTABLE_PROTOCOLS: &[(&str, &[(&str, &[(&str, &str)])])] = &[
+    ("fullscreen-shell", &[("v1", &[])]),
+    ("idle-inhibit", &[("v1", &[])]),
+    ("input-method", &[("v1", &[])]),
+    ("input-timestamps", &[("v1", &[])]),
+    ("keyboard-shortcuts-inhibit", &[("v1", &[])]),
+    ("linux-dmabuf", &[("v1", &[])]),
+    (
+        "linux-explicit-synchronization",
+        &[(
+            "v1",
+            &[
+                ("zwp_linux_buffer_release_v1", "fenced_release"),
+                ("zwp_linux_buffer_release_v1", "immediate_release"),
+            ],
+        )],
+    ),
+    ("pointer-constraints", &[("v1", &[])]),
+    ("pointer-gestures", &[("v1", &[])]),
+    ("primary-selection", &[("v1", &[])]),
+    ("relative-pointer", &[("v1", &[])]),
+    ("tablet", &[("v1", &[]), ("v2", &[])]),
+    ("text-input", &[("v1", &[]), ("v3", &[])]),
+    ("xdg-decoration", &[("v1", &[])]),
+    ("xdg-foreign", &[("v1", &[]), ("v2", &[])]),
+    ("xdg-output", &[("v1", &[])]),
+    ("xdg-shell", &[("v5", &[]), ("v6", &[])]),
+    ("xwayland-keyboard-grab", &[("v1", &[])]),
 ];
 
-static MISC_PROTOCOLS: &[&str] = &["gtk-primary-selection"];
+static WLR_UNSTABLE_PROTOCOLS: &[(&str, &[(&str, &[(&str, &str)])])] = &[
+    ("wlr-data-control", &[("v1", &[])]),
+    ("wlr-export-dmabuf", &[("v1", &[])]),
+    ("wlr-foreign-toplevel-management", &[("v1", &[])]),
+    ("wlr-gamma-control", &[("v1", &[])]),
+    ("wlr-input-inhibitor", &[("v1", &[])]),
+    ("wlr-layer-shell", &[("v1", &[])]),
+    ("wlr-screencopy", &[("v1", &[])]),
+];
 
-fn generate_protocol(name: &str, protocol_file: &Path, out_dir: &Path, client: bool, server: bool) {
+static MISC_PROTOCOLS: &[(&str, &[(&str, &str)])] = &[("gtk-primary-selection", &[])];
+
+fn generate_protocol(
+    name: &str,
+    protocol_file: &Path,
+    out_dir: &Path,
+    client: bool,
+    server: bool,
+    dest_events: &[(&str, &str)],
+) {
     println!("cargo:rerun-if-changed={}", protocol_file.display());
 
     if client {
-        generate_code(
+        generate_code_with_destructor_events(
             &protocol_file,
             out_dir.join(&format!("{}_client_api.rs", name)),
             Side::Client,
+            dest_events,
         );
     }
     if server {
-        generate_code(
+        generate_code_with_destructor_events(
             &protocol_file,
             out_dir.join(&format!("{}_server_api.rs", name)),
             Side::Server,
+            dest_events,
         );
     }
 }
@@ -69,7 +91,7 @@ fn main() {
     let client = var("CARGO_FEATURE_CLIENT").ok().is_some();
     let server = var("CARGO_FEATURE_SERVER").ok().is_some();
 
-    for name in STABLE_PROTOCOLS {
+    for &(name, dest_events) in STABLE_PROTOCOLS {
         let file = format!("{name}/{name}.xml", name = name);
         generate_protocol(
             name,
@@ -77,17 +99,25 @@ fn main() {
             out_dir,
             client,
             server,
+            dest_events,
         );
     }
 
-    for name in MISC_PROTOCOLS {
+    for &(name, dest_events) in MISC_PROTOCOLS {
         let file = format!("{name}.xml", name = name);
-        generate_protocol(name, &Path::new("./misc").join(&file), out_dir, client, server);
+        generate_protocol(
+            name,
+            &Path::new("./misc").join(&file),
+            out_dir,
+            client,
+            server,
+            dest_events,
+        );
     }
 
     if var("CARGO_FEATURE_UNSTABLE_PROTOCOLS").ok().is_some() {
         for &(name, versions) in UNSTABLE_PROTOCOLS {
-            for version in versions {
+            for &(version, dest_events) in versions {
                 let file = format!(
                     "{name}/{name}-unstable-{version}.xml",
                     name = name,
@@ -99,11 +129,12 @@ fn main() {
                     out_dir,
                     client,
                     server,
+                    dest_events,
                 );
             }
         }
         for &(name, versions) in WLR_UNSTABLE_PROTOCOLS {
-            for version in versions {
+            for &(version, dest_events) in versions {
                 let file = format!("{name}-unstable-{version}.xml", name = name, version = version);
                 generate_protocol(
                     &format!("{name}-{version}", name = name, version = version),
@@ -111,6 +142,7 @@ fn main() {
                     out_dir,
                     client,
                     server,
+                    dest_events,
                 );
             }
         }

--- a/wayland-scanner/src/parse.rs
+++ b/wayland-scanner/src/parse.rs
@@ -25,23 +25,7 @@ macro_rules! extract_end_tag(
 pub fn parse_stream<S: Read>(stream: S) -> Protocol {
     let mut reader = EventReader::new_with_config(stream, ParserConfig::new().trim_whitespace(true));
     reader.next().expect("Could not read from event reader");
-    let mut protocol = parse_protocol(reader);
-
-    // yay, hardcoding things
-    if protocol.name == "wayland" {
-        // wl_callback has actually a destructor *event*, but the wayland specification
-        // format does not handle this.
-        // Luckily, wayland-scanner does, so we inject it
-        for interface in &mut protocol.interfaces {
-            if interface.name == "wl_callback" {
-                let done_event = &mut interface.events[0];
-                assert!(done_event.name == "done");
-                done_event.typ = Some(Type::Destructor);
-            }
-        }
-    }
-
-    protocol
+    parse_protocol(reader)
 }
 
 fn parse_protocol<R: Read>(mut reader: EventReader<R>) -> Protocol {

--- a/wayland-server/build.rs
+++ b/wayland-server/build.rs
@@ -11,5 +11,10 @@ fn main() {
     let out_dir = Path::new(&out_dir_str);
 
     println!("cargo:rerun-if-changed={}", protocol_file);
-    generate_code(protocol_file, out_dir.join("wayland_api.rs"), Side::Server);
+    generate_code_with_destructor_events(
+        protocol_file,
+        out_dir.join("wayland_api.rs"),
+        Side::Server,
+        &[("wl_callback", "done")],
+    );
 }


### PR DESCRIPTION
This moves the logic of specifying destructor events out of wayland-scanner, as my initial assumption that `wl_callback.done` would be the only ever destructor event turned out to be wrong.