### PR TITLE
Set Proxy::implement_dummy threadsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.23.6 -- 2019-06-16
+
+- [client/server] Make `NewProxy/NewResource::implement_dummy()` threadsafe.
+
 ## 0.23.5 -- 2019-06-13
 
 - Update `nix` dependency to 0.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## 0.23.6 -- 2019-06-16
-
 - [client/server] Make `NewProxy/NewResource::implement_dummy()` threadsafe.
 
 ## 0.23.5 -- 2019-06-13

--- a/wayland-client/src/proxy.rs
+++ b/wayland-client/src/proxy.rs
@@ -402,7 +402,7 @@ impl<I: Interface + 'static> NewProxy<I> {
         I: From<Proxy<I>>,
         I::Event: MessageGroup<Map = ProxyMap>,
     {
-        self.implement_closure(|_, _| (), ())
+        self.implement_closure_threadsafe(|_, _| (), ())
     }
 
     /// Implement this proxy using the given handler and implementation data.

--- a/wayland-server/src/resource.rs
+++ b/wayland-server/src/resource.rs
@@ -320,7 +320,7 @@ impl<I: Interface + 'static> NewResource<I> {
         I: From<Resource<I>>,
         I::Request: MessageGroup<Map = ::imp::ResourceMap>,
     {
-        self.implement_closure(|_, _| (), None::<fn(_)>, ())
+        self.implement_closure_threadsafe(|_, _| (), None::<fn(_)>, ())
     }
 
     /// Implement this resource using a handler, destructor and user data.


### PR DESCRIPTION
Since `|_, _| ()` and `()` are both `Send`, I see no reasons why `Proxy::implement_dummy` shouldn't use `implement_closure_threadsafe` instead of `implement_closure`.