### PR TITLE
Update to nix 0.14.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ lazycell = "=1.0.0"
 [dev-dependencies]
 difference = "2.0"
 tempfile = ">=2.0, <4.0"
-nix = "0.13"
+nix = "0.14.1"
 calloop = "0.4.2"
 
 [workspace]

--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "Smithay/wayland-rs" }
 [dependencies]
 wayland-commons = { version = "0.23.4", path = "../wayland-commons" }
 wayland-sys = { version = "0.23.4", path = "../wayland-sys" }
-nix = "0.13"
+nix = "0.14.1"
 downcast-rs = "1.0"
 bitflags = "1.0"
 libc = "0.2"

--- a/wayland-client/src/rust_imp/queues.rs
+++ b/wayland-client/src/rust_imp/queues.rs
@@ -5,7 +5,7 @@ use std::os::unix::io::AsRawFd;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
-use nix::poll::{poll, EventFlags, PollFd};
+use nix::poll::{poll, PollFlags, PollFd};
 
 use wayland_commons::map::ObjectMap;
 use wayland_commons::utils::UserData;
@@ -62,7 +62,7 @@ impl EventQueueInner {
                     Ok(_) => break,
                     Err(::nix::Error::Sys(::nix::errno::Errno::EAGAIN)) => {
                         // EAGAIN, we need to wait before writing, so we poll the socket
-                        let poll_ret = poll(&mut [PollFd::new(socket_fd, EventFlags::POLLOUT)], -1);
+                        let poll_ret = poll(&mut [PollFd::new(socket_fd, PollFlags::POLLOUT)], -1);
                         match poll_ret {
                             Ok(_) => continue,
                             Err(::nix::Error::Sys(e)) => {
@@ -86,7 +86,7 @@ impl EventQueueInner {
         }
 
         // wait for incoming messages to arrive
-        match poll(&mut [PollFd::new(socket_fd, EventFlags::POLLIN)], -1) {
+        match poll(&mut [PollFd::new(socket_fd, PollFlags::POLLIN)], -1) {
             Ok(_) => (),
             Err(::nix::Error::Sys(e)) => {
                 self.cancel_read();

--- a/wayland-commons/Cargo.toml
+++ b/wayland-commons/Cargo.toml
@@ -14,5 +14,5 @@ travis-ci = { repository = "Smithay/wayland-rs" }
 
 [dependencies]
 wayland-sys = { version = "0.23.4", path = "../wayland-sys" }
-nix = "0.13"
+nix = "0.14.1"
 

--- a/wayland-commons/src/lib.rs
+++ b/wayland-commons/src/lib.rs
@@ -15,6 +15,7 @@
 
 #![warn(missing_docs)]
 
+#[macro_use]
 extern crate nix;
 extern crate wayland_sys;
 use std::os::raw::c_void;

--- a/wayland-commons/src/socket.rs
+++ b/wayland-commons/src/socket.rs
@@ -53,7 +53,7 @@ impl Socket {
     /// slice `MAX_FDS_OUT` long, otherwise some data of the received message may
     /// be lost.
     pub fn rcv_msg(&self, buffer: &mut [u8], fds: &mut [RawFd]) -> NixResult<(usize, usize)> {
-        let mut cmsg = nix::cmsg_space!([RawFd; MAX_FDS_OUT]);
+        let mut cmsg = cmsg_space!([RawFd; MAX_FDS_OUT]);
         let iov = [uio::IoVec::from_mut_slice(buffer)];
 
         let msg = socket::recvmsg(self.fd, &iov[..], Some(&mut cmsg), socket::MsgFlags::MSG_DONTWAIT)?;

--- a/wayland-commons/src/socket.rs
+++ b/wayland-commons/src/socket.rs
@@ -61,14 +61,13 @@ impl Socket {
         let mut fd_count = 0;
         let received_fds = msg.cmsgs().flat_map(|cmsg| {
             match cmsg {
-                socket::ControlMessage::ScmRights(s) => s,
-                _ => &[],
+                socket::ControlMessageOwned::ScmRights(s) => s,
+                _ => Vec::new(),
             }
-            .iter()
         });
         for (fd, place) in received_fds.zip(fds.iter_mut()) {
             fd_count += 1;
-            *place = *fd;
+            *place = fd;
         }
         Ok((msg.bytes, fd_count))
     }

--- a/wayland-commons/src/socket.rs
+++ b/wayland-commons/src/socket.rs
@@ -53,7 +53,7 @@ impl Socket {
     /// slice `MAX_FDS_OUT` long, otherwise some data of the received message may
     /// be lost.
     pub fn rcv_msg(&self, buffer: &mut [u8], fds: &mut [RawFd]) -> NixResult<(usize, usize)> {
-        let mut cmsg = socket::CmsgSpace::<[RawFd; MAX_FDS_OUT]>::new();
+        let mut cmsg = nix::cmsg_space!([RawFd; MAX_FDS_OUT]);
         let iov = [uio::IoVec::from_mut_slice(buffer)];
 
         let msg = socket::recvmsg(self.fd, &iov[..], Some(&mut cmsg), socket::MsgFlags::MSG_DONTWAIT)?;

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -19,7 +19,7 @@ wayland-sys = { version = "0.23.4", path = "../wayland-sys" }
 bitflags = "1.0"
 downcast-rs = "1.0"
 libc = "0.2"
-nix = "0.13"
+nix = "0.14.1"
 mio = "0.6"
 calloop = ">=0.3.1, <0.5"
 


### PR DESCRIPTION
This should probably be handled as a follow-up to https://github.com/Smithay/calloop/pull/6.

Once that is merged, I can update this to completely get rid of nix 0.13.