### PR TITLE
Use smallvec for message arguments

### DIFF
--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -20,6 +20,7 @@ nix = "0.14.1"
 downcast-rs = "1.0"
 bitflags = "1.0"
 libc = "0.2"
+smallvec = "0.6"
 calloop = { version = ">=0.3.1, <0.5", optional = true }
 mio = { version = "0.6.0", optional = true }
 

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -120,6 +120,8 @@ extern crate bitflags;
 extern crate downcast_rs as downcast;
 extern crate libc;
 extern crate nix;
+#[macro_use]
+extern crate smallvec;
 
 #[cfg(feature = "eventloop")]
 extern crate calloop;

--- a/wayland-commons/Cargo.toml
+++ b/wayland-commons/Cargo.toml
@@ -15,4 +15,4 @@ travis-ci = { repository = "Smithay/wayland-rs" }
 [dependencies]
 wayland-sys = { version = "0.23.5", path = "../wayland-sys" }
 nix = "0.14.1"
-
+smallvec = "0.6"

--- a/wayland-commons/src/lib.rs
+++ b/wayland-commons/src/lib.rs
@@ -18,6 +18,8 @@
 #[macro_use]
 extern crate nix;
 extern crate wayland_sys;
+#[macro_use]
+extern crate smallvec;
 use std::os::raw::c_void;
 use wayland_sys::common as syscom;
 

--- a/wayland-commons/src/socket.rs
+++ b/wayland-commons/src/socket.rs
@@ -464,7 +464,7 @@ mod tests {
         let msg = Message {
             sender_id: 42,
             opcode: 7,
-            args: vec![
+            args: smallvec![
                 Argument::Uint(3),
                 Argument::Fixed(-89),
                 Argument::Str(CString::new(&b"I like trains!"[..]).unwrap()),
@@ -517,7 +517,7 @@ mod tests {
         let msg = Message {
             sender_id: 42,
             opcode: 7,
-            args: vec![
+            args: smallvec![
                 Argument::Fd(1), // stdin
                 Argument::Fd(0), // stdout
             ],
@@ -558,7 +558,7 @@ mod tests {
             Message {
                 sender_id: 42,
                 opcode: 0,
-                args: vec![
+                args: smallvec![
                     Argument::Int(42),
                     Argument::Str(CString::new(&b"I like trains"[..]).unwrap()),
                 ],
@@ -566,7 +566,7 @@ mod tests {
             Message {
                 sender_id: 42,
                 opcode: 1,
-                args: vec![
+                args: smallvec![
                     Argument::Fd(1), // stdin
                     Argument::Fd(0), // stdout
                 ],
@@ -574,7 +574,7 @@ mod tests {
             Message {
                 sender_id: 42,
                 opcode: 2,
-                args: vec![
+                args: smallvec![
                     Argument::Uint(3),
                     Argument::Fd(2), // stderr
                 ],
@@ -626,7 +626,7 @@ mod tests {
         let msg = Message {
             sender_id: 2,
             opcode: 0,
-            args: vec![
+            args: smallvec![
                 Argument::Uint(18),
                 Argument::Str(CString::new(&b"wl_shell"[..]).unwrap()),
                 Argument::Uint(1),

--- a/wayland-commons/src/wire.rs
+++ b/wayland-commons/src/wire.rs
@@ -6,6 +6,7 @@ use std::ptr;
 
 use nix::errno::Errno;
 use nix::{Error as NixError, Result as NixResult};
+use smallvec::SmallVec;
 
 /// Wire metadata of a given message
 pub struct MessageDesc {
@@ -83,7 +84,7 @@ pub struct Message {
     /// Opcode of the message
     pub opcode: u16,
     /// Arguments of the message
-    pub args: Vec<Argument>,
+    pub args: SmallVec::<[Argument; 4]>,
 }
 
 /// Error generated when trying to serialize a message into buffers
@@ -314,7 +315,7 @@ impl Message {
                     Err(MessageParseError::MissingData)
                 }
             })
-            .collect::<Result<Vec<_>, MessageParseError>>()?;
+            .collect::<Result<SmallVec<_>, MessageParseError>>()?;
 
         let msg = Message {
             sender_id,
@@ -397,7 +398,7 @@ mod tests {
         let msg = Message {
             sender_id: 42,
             opcode: 7,
-            args: vec![
+            args: smallvec![
                 Argument::Uint(3),
                 Argument::Fixed(-89),
                 Argument::Str(CString::new(&b"I like trains!"[..]).unwrap()),

--- a/wayland-scanner/src/common_gen.rs
+++ b/wayland-scanner/src/common_gen.rs
@@ -595,7 +595,7 @@ pub(crate) fn gen_messagegroup(
             quote!(#pattern => Message {
                 sender_id: sender_id,
                 opcode: #opcode_value,
-                args: vec![
+                args: smallvec![
                     #(#args_values,)*
                 ],
             })

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -19,6 +19,7 @@ wayland-sys = { version = "0.23.5", path = "../wayland-sys" }
 bitflags = "1.0"
 downcast-rs = "1.0"
 libc = "0.2"
+smallvec = "0.6"
 nix = "0.14.1"
 mio = "0.6"
 calloop = ">=0.3.1, <0.5"

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -79,6 +79,8 @@ pub extern crate calloop;
 #[cfg(not(feature = "native_lib"))]
 #[macro_use]
 extern crate downcast_rs as downcast;
+#[macro_use]
+extern crate smallvec;
 extern crate libc;
 extern crate mio;
 extern crate nix;

--- a/wayland-server/src/rust_imp/clients.rs
+++ b/wayland-server/src/rust_imp/clients.rs
@@ -94,7 +94,7 @@ impl ClientConnection {
             self.write_message(&Message {
                 sender_id: 1,
                 opcode: 1,
-                args: vec![Argument::Uint(id)],
+                args: smallvec![Argument::Uint(id)],
             })
         } else {
             Ok(())
@@ -271,7 +271,7 @@ impl ClientInner {
             let _ = data.write_message(&Message {
                 sender_id: 1,
                 opcode: 0,
-                args: vec![
+                args: smallvec![
                     Argument::Object(object),
                     Argument::Uint(error_code),
                     Argument::Str(CString::new(msg).unwrap()),

--- a/wayland-server/src/rust_imp/globals.rs
+++ b/wayland-server/src/rust_imp/globals.rs
@@ -213,7 +213,7 @@ fn send_global_msg(reg: &(u32, ClientInner), global_id: u32, interface: CString,
         let _ = clientconn.write_message(&Message {
             sender_id: reg.0,
             opcode: 0,
-            args: vec![
+            args: smallvec![
                 Argument::Uint(global_id),
                 Argument::Str(interface),
                 Argument::Uint(version),
@@ -260,7 +260,7 @@ fn send_destroyed_global(
                 let _ = clientconn.write_message(&Message {
                     sender_id: id,
                     opcode: 1,
-                    args: vec![Argument::Uint(global_id)],
+                    args: smallvec![Argument::Uint(global_id)],
                 });
             }
         }
@@ -270,7 +270,7 @@ fn send_destroyed_global(
                 let _ = clientconn.write_message(&Message {
                     sender_id: id,
                     opcode: 1,
-                    args: vec![Argument::Uint(global_id)],
+                    args: smallvec![Argument::Uint(global_id)],
                 });
             }
         }


### PR DESCRIPTION
Closes #249 

Unfortunately it's a backwards incompatible change, at lease for `wayland-commons` and probably for other crates which use it in public API.

Maybe use this chance to update to 2018 edition?