### PR TITLE
Add `implement*_user_data_threadsafe()` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - [client/server] Make `NewProxy/NewResource::implement_dummy()` threadsafe.
+- [client/server] Add new `NewProxy/NewResource::implement*_user_data_threadsafe()` functions
+  to mix thread unsafe implementations with threadsafe user data.
 
 ## 0.23.5 -- 2019-06-13
 


### PR DESCRIPTION
This follows #269.

I've introduced new implementation functions in `NewProxy` and `NewResource` to be able
to mix thread unsafe implementations with threadsafe user data.

To keep it consistent, it comes in two flavors: `implement` and `implement_closure`. I've also modified the documentation of the non-threadsafe functions, I hope it's ok.