### PR TITLE
client/server: introduce DispatchData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- [client/server] Introduce the `DispatchData` mechanism, allowing global state to be shared with the
+  filters and callbaks during an event dispatch.
+
 ## 0.24.1 -- 2019-12-13
 
 - [client] Add `get_connection_fd()` to `Display` as well as `EventQueue`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,9 @@ name = "client_proxies"
 name = "destructors"
 
 [[test]]
+name = "dispatch_data"
+
+[[test]]
 name = "globals"
 
 [[test]]

--- a/tests/attach_to_surface.rs
+++ b/tests/attach_to_surface.rs
@@ -24,7 +24,7 @@ fn insert_compositor(server: &mut TestServer) -> Arc<Mutex<Option<Option<ServerB
         Surface => wl_surface::WlSurface
     );
 
-    let filter = ways::Filter::new(move |req, filter| match req {
+    let filter = ways::Filter::new(move |req, filter, _| match req {
         Reqs::Compositor {
             request: wl_compositor::Request::CreateSurface { id: surface },
             ..
@@ -45,7 +45,7 @@ fn insert_compositor(server: &mut TestServer) -> Arc<Mutex<Option<Option<ServerB
 
     server
         .display
-        .create_global::<wl_compositor::WlCompositor, _>(1, move |compositor, version| {
+        .create_global::<wl_compositor::WlCompositor, _>(1, move |compositor, version, _| {
             assert!(version == 1);
             compositor.assign(filter.clone());
         });
@@ -64,7 +64,7 @@ fn insert_shm(server: &mut TestServer) -> Arc<Mutex<Option<(RawFd, Option<ways::
         Pool => wl_shm_pool::WlShmPool
     );
 
-    let filter = ways::Filter::new(move |req, filter| match req {
+    let filter = ways::Filter::new(move |req, filter, _| match req {
         Reqs::Shm {
             request: wl_shm::Request::CreatePool { id, fd, size },
             ..
@@ -81,7 +81,7 @@ fn insert_shm(server: &mut TestServer) -> Arc<Mutex<Option<(RawFd, Option<ways::
             let mut guard = buffer.lock().unwrap();
             let buf = guard.as_mut().unwrap();
             assert!(buf.1.is_none());
-            id.assign_mono(|_, _| {});
+            id.quick_assign(|_, _, _| {});
             buf.1 = Some(id);
         }
         _ => {
@@ -91,7 +91,7 @@ fn insert_shm(server: &mut TestServer) -> Arc<Mutex<Option<(RawFd, Option<ways::
 
     server
         .display
-        .create_global::<wl_shm::WlShm, _>(1, move |shm, version| {
+        .create_global::<wl_shm::WlShm, _>(1, move |shm, version, _| {
             assert!(version == 1);
             shm.assign(filter.clone());
         });

--- a/tests/client_bad_requests.rs
+++ b/tests/client_bad_requests.rs
@@ -9,7 +9,7 @@ use wayc::protocol::{wl_keyboard, wl_seat};
 #[test]
 fn constructor_dead() {
     let mut server = TestServer::new();
-    server.display.create_global::<ServerSeat, _>(5, |_, _| {});
+    server.display.create_global::<ServerSeat, _>(5, |_, _, _| {});
 
     let mut client = TestClient::new(&server.socket_name);
     let manager = wayc::GlobalManager::new(&client.display_proxy);
@@ -26,7 +26,7 @@ fn constructor_dead() {
 #[should_panic]
 fn send_constructor_wrong_type() {
     let mut server = TestServer::new();
-    server.display.create_global::<ServerSeat, _>(5, |_, _| {});
+    server.display.create_global::<ServerSeat, _>(5, |_, _, _| {});
 
     let mut client = TestClient::new(&server.socket_name);
     let manager = wayc::GlobalManager::new(&client.display_proxy);

--- a/tests/client_connect_to_env.rs
+++ b/tests/client_connect_to_env.rs
@@ -6,7 +6,7 @@ use ways::protocol::wl_output::WlOutput as ServerOutput;
 
 fn main() {
     let mut server = TestServer::new();
-    server.display.create_global::<ServerOutput, _>(1, |_, _| {});
+    server.display.create_global::<ServerOutput, _>(1, |_, _, _| {});
 
     ::std::env::remove_var("WAYLAND_DISPLAY");
 

--- a/tests/client_connect_to_socket.rs
+++ b/tests/client_connect_to_socket.rs
@@ -8,11 +8,11 @@ use std::os::unix::io::IntoRawFd;
 
 fn main() {
     let mut server = TestServer::new();
-    server.display.create_global::<ServerOutput, _>(2, |_, _| {});
+    server.display.create_global::<ServerOutput, _>(2, |_, _, _| {});
 
     let (s1, s2) = ::std::os::unix::net::UnixStream::pair().unwrap();
 
-    let my_client = unsafe { server.display.create_client(s1.into_raw_fd()) };
+    let my_client = unsafe { server.display.create_client(s1.into_raw_fd(), &mut ()) };
 
     let fd2 = s2.into_raw_fd();
     ::std::env::set_var("WAYLAND_SOCKET", format!("{}", fd2));

--- a/tests/client_dispatch.rs
+++ b/tests/client_dispatch.rs
@@ -20,8 +20,8 @@ fn client_sync_roundtrip() {
         display.add_socket(Some(socket_name)).unwrap();
 
         loop {
-            display.dispatch(Duration::from_millis(10)).unwrap();
-            display.flush_clients();
+            display.dispatch(Duration::from_millis(10), &mut ()).unwrap();
+            display.flush_clients(&mut ());
             if *(server_kill_switch.lock().unwrap()) {
                 break;
             }
@@ -33,7 +33,10 @@ fn client_sync_roundtrip() {
 
     let mut client = TestClient::new(OsStr::new(socket_name));
 
-    client.event_queue.sync_roundtrip(|_, _| unreachable!()).unwrap();
+    client
+        .event_queue
+        .sync_roundtrip(&mut (), |_, _, _| unreachable!())
+        .unwrap();
 
     *(kill_switch.lock().unwrap()) = true;
 
@@ -52,8 +55,8 @@ fn client_dispatch() {
         display.add_socket(Some(socket_name)).unwrap();
 
         loop {
-            display.dispatch(Duration::from_millis(10)).unwrap();
-            display.flush_clients();
+            display.dispatch(Duration::from_millis(10), &mut ()).unwrap();
+            display.flush_clients(&mut ());
             if *(server_kill_switch.lock().unwrap()) {
                 break;
             }
@@ -71,9 +74,12 @@ fn client_dispatch() {
     client
         .display_proxy
         .sync()
-        .assign_mono(move |_, _| done2.set(true));
+        .quick_assign(move |_, _, _| done2.set(true));
     while !done.get() {
-        client.event_queue.dispatch(|_, _| unreachable!()).unwrap();
+        client
+            .event_queue
+            .dispatch(&mut (), |_, _, _| unreachable!())
+            .unwrap();
     }
 
     *(kill_switch.lock().unwrap()) = true;

--- a/tests/client_multithread.rs
+++ b/tests/client_multithread.rs
@@ -21,11 +21,11 @@ fn display_to_new_thread() {
     let server_thread = thread::spawn(move || {
         let mut display = ways::Display::new();
         display.add_socket(Some(socket_name)).unwrap();
-        display.create_global::<ServerSeat, _>(5, |_, _| {});
+        display.create_global::<ServerSeat, _>(5, |_, _, _| {});
 
         loop {
-            display.dispatch(Duration::from_millis(10)).unwrap();
-            display.flush_clients();
+            display.dispatch(Duration::from_millis(10), &mut ()).unwrap();
+            display.flush_clients(&mut ());
             if *(server_kill_switch.lock().unwrap()) {
                 break;
             }
@@ -43,7 +43,7 @@ fn display_to_new_thread() {
         let mut evq = display_clone.create_event_queue();
         let attached = (**display_clone).clone().attach(evq.get_token());
         let manager = wayc::GlobalManager::new(&attached);
-        evq.sync_roundtrip(|_, _| unreachable!()).unwrap();
+        evq.sync_roundtrip(&mut (), |_, _, _| unreachable!()).unwrap();
         manager.instantiate_exact::<wl_seat::WlSeat>(5).unwrap();
     })
     .join()
@@ -65,11 +65,11 @@ fn display_from_external_on_new_thread() {
     let server_thread = thread::spawn(move || {
         let mut display = ways::Display::new();
         display.add_socket(Some(socket_name)).unwrap();
-        display.create_global::<ServerSeat, _>(5, |_, _| {});
+        display.create_global::<ServerSeat, _>(5, |_, _, _| {});
 
         loop {
-            display.dispatch(Duration::from_millis(10)).unwrap();
-            display.flush_clients();
+            display.dispatch(Duration::from_millis(10), &mut ()).unwrap();
+            display.flush_clients(&mut ());
             if *(server_kill_switch.lock().unwrap()) {
                 break;
             }
@@ -88,11 +88,11 @@ fn display_from_external_on_new_thread() {
         let mut evq = display.create_event_queue();
         let attached = (*display).clone().attach(evq.get_token());
         let manager = wayc::GlobalManager::new(&attached);
-        evq.sync_roundtrip(|_, _| {}).unwrap();
+        evq.sync_roundtrip(&mut (), |_, _, _| {}).unwrap();
         manager
             .instantiate_exact::<wl_seat::WlSeat>(5)
             .unwrap()
-            .assign_mono(|_, _| {});
+            .quick_assign(|_, _, _| {});
     })
     .join()
     .unwrap();

--- a/tests/client_proxies.rs
+++ b/tests/client_proxies.rs
@@ -12,7 +12,9 @@ use wayc::Proxy;
 #[test]
 fn proxy_equals() {
     let mut server = TestServer::new();
-    server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, _| {});
 
     let mut client = TestClient::new(&server.socket_name);
     let manager = wayc::GlobalManager::new(&client.display_proxy);
@@ -37,7 +39,9 @@ fn proxy_equals() {
 #[test]
 fn proxy_user_data() {
     let mut server = TestServer::new();
-    server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, _| {});
 
     let mut client = TestClient::new(&server.socket_name);
     let manager = wayc::GlobalManager::new(&client.display_proxy);
@@ -67,7 +71,9 @@ fn proxy_user_data() {
 #[test]
 fn proxy_user_data_wrong_thread() {
     let mut server = TestServer::new();
-    server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, _| {});
 
     let mut client = TestClient::new(&server.socket_name);
     let manager = wayc::GlobalManager::new(&client.display_proxy);
@@ -94,7 +100,9 @@ fn proxy_user_data_wrong_thread() {
 #[test]
 fn proxy_wrapper() {
     let mut server = TestServer::new();
-    server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, _| {});
 
     let mut client = TestClient::new(&server.socket_name);
 
@@ -106,7 +114,9 @@ fn proxy_wrapper() {
     // event_queue_2 has not been dispatched
     assert!(manager.list().len() == 0);
 
-    event_queue_2.dispatch_pending(|_, _| unreachable!()).unwrap();
+    event_queue_2
+        .dispatch_pending(&mut (), |_, _, _| unreachable!())
+        .unwrap();
 
     assert!(manager.list().len() == 1);
 }
@@ -114,7 +124,9 @@ fn proxy_wrapper() {
 #[test]
 fn proxy_create_unattached() {
     let mut server = TestServer::new();
-    server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, _| {});
 
     let mut client = TestClient::new(&server.socket_name);
 
@@ -139,7 +151,9 @@ fn proxy_create_unattached() {
 #[test]
 fn proxy_create_attached() {
     let mut server = TestServer::new();
-    server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, _| {});
 
     let mut client = TestClient::new(&server.socket_name);
 
@@ -166,7 +180,7 @@ fn proxy_create_attached() {
 #[test]
 fn dead_proxies() {
     let mut server = TestServer::new();
-    server.display.create_global::<ServerOutput, _>(3, |_, _| {});
+    server.display.create_global::<ServerOutput, _>(3, |_, _, _| {});
 
     let mut client = TestClient::new(&server.socket_name);
     let manager = wayc::GlobalManager::new(&client.display_proxy);

--- a/tests/destructors.rs
+++ b/tests/destructors.rs
@@ -16,10 +16,10 @@ fn resource_destructor_request() {
     let mut server = TestServer::new();
     server
         .display
-        .create_global::<ServerOutput, _>(3, move |newo, _| {
+        .create_global::<ServerOutput, _>(3, move |newo, _, _| {
             let destructor_called_resource = destructor_called_global.clone();
-            newo.assign_mono(|_, _| {});
-            newo.assign_destructor(ways::Filter::new(move |_: ways::Resource<_>, _| {
+            newo.quick_assign(|_, _, _| {});
+            newo.assign_destructor(ways::Filter::new(move |_: ways::Resource<_>, _, _| {
                 *destructor_called_resource.lock().unwrap() = true;
             }));
         });
@@ -48,9 +48,9 @@ fn resource_destructor_cleanup() {
     let mut server = TestServer::new();
     server
         .display
-        .create_global::<ServerOutput, _>(3, move |newo, _| {
+        .create_global::<ServerOutput, _>(3, move |newo, _, _| {
             let destructor_called_resource = destructor_called_global.clone();
-            newo.assign_destructor(ways::Filter::new(move |_: ways::Resource<_>, _| {
+            newo.assign_destructor(ways::Filter::new(move |_: ways::Resource<_>, _, _| {
                 *destructor_called_resource.lock().unwrap() = true;
             }));
         });
@@ -80,10 +80,10 @@ fn client_destructor_cleanup() {
     let mut server = TestServer::new();
     server
         .display
-        .create_global::<ServerOutput, _>(3, move |output, _| {
+        .create_global::<ServerOutput, _>(3, move |output, _, _| {
             let destructor_called_resource = destructor_called_global.clone();
             let client = output.as_ref().client().unwrap();
-            client.add_destructor(ways::Filter::new(move |_, _| {
+            client.add_destructor(ways::Filter::new(move |_, _, _| {
                 *destructor_called_resource.lock().unwrap() = true;
             }));
         });

--- a/tests/dispatch_data.rs
+++ b/tests/dispatch_data.rs
@@ -1,0 +1,170 @@
+mod helpers;
+
+use helpers::{roundtrip, wayc, ways, TestClient, TestServer};
+
+use wayc::protocol::wl_compositor;
+use ways::protocol::wl_compositor::WlCompositor as ServerCompositor;
+
+use std::time::Duration;
+
+#[test]
+fn client_dispatch_data() {
+    let mut server = TestServer::new();
+
+    let mut client = TestClient::new(&server.socket_name);
+
+    // do a manual roundtrip
+    let mut done = false;
+    client.display_proxy.sync().quick_assign(move |_, _, mut data| {
+        let done = data.get::<bool>().unwrap();
+        *done = true;
+    });
+    client.display.flush().unwrap();
+    server.answer();
+    client
+        .event_queue
+        .dispatch(&mut done, |_, _, _| unreachable!())
+        .unwrap();
+    assert!(done);
+}
+
+#[test]
+fn server_dispatch_data_global() {
+    let mut server = TestServer::new();
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, mut data| {
+            let done = data.get::<bool>().unwrap();
+            *done = true;
+        });
+
+    let mut client = TestClient::new(&server.socket_name);
+    let manager = wayc::GlobalManager::new(&client.display_proxy);
+    roundtrip(&mut client, &mut server).unwrap();
+
+    manager
+        .instantiate_exact::<wl_compositor::WlCompositor>(1)
+        .unwrap();
+    client.display.flush().unwrap();
+
+    let mut done = false;
+    server
+        .display
+        .dispatch(Duration::from_millis(10), &mut done)
+        .unwrap();
+    assert!(done);
+}
+
+#[test]
+fn server_dispatch_data_client_destructor() {
+    let mut server = TestServer::new();
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, move |compositor, _, _| {
+            compositor
+                .as_ref()
+                .client()
+                .unwrap()
+                .add_destructor(ways::Filter::new(|_, _, mut data| {
+                    let done = data.get::<bool>().unwrap();
+                    *done = true;
+                }));
+        });
+
+    let mut client = TestClient::new(&server.socket_name);
+    let manager = wayc::GlobalManager::new(&client.display_proxy);
+    roundtrip(&mut client, &mut server).unwrap();
+
+    manager
+        .instantiate_exact::<wl_compositor::WlCompositor>(1)
+        .unwrap();
+    roundtrip(&mut client, &mut server).unwrap();
+
+    // the client detructor should be in place and ready
+
+    // disconnect the client
+    std::mem::drop(manager);
+    std::mem::drop(client);
+
+    // process the destructor
+    let mut done = false;
+    // system_lib / rust_impl do not process destructors at the same time
+    server
+        .display
+        .dispatch(Duration::from_millis(10), &mut done)
+        .unwrap();
+    server.display.flush_clients(&mut done);
+    assert!(done);
+}
+
+#[test]
+fn server_dispatch_data_resource() {
+    let mut server = TestServer::new();
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, move |compositor, _, _| {
+            compositor.quick_assign(|_, _, mut data| {
+                let done = data.get::<bool>().unwrap();
+                *done = true;
+            });
+        });
+
+    let mut client = TestClient::new(&server.socket_name);
+    let manager = wayc::GlobalManager::new(&client.display_proxy);
+    roundtrip(&mut client, &mut server).unwrap();
+
+    let compositor = manager
+        .instantiate_exact::<wl_compositor::WlCompositor>(1)
+        .unwrap();
+    roundtrip(&mut client, &mut server).unwrap();
+
+    // the resource filter should be in place and ready
+    compositor.create_surface();
+    client.display.flush().unwrap();
+
+    // process the event
+    let mut done = false;
+    server
+        .display
+        .dispatch(Duration::from_millis(10), &mut done)
+        .unwrap();
+    assert!(done);
+}
+
+#[test]
+fn server_dispatch_data_resource_destructor() {
+    let mut server = TestServer::new();
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, move |compositor, _, _| {
+            compositor.assign_destructor(ways::Filter::new(|_: ways::Resource<_>, _, mut data| {
+                let done = data.get::<bool>().unwrap();
+                *done = true;
+            }));
+        });
+
+    let mut client = TestClient::new(&server.socket_name);
+    let manager = wayc::GlobalManager::new(&client.display_proxy);
+    roundtrip(&mut client, &mut server).unwrap();
+
+    manager
+        .instantiate_exact::<wl_compositor::WlCompositor>(1)
+        .unwrap();
+    roundtrip(&mut client, &mut server).unwrap();
+
+    // the resource detructor should be in place and ready
+
+    // disconnect the client
+    std::mem::drop(manager);
+    std::mem::drop(client);
+
+    // process the destructor
+    let mut done = false;
+    // system_lib / rust_impl do not process destructors at the same time
+    server
+        .display
+        .dispatch(Duration::from_millis(10), &mut done)
+        .unwrap();
+    server.display.flush_clients(&mut done);
+    assert!(done);
+}

--- a/tests/globals.rs
+++ b/tests/globals.rs
@@ -11,7 +11,9 @@ use std::sync::{Arc, Mutex};
 #[test]
 fn simple_global() {
     let mut server = TestServer::new();
-    server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, _| {});
 
     let mut client = TestClient::new(&server.socket_name);
     let manager = wayc::GlobalManager::new(&client.display_proxy);
@@ -25,10 +27,18 @@ fn simple_global() {
 #[test]
 fn multi_versions() {
     let mut server = TestServer::new();
-    server.display.create_global::<ServerCompositor, _>(4, |_, _| {});
-    server.display.create_global::<ServerCompositor, _>(3, |_, _| {});
-    server.display.create_global::<ServerCompositor, _>(2, |_, _| {});
-    server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(4, |_, _, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(3, |_, _, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(2, |_, _, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, _| {});
 
     let mut client = TestClient::new(&server.socket_name);
     let manager = wayc::GlobalManager::new(&client.display_proxy);
@@ -47,7 +57,9 @@ fn multi_versions() {
 #[test]
 fn dynamic_global() {
     let mut server = TestServer::new();
-    server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, _| {});
 
     let mut client = TestClient::new(&server.socket_name);
     let manager = wayc::GlobalManager::new(&client.display_proxy);
@@ -55,12 +67,12 @@ fn dynamic_global() {
     roundtrip(&mut client, &mut server).unwrap();
     assert!(manager.list().len() == 1);
 
-    server.display.create_global::<ServerShell, _>(1, |_, _| {});
+    server.display.create_global::<ServerShell, _>(1, |_, _, _| {});
 
     roundtrip(&mut client, &mut server).unwrap();
     assert!(manager.list().len() == 2);
 
-    let output = server.display.create_global::<ServerOutput, _>(1, |_, _| {});
+    let output = server.display.create_global::<ServerOutput, _>(1, |_, _, _| {});
 
     roundtrip(&mut client, &mut server).unwrap();
     assert!(manager.list().len() == 3);
@@ -76,7 +88,9 @@ fn global_manager_cb() {
     use wayc::GlobalEvent;
 
     let mut server = TestServer::new();
-    server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, _| {});
 
     let counter = Arc::new(Mutex::new(0));
     let counter2 = counter.clone();
@@ -89,9 +103,15 @@ fn global_manager_cb() {
 
     roundtrip(&mut client, &mut server).unwrap();
 
-    server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
-    server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
-    let comp = server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, _| {});
+    let comp = server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, _| {});
 
     roundtrip(&mut client, &mut server).unwrap();
 
@@ -114,8 +134,10 @@ fn range_instantiate() {
     use wayc::GlobalError;
 
     let mut server = TestServer::new();
-    server.display.create_global::<ServerCompositor, _>(4, |_, _| {});
-    server.display.create_global::<ServerShell, _>(1, |_, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(4, |_, _, _| {});
+    server.display.create_global::<ServerShell, _>(1, |_, _, _| {});
 
     let mut client = TestClient::new(&server.socket_name);
     let manager = wayc::GlobalManager::new(&client.display_proxy);
@@ -136,7 +158,9 @@ fn range_instantiate() {
 #[should_panic]
 fn wrong_version_create_global() {
     let mut server = TestServer::new();
-    server.display.create_global::<ServerCompositor, _>(42, |_, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(42, |_, _, _| {});
 }
 
 #[test]
@@ -145,7 +169,9 @@ fn wrong_global() {
     use wayc::protocol::wl_output::WlOutput;
 
     let mut server = TestServer::new();
-    server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, _| {});
 
     let mut client = TestClient::new(&server.socket_name);
     let registry = client.display_proxy.get_registry();
@@ -163,7 +189,9 @@ fn wrong_global_version() {
     use wayc::protocol::wl_compositor::WlCompositor;
 
     let mut server = TestServer::new();
-    server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, _| {});
 
     let mut client = TestClient::new(&server.socket_name);
     let registry = client.display_proxy.get_registry();
@@ -179,7 +207,9 @@ fn invalid_global_version() {
     use wayc::protocol::wl_compositor::WlCompositor;
 
     let mut server = TestServer::new();
-    server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, _| {});
 
     let mut client = TestClient::new(&server.socket_name);
     let registry = client.display_proxy.get_registry();
@@ -196,7 +226,9 @@ fn wrong_global_id() {
     use wayc::protocol::wl_compositor::WlCompositor;
 
     let mut server = TestServer::new();
-    server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, _| {});
 
     let mut client = TestClient::new(&server.socket_name);
     let registry = client.display_proxy.get_registry();
@@ -214,7 +246,9 @@ fn two_step_binding() {
     use wayc::protocol::wl_output::WlOutput;
 
     let mut server = TestServer::new();
-    server.display.create_global::<ServerCompositor, _>(1, |_, _| {});
+    server
+        .display
+        .create_global::<ServerCompositor, _>(1, |_, _, _| {});
 
     let mut client = TestClient::new(&server.socket_name);
     let manager = wayc::GlobalManager::new(&client.display_proxy);
@@ -222,7 +256,7 @@ fn two_step_binding() {
     roundtrip(&mut client, &mut server).unwrap();
 
     // add a new global while clients already exist
-    server.display.create_global::<ServerOutput, _>(1, |_, _| {});
+    server.display.create_global::<ServerOutput, _>(1, |_, _, _| {});
 
     roundtrip(&mut client, &mut server).unwrap();
 

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -33,11 +33,11 @@ impl TestServer {
     }
 
     pub fn answer(&mut self) {
-        self.display.dispatch(Duration::from_millis(10)).unwrap();
-        self.display.flush_clients();
+        self.display.dispatch(Duration::from_millis(10), &mut ()).unwrap();
+        self.display.flush_clients(&mut ());
         // TODO: find out why native_lib requires two dispatches
-        self.display.dispatch(Duration::from_millis(10)).unwrap();
-        self.display.flush_clients();
+        self.display.dispatch(Duration::from_millis(10), &mut ()).unwrap();
+        self.display.flush_clients(&mut ());
     }
 }
 
@@ -90,7 +90,7 @@ pub fn roundtrip(client: &mut TestClient, server: &mut TestServer) -> io::Result
     client
         .display_proxy
         .sync()
-        .assign_mono(move |_, _| done2.set(true));
+        .quick_assign(move |_, _, _| done2.set(true));
     while !done.get() {
         match client.display.flush() {
             Ok(_) => {}
@@ -105,10 +105,10 @@ pub fn roundtrip(client: &mut TestClient, server: &mut TestServer) -> io::Result
         server.answer();
         ::std::thread::sleep(::std::time::Duration::from_millis(100));
         // dispatch all client-side
-        client.event_queue.dispatch_pending(|_, _| {})?;
+        client.event_queue.dispatch_pending(&mut (), |_, _, _| {})?;
         let e = client.event_queue.prepare_read().unwrap().read_events();
         // even if read_events returns an error, some messages may need dispatching
-        client.event_queue.dispatch_pending(|_, _| {})?;
+        client.event_queue.dispatch_pending(&mut (), |_, _, _| {})?;
         e?;
     }
     Ok(())

--- a/tests/protocol_errors.rs
+++ b/tests/protocol_errors.rs
@@ -97,7 +97,7 @@ fn client_receive_error() {
     let my_server_output = server_output.clone();
     server
         .display
-        .create_global::<ways::protocol::wl_output::WlOutput, _>(3, move |output, _| {
+        .create_global::<ways::protocol::wl_output::WlOutput, _>(3, move |output, _, _| {
             *my_server_output.borrow_mut() = Some(output)
         });
 

--- a/tests/server_clients.rs
+++ b/tests/server_clients.rs
@@ -19,7 +19,7 @@ fn client_user_data() {
 
     server.display.create_global::<wl_output::WlOutput, _>(1, {
         let clients = clients.clone();
-        move |output, _| {
+        move |output, _, _| {
             let client = output.as_ref().client().unwrap();
             let ret = client.data_map().insert_if_missing(|| HasOutput);
             // the data should not be already here
@@ -31,7 +31,7 @@ fn client_user_data() {
         .display
         .create_global::<wl_compositor::WlCompositor, _>(1, {
             let clients = clients.clone();
-            move |compositor, _| {
+            move |compositor, _, _| {
                 let client = compositor.as_ref().client().unwrap();
                 let ret = client.data_map().insert_if_missing(|| HasCompositor);
                 // the data should not be already here

--- a/tests/server_global_filter.rs
+++ b/tests/server_global_filter.rs
@@ -19,19 +19,19 @@ fn global_filter() {
     // everyone see the compositor
     server
         .display
-        .create_global::<wl_compositor::WlCompositor, _>(1, |_, _| {});
+        .create_global::<wl_compositor::WlCompositor, _>(1, |_, _, _| {});
 
     // everyone see the shm
     server
         .display
-        .create_global_with_filter::<wl_shm::WlShm, _, _>(1, |_, _| {}, |_| true);
+        .create_global_with_filter::<wl_shm::WlShm, _, _>(1, |_, _, _| {}, |_| true);
 
     // only privileged clients see the output
     let privileged_output = server
         .display
         .create_global_with_filter::<wl_output::WlOutput, _, _>(
             1,
-            |_, _| {},
+            |_, _, _| {},
             |client| client.data_map().get::<Privileged>().is_some(),
         );
 
@@ -45,7 +45,7 @@ fn global_filter() {
 
     let (server_cx, client_cx) = ::std::os::unix::net::UnixStream::pair().unwrap();
 
-    let priv_client = unsafe { server.display.create_client(server_cx.into_raw_fd()) };
+    let priv_client = unsafe { server.display.create_client(server_cx.into_raw_fd(), &mut ()) };
     priv_client.data_map().insert_if_missing(|| Privileged);
 
     let mut client2 = unsafe { TestClient::from_fd(client_cx.into_raw_fd()) };
@@ -82,7 +82,7 @@ fn global_filter_try_force() {
         .display
         .create_global_with_filter::<wl_output::WlOutput, _, _>(
             1,
-            |_, _| {},
+            |_, _, _| {},
             |client| client.data_map().get::<Privileged>().is_some(),
         );
 
@@ -92,7 +92,7 @@ fn global_filter_try_force() {
     // privileged client that can
     let (server_cx, client_cx) = ::std::os::unix::net::UnixStream::pair().unwrap();
 
-    let priv_client = unsafe { server.display.create_client(server_cx.into_raw_fd()) };
+    let priv_client = unsafe { server.display.create_client(server_cx.into_raw_fd(), &mut ()) };
     priv_client.data_map().insert_if_missing(|| Privileged);
 
     let mut client2 = unsafe { TestClient::from_fd(client_cx.into_raw_fd()) };
@@ -127,7 +127,7 @@ fn external_globals() {
     // everyone see the compositor
     server
         .display
-        .create_global::<wl_compositor::WlCompositor, _>(1, |_, _| {});
+        .create_global::<wl_compositor::WlCompositor, _>(1, |_, _, _| {});
 
     // create a global via the C API, it'll not be initialized like a rust one
     unsafe {

--- a/tests/server_resources.rs
+++ b/tests/server_resources.rs
@@ -17,7 +17,7 @@ fn resource_equals() {
 
     server
         .display
-        .create_global::<wl_output::WlOutput, _>(1, move |newo, _| {
+        .create_global::<wl_output::WlOutput, _>(1, move |newo, _, _| {
             outputs2.lock().unwrap().push(newo);
         });
 
@@ -51,7 +51,7 @@ fn resource_user_data() {
 
     server
         .display
-        .create_global::<wl_output::WlOutput, _>(1, move |output, _| {
+        .create_global::<wl_output::WlOutput, _>(1, move |output, _, _| {
             let mut guard = outputs2.lock().unwrap();
             output.as_ref().user_data().set(|| 1000 + guard.len());
             guard.push(output);
@@ -84,8 +84,8 @@ fn dead_resources() {
 
     server
         .display
-        .create_global::<wl_output::WlOutput, _>(3, move |newo, _| {
-            newo.assign_mono(|_, _| {});
+        .create_global::<wl_output::WlOutput, _>(3, move |newo, _, _| {
+            newo.quick_assign(|_, _, _| {});
             outputs2.lock().unwrap().push(newo);
         });
 

--- a/wayland-client/examples/dynamic_globals.rs
+++ b/wayland-client/examples/dynamic_globals.rs
@@ -32,7 +32,7 @@ fn main() {
             [wl_seat::WlSeat, 1, |seat: Main<wl_seat::WlSeat>| {
                 let mut seat_name = None;
                 let mut caps = None;
-                seat.assign_mono(move |_, event| {
+                seat.quick_assign(move |_, event, _| {
                     use wayland_client::protocol::wl_seat::Event;
                     match event {
                         Event::Name { name } => {
@@ -51,7 +51,7 @@ fn main() {
                 let mut name = "<unknown>".to_owned();
                 let mut modes = vec![];
                 let mut scale = 1;
-                output.assign_mono(move |_, event| {
+                output.quick_assign(move |_, event, _| {
                     use wayland_client::protocol::wl_output::Event;
                     match event {
                         Event::Geometry {
@@ -103,7 +103,13 @@ fn main() {
         ),
     );
 
-    event_queue.sync_roundtrip(|_, _| unreachable!()).unwrap();
-    event_queue.sync_roundtrip(|_, _| unreachable!()).unwrap();
-    event_queue.sync_roundtrip(|_, _| unreachable!()).unwrap();
+    event_queue
+        .sync_roundtrip(&mut (), |_, _, _| unreachable!())
+        .unwrap();
+    event_queue
+        .sync_roundtrip(&mut (), |_, _, _| unreachable!())
+        .unwrap();
+    event_queue
+        .sync_roundtrip(&mut (), |_, _, _| unreachable!())
+        .unwrap();
 }

--- a/wayland-client/examples/list_globals.rs
+++ b/wayland-client/examples/list_globals.rs
@@ -20,7 +20,9 @@ fn main() {
 
     // A roundtrip synchronization to make sure the server received our registry
     // creation and sent us the global list
-    event_queue.sync_roundtrip(|_, _| unreachable!()).unwrap();
+    event_queue
+        .sync_roundtrip(&mut (), |_, _, _| unreachable!())
+        .unwrap();
 
     // Print the list
     for (id, interface, version) in globals.list() {

--- a/wayland-client/examples/simple_window.rs
+++ b/wayland-client/examples/simple_window.rs
@@ -29,7 +29,9 @@ fn main() {
     let globals = GlobalManager::new(&attached_display);
 
     // roundtrip to retrieve the globals list
-    event_queue.sync_roundtrip(|_, _| unreachable!()).unwrap();
+    event_queue
+        .sync_roundtrip(&mut (), |_, _, _| unreachable!())
+        .unwrap();
 
     /*
      * Create a buffer with window contents
@@ -86,7 +88,7 @@ fn main() {
         .instantiate_exact::<wl_shell::WlShell>(1)
         .expect("Compositor does not support wl_shell");
     let shell_surface = shell.get_shell_surface(&surface);
-    shell_surface.assign_mono(|shell_surface, event| {
+    shell_surface.quick_assign(|shell_surface, event, _| {
         use wayland_client::protocol::wl_shell_surface::Event;
         // This ping/pong mechanism is used by the wayland server to detect
         // unresponsive applications
@@ -103,7 +105,7 @@ fn main() {
     // initialize a seat to retrieve pointer & keyboard events
     //
     // example of using a common filter to handle both pointer & keyboard events
-    let common_filter = Filter::new(move |event, _| match event {
+    let common_filter = Filter::new(move |event, _, _| match event {
         Events::Pointer { event, .. } => match event {
             wl_pointer::Event::Enter {
                 surface_x, surface_y, ..
@@ -145,7 +147,7 @@ fn main() {
     globals
         .instantiate_exact::<wl_seat::WlSeat>(1)
         .unwrap()
-        .assign_mono(move |seat, event| {
+        .quick_assign(move |seat, event, _| {
             // The capabilities of a seat are known at runtime and we retrieve
             // them via an events. 3 capabilities exists: pointer, keyboard, and touch
             // we are only interested in pointer & keyboard here
@@ -166,12 +168,12 @@ fn main() {
         });
 
     event_queue
-        .sync_roundtrip(|_, _| { /* we ignore unfiltered messages */ })
+        .sync_roundtrip(&mut (), |_, _, _| { /* we ignore unfiltered messages */ })
         .unwrap();
 
     loop {
         event_queue
-            .dispatch(|_, _| { /* we ignore unfiltered messages */ })
+            .dispatch(&mut (), |_, _, _| { /* we ignore unfiltered messages */ })
             .unwrap();
     }
 }

--- a/wayland-client/src/display.rs
+++ b/wayland-client/src/display.rs
@@ -164,10 +164,13 @@ impl Display {
 
     /// Attempt to use an already connected unix socket on given FD to start a wayland connection
     ///
-    /// On success, you are given the `Display` object as well as the main `EventQueue` hosting
-    /// the `WlDisplay` wayland object.
+    /// On success, you are given the `Display` object.
     ///
     /// Will take ownership of the FD.
+    ///
+    /// # Safety
+    ///
+    /// The file descriptor must be associated to a connected unix socket.
     pub unsafe fn from_fd(fd: RawFd) -> Result<Display, ConnectError> {
         Ok(Display {
             inner: DisplayInner::from_fd(fd)?,
@@ -223,6 +226,10 @@ impl Display {
     ///
     /// Note that if you need to retrieve the actual `wl_display` pointer back (rather than
     /// its wrapper), you must use the `get_display_ptr()` method.
+    ///
+    /// # Safety
+    ///
+    /// The provided pointer must point to a valid `wl_display` from `libwayland-client`
     pub unsafe fn from_external_display(display_ptr: *mut wl_display) -> Display {
         Display {
             inner: DisplayInner::from_external(display_ptr),

--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -28,9 +28,8 @@ use crate::{AnonymousObject, DispatchData, Main, RawEvent};
 /// ```no_run
 /// # extern crate wayland_client;
 /// # use wayland_client::{Display};
-/// # fn main() {
-/// #     let display = Display::connect_to_env().unwrap();
-/// #     let mut event_queue = display.create_event_queue();
+/// # let display = Display::connect_to_env().unwrap();
+/// # let mut event_queue = display.create_event_queue();
 /// loop {
 ///     // The dispatch() method returns once it has received some events to dispatch
 ///     // and have emptied the wayland socket from its pending messages, so it needs
@@ -43,7 +42,6 @@ use crate::{AnonymousObject, DispatchData, Main, RawEvent};
 ///         unreachable!();
 ///     }).expect("An error occurred during event dispatching!");
 /// }
-/// # }
 /// ```
 ///
 /// The second way is more appropriate for apps that are either multithreaded (and need to process
@@ -54,7 +52,6 @@ use crate::{AnonymousObject, DispatchData, Main, RawEvent};
 /// ```no_run
 /// # extern crate wayland_client;
 /// # use wayland_client::Display;
-/// # fn main() {
 /// # let display = Display::connect_to_env().unwrap();
 /// # let mut event_queue = display.create_event_queue();
 /// loop {
@@ -100,7 +97,6 @@ use crate::{AnonymousObject, DispatchData, Main, RawEvent};
 ///     // The wayland socket can also be integrated in a poll-like mechanism by using
 ///     // the file descriptor provided by the `get_connection_fd()` method.
 /// }
-/// # }
 /// ```
 pub struct EventQueue {
     // EventQueue is *not* Send

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -78,7 +78,7 @@ impl GlobalManager {
             .as_ref()
             .send::<wl_registry::WlRegistry>(wl_display::Request::GetRegistry {}, None)
             .unwrap();
-        registry.assign_mono(move |_proxy, msg| {
+        registry.quick_assign(move |_proxy, msg, _data| {
             let mut inner = inner.lock().unwrap();
             match msg {
                 wl_registry::Event::Global {
@@ -123,7 +123,7 @@ impl GlobalManager {
             .as_ref()
             .send::<wl_registry::WlRegistry>(wl_display::Request::GetRegistry {}, None)
             .unwrap();
-        registry.assign_mono(move |proxy, msg| {
+        registry.quick_assign(move |proxy, msg, _data| {
             let mut inner = inner.lock().unwrap();
             let inner = &mut *inner;
             match msg {

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -109,7 +109,11 @@ pub use event_queue::{EventQueue, QueueToken, ReadEventsGuard};
 pub use globals::{GlobalError, GlobalEvent, GlobalImplementor, GlobalManager};
 pub use imp::ProxyMap;
 pub use proxy::{Attached, Main, Proxy};
-pub use wayland_commons::{filter::Filter, user_data::UserData, Interface, MessageGroup, NoMessage};
+pub use wayland_commons::{
+    filter::{DispatchData, Filter},
+    user_data::UserData,
+    Interface, MessageGroup, NoMessage,
+};
 
 // rust implementation
 #[cfg(not(feature = "use_system_lib"))]

--- a/wayland-client/src/native_lib/event_queue.rs
+++ b/wayland-client/src/native_lib/event_queue.rs
@@ -11,6 +11,7 @@ scoped_tls::scoped_thread_local! {
     pub(crate) static DISPATCH_METADATA: RefCell<(&mut dyn FnMut(RawEvent, Main<AnonymousObject>, DispatchData), DispatchData)>
 }
 
+#[allow(clippy::transmute_ptr_to_ptr)]
 fn with_dispatch_meta<T, FB, F>(mut fb: FB, data: DispatchData, f: F) -> T
 where
     FB: FnMut(RawEvent, Main<AnonymousObject>, DispatchData),

--- a/wayland-client/src/proxy.rs
+++ b/wayland-client/src/proxy.rs
@@ -272,13 +272,13 @@ where
     /// you want to assign this object to its own filter. In which
     /// case you just need to provide the appropriate closure, of
     /// type `FnMut(Main<I>, I::Event)`.
-    pub fn assign_mono<F>(&self, mut f: F)
+    pub fn quick_assign<F>(&self, mut f: F)
     where
         I: Interface + AsRef<Proxy<I>> + From<Proxy<I>> + Sync,
-        F: FnMut(Main<I>, I::Event) + 'static,
+        F: FnMut(Main<I>, I::Event, crate::DispatchData) + 'static,
         I::Event: MessageGroup<Map = crate::ProxyMap>,
     {
-        self.assign(Filter::new(move |(proxy, event), _| f(proxy, event)))
+        self.assign(Filter::new(move |(proxy, event), _, data| f(proxy, event, data)))
     }
 }
 

--- a/wayland-client/src/proxy.rs
+++ b/wayland-client/src/proxy.rs
@@ -338,6 +338,10 @@ where
     ///
     /// NOTE: This method will panic if called while the `use_system_lib` feature is
     /// not activated.
+    ///
+    /// # Safety
+    ///
+    /// The provided pointer must point to a valid wayland object from `libwayland-client`
     pub unsafe fn from_c_ptr(_ptr: *mut wl_proxy) -> Main<I> {
         #[cfg(feature = "use_system_lib")]
         {
@@ -409,6 +413,11 @@ impl<I: Interface + AsRef<Proxy<I>> + From<Proxy<I>>> Proxy<I> {
     ///
     /// NOTE: This method will panic if called while the `use_system_lib` feature is
     /// not activated.
+    ///
+    /// # Safety
+    ///
+    /// The provided pointer must point to a valid wayland object from `libwayland-client`
+    /// with the correct interface.
     pub unsafe fn from_c_ptr(_ptr: *mut wl_proxy) -> Proxy<I>
     where
         I: From<Proxy<I>>,

--- a/wayland-client/src/rust_imp/display.rs
+++ b/wayland-client/src/rust_imp/display.rs
@@ -89,7 +89,13 @@ struct DisplayDispatcher {
 }
 
 impl super::Dispatcher for DisplayDispatcher {
-    fn dispatch(&mut self, msg: Message, proxy: ProxyInner, map: &mut ProxyMap) -> Dispatched {
+    fn dispatch(
+        &mut self,
+        msg: Message,
+        proxy: ProxyInner,
+        map: &mut ProxyMap,
+        _data: crate::DispatchData,
+    ) -> Dispatched {
         let opcode = msg.opcode as usize;
         if ::std::env::var_os("WAYLAND_DEBUG").is_some() {
             eprintln!(

--- a/wayland-client/src/rust_imp/display.rs
+++ b/wayland-client/src/rust_imp/display.rs
@@ -23,7 +23,7 @@ impl DisplayInner {
     pub unsafe fn from_fd(fd: RawFd) -> Result<Arc<DisplayInner>, ConnectError> {
         // The special buffer for display events
         let buffer = super::queues::create_queue_buffer();
-        let display_object = Object::from_interface::<WlDisplay>(1, ObjectMeta::new(buffer.clone()));
+        let display_object = Object::from_interface::<WlDisplay>(1, ObjectMeta::new(buffer));
         let (connection, map) = {
             let c = Connection::new(fd, display_object);
             let m = c.map.clone();
@@ -41,7 +41,7 @@ impl DisplayInner {
             })
             .unwrap();
 
-        let display_proxy = ProxyInner::from_id(1, map.clone(), connection.clone()).unwrap();
+        let display_proxy = ProxyInner::from_id(1, map, connection.clone()).unwrap();
 
         let display = DisplayInner {
             proxy: Proxy::wrap(display_proxy),

--- a/wayland-commons/src/filter.rs
+++ b/wayland-commons/src/filter.rs
@@ -2,12 +2,54 @@
 
 use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 
+/// Holder of global dispatch-related data
+///
+/// This struct serves as a dynamic container for the dispatch-time
+/// global data that you gave to the dispatch method, and is given as
+/// input to all your callbacks. It allows you to share global state
+/// between your filters.
+///
+/// The main method of interest is the `get` method, which allows you to
+/// access a `&mut _` reference to the global data itself. The other methods
+/// are mostly used internally by the crate.
+pub struct DispatchData<'a> {
+    data: &'a mut dyn std::any::Any,
+}
+
+impl<'a> DispatchData<'a> {
+    /// Access the dispatch data knowing its type
+    ///
+    /// Will return `None` if the provided type is not the correct
+    /// inner type.
+    pub fn get<T: std::any::Any>(&mut self) -> Option<&mut T> {
+        self.data.downcast_mut()
+    }
+
+    /// Wrap a mutable reference
+    ///
+    /// This creates a new `DispatchData` from a mutable reference
+    pub fn wrap<T: std::any::Any>(data: &'a mut T) -> DispatchData<'a> {
+        DispatchData { data }
+    }
+
+    /// Reborrows this `DispatchData` to create a new one with the same content
+    ///
+    /// This is a quick and cheap way to propagate the `DispatchData` down a
+    /// callback stack by value. It is basically a noop only there to ease
+    /// work with the borrow checker.
+    pub fn reborrow(&mut self) -> DispatchData {
+        DispatchData {
+            data: &mut *self.data,
+        }
+    }
+}
+
 struct Inner<E, F: ?Sized> {
     pending: RefCell<VecDeque<E>>,
     cb: RefCell<F>,
 }
 
-type DynInner<E> = Inner<E, dyn FnMut(E, &Filter<E>)>;
+type DynInner<E> = Inner<E, dyn FnMut(E, &Filter<E>, DispatchData<'_>)>;
 
 /// An event filter
 ///
@@ -37,7 +79,7 @@ impl<E> Clone for Filter<E> {
 
 impl<E> Filter<E> {
     /// Create a new filter from given closure
-    pub fn new<F: FnMut(E, &Filter<E>) + 'static>(f: F) -> Filter<E> {
+    pub fn new<F: FnMut(E, &Filter<E>, DispatchData<'_>) + 'static>(f: F) -> Filter<E> {
         Filter {
             inner: Rc::new(Inner {
                 pending: RefCell::new(VecDeque::new()),
@@ -47,13 +89,13 @@ impl<E> Filter<E> {
     }
 
     /// Send a message to this filter
-    pub fn send(&self, evt: E) {
+    pub fn send(&self, evt: E, mut data: DispatchData) {
         // gracefully handle reentrancy
         if let Ok(mut guard) = self.inner.cb.try_borrow_mut() {
-            (&mut *guard)(evt, self);
+            (&mut *guard)(evt, self, data.reborrow());
             // process all events that might have been enqueued by the cb
             while let Some(evt) = self.inner.pending.borrow_mut().pop_front() {
-                (&mut *guard)(evt, self);
+                (&mut *guard)(evt, self, data.reborrow());
             }
         } else {
             self.inner.pending.borrow_mut().push_back(evt);

--- a/wayland-commons/src/lib.rs
+++ b/wayland-commons/src/lib.rs
@@ -61,6 +61,11 @@ pub trait MessageGroup: Sized {
     /// Turn this message into its raw representation
     fn into_raw(self, send_id: u32) -> wire::Message;
     /// Construct a message of this group from its C representation
+    ///
+    /// # Safety
+    ///
+    /// The pointers provided to this function must all be valid pointers from
+    /// `libwayland-client`
     unsafe fn from_raw_c(obj: *mut c_void, opcode: u32, args: *const syscom::wl_argument)
         -> Result<Self, ()>;
     /// Build a C representation of this message

--- a/wayland-egl/src/lib.rs
+++ b/wayland-egl/src/lib.rs
@@ -42,7 +42,9 @@ impl WlEglSurface {
 
     /// Create an EGL surface from a raw pointer to a wayland surface
     ///
-    /// This function is unsafe because `surface` must be a valid wl_surface pointer
+    /// # Safety
+    ///
+    /// The provided pointer must be a valid `wl_surface` pointer from `libwayland-client`.
     pub unsafe fn new_from_raw(surface: *mut wl_proxy, width: i32, height: i32) -> WlEglSurface {
         let ptr = ffi_dispatch!(WAYLAND_EGL_HANDLE, wl_egl_window_create, surface, width, height);
         WlEglSurface { ptr }

--- a/wayland-scanner/src/lib.rs
+++ b/wayland-scanner/src/lib.rs
@@ -31,20 +31,18 @@
 //!
 //! use wayland_scanner::{Side, generate_code};
 //!
-//! fn main() {
-//!     // Location of the xml file, relative to the `Cargo.toml`
-//!     let protocol_file = "./my_protocol.xml";
+//! // Location of the xml file, relative to the `Cargo.toml`
+//! let protocol_file = "./my_protocol.xml";
 //!
-//!     // Target directory for the generate files
-//!     let out_dir_str = var("OUT_DIR").unwrap();
-//!     let out_dir = Path::new(&out_dir_str);
+//! // Target directory for the generate files
+//! let out_dir_str = var("OUT_DIR").unwrap();
+//! let out_dir = Path::new(&out_dir_str);
 //!
-//!     generate_code(
-//!         protocol_file,
-//!         out_dir.join("my_protocol_api.rs"),
-//!         Side::Client, // Replace by `Side::Server` for server-side code
-//!     );
-//! }
+//! generate_code(
+//!     protocol_file,
+//!     out_dir.join("my_protocol_api.rs"),
+//!     Side::Client, // Replace by `Side::Server` for server-side code
+//! );
 //! ```
 //!
 //! The above example will output two `.rs` files in the `OUT_DIR` defined by
@@ -195,5 +193,5 @@ pub fn generate_code_streams_with_destructor_events<P1: Read, P2: Write>(
         Side::Server => c_code_gen::generate_protocol_server(protocol),
     };
 
-    write!(target, "{}", output.clone()).unwrap();
+    write!(target, "{}", output).unwrap();
 }

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -23,10 +23,11 @@ libc = "0.2"
 nix = "0.15"
 lazy_static = { version = "1.0", optional = true}
 parking_lot = "0.9"
+scoped-tls = { version = "1.0", optional = true }
 
 [build-dependencies]
 wayland-scanner = { version = "0.24.1", path = "../wayland-scanner" }
 
 [features]
-use_system_lib = [ "wayland-sys/server", "lazy_static" ]
+use_system_lib = [ "wayland-sys/server", "lazy_static", "scoped-tls" ]
 dlopen = [ "wayland-sys/dlopen", "use_system_lib" ]

--- a/wayland-server/src/client.rs
+++ b/wayland-server/src/client.rs
@@ -77,7 +77,8 @@ impl Client {
     /// **Panics**: This function will panic if called from an other thread than the one
     /// hosting the Display.
     pub fn add_destructor(&self, destructor: crate::Filter<Arc<UserDataMap>>) {
-        self.inner.add_destructor(move |ud| destructor.send(ud));
+        self.inner
+            .add_destructor(move |ud, data| destructor.send(ud, data));
     }
 
     /// Creates a new resource for this client

--- a/wayland-server/src/client.rs
+++ b/wayland-server/src/client.rs
@@ -17,7 +17,11 @@ pub struct Client {
 
 impl Client {
     #[cfg(feature = "use_system_lib")]
-    /// Creates a client from a `wayland-server.so` pointer
+    /// Creates a client from a pointer
+    ///
+    /// # Safety
+    ///
+    /// The provided pointer must be a valid pointer from `libwayland-server`.
     pub unsafe fn from_ptr(ptr: *mut wl_client) -> Client {
         Client {
             inner: ClientInner::from_ptr(ptr),
@@ -25,7 +29,7 @@ impl Client {
     }
 
     #[cfg(feature = "use_system_lib")]
-    /// Returns a pointer to the underlying `wl_client` of `wayland-server.so`
+    /// Returns a pointer to the underlying `wl_client` of `libwayland-server`
     pub fn c_ptr(&self) -> *mut wl_client {
         self.inner.ptr()
     }

--- a/wayland-server/src/display.rs
+++ b/wayland-server/src/display.rs
@@ -213,6 +213,8 @@ impl Display {
     /// The library takes ownership of the provided socket if this method returns
     /// successfully.
     ///
+    /// # Safety
+    ///
     /// The existing socket fd must already be created, opened, and locked.
     /// The fd must be properly set to CLOEXEC and bound to a socket file
     /// with both bind() and listen() already called. An error is returned
@@ -222,6 +224,10 @@ impl Display {
     }
 
     /// Create a new client to this display from an already-existing connected Fd
+    ///
+    /// # Safety
+    ///
+    /// The provided file descriptor must be associated to a valid client connection.
     pub unsafe fn create_client<T: std::any::Any>(&self, fd: RawFd, data: &mut T) -> Client {
         let data = crate::DispatchData::wrap(data);
         Client::make(self.inner.borrow_mut().create_client(fd, data))

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -91,7 +91,10 @@ pub use resource::{Main, Resource};
 
 pub use anonymous_object::AnonymousObject;
 pub use wayland_commons::user_data::UserDataMap;
-pub use wayland_commons::{filter::Filter, Interface, MessageGroup, NoMessage};
+pub use wayland_commons::{
+    filter::{DispatchData, Filter},
+    Interface, MessageGroup, NoMessage,
+};
 
 /// C-associated types
 ///

--- a/wayland-server/src/resource.rs
+++ b/wayland-server/src/resource.rs
@@ -298,13 +298,13 @@ where
     /// you want to assign this object to its own filter. In which
     /// case you just need to provide the appropriate closure, of
     /// type `FnMut(Main<I>, I::Event)`.
-    pub fn assign_mono<F>(&self, mut f: F)
+    pub fn quick_assign<F>(&self, mut f: F)
     where
         I: Interface + AsRef<Resource<I>> + From<Resource<I>>,
-        F: FnMut(Main<I>, I::Request) + 'static,
+        F: FnMut(Main<I>, I::Request, crate::DispatchData) + 'static,
         I::Request: MessageGroup<Map = crate::ResourceMap>,
     {
-        self.assign(Filter::new(move |(proxy, event), _| f(proxy, event)))
+        self.assign(Filter::new(move |(proxy, event), _, data| f(proxy, event, data)))
     }
 
     /// Assign a destructor to this object

--- a/wayland-server/src/resource.rs
+++ b/wayland-server/src/resource.rs
@@ -203,6 +203,11 @@ where
     ///
     /// NOTE: This method will panic if called while the `use_system_lib` feature is not
     /// activated
+    ///
+    /// # Safety
+    ///
+    /// The provided pointer must be a valid pointer to a wayland object from
+    /// `libwayland-client` associated to the correct interface.
     pub unsafe fn from_c_ptr(_ptr: *mut wl_resource) -> Self
     where
         I: From<Resource<I>>,
@@ -330,6 +335,11 @@ where
     ///
     /// NOTE: This method will panic if called while the `use_system_lib` feature is not
     /// activated
+    ///
+    /// # Safety
+    ///
+    /// The provided pointer must be a valid pointer to a wayland object from
+    /// `libwayland-client` associated to the correct interface.
     pub unsafe fn init_from_c_ptr(_ptr: *mut wl_resource) -> Self {
         #[cfg(feature = "use_system_lib")]
         {

--- a/wayland-server/src/rust_imp/globals.rs
+++ b/wayland-server/src/rust_imp/globals.rs
@@ -32,11 +32,13 @@ impl<I: Interface> GlobalInner<I> {
     }
 }
 
+type GlobalImplementation = dyn Fn(u32, u32, ClientInner, DispatchData) -> Result<(), ()>;
+
 struct GlobalData {
     version: u32,
     interface: &'static str,
     destroyed: Rc<Cell<bool>>,
-    implem: Box<dyn Fn(u32, u32, ClientInner, DispatchData) -> Result<(), ()>>,
+    implem: Box<GlobalImplementation>,
     filter: Option<GlobalFilter>,
 }
 
@@ -85,7 +87,7 @@ impl GlobalManager {
                 };
                 if let Some(map) = map {
                     (&mut *implem.borrow_mut())(
-                        Main::wrap(ResourceInner::from_id(newid, map, client.clone()).unwrap()),
+                        Main::wrap(ResourceInner::from_id(newid, map, client).unwrap()),
                         version,
                         data,
                     )
@@ -141,6 +143,7 @@ impl GlobalManager {
         self.self_cleanup();
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn bind(
         &self,
         registry_id: u32,

--- a/wayland-server/src/rust_imp/mod.rs
+++ b/wayland-server/src/rust_imp/mod.rs
@@ -143,10 +143,8 @@ where
             if kill {
                 resource.client.kill();
             }
-            (self.implementation)(message, Main::<I>::wrap(resource.clone()), data);
-        } else {
-            (self.implementation)(message, Main::<I>::wrap(resource), data);
         }
+        (self.implementation)(message, Main::<I>::wrap(resource), data);
         Dispatched::Yes
     }
 }

--- a/wayland-server/src/rust_imp/resources.rs
+++ b/wayland-server/src/rust_imp/resources.rs
@@ -10,7 +10,7 @@ use wayland_commons::{MessageGroup, ThreadGuard};
 
 use super::{ClientInner, Dispatcher};
 
-pub(crate) type ResourceDestructor = RefCell<dyn FnMut(ResourceInner)>;
+pub(crate) type ResourceDestructor = RefCell<dyn FnMut(ResourceInner, crate::DispatchData<'_>)>;
 
 #[derive(Clone)]
 pub(crate) struct ObjectMeta {

--- a/wayland-sys/src/lib.rs
+++ b/wayland-sys/src/lib.rs
@@ -18,11 +18,9 @@
 //!
 //! use wayland_sys::client::*;
 //!
-//! fn main() {
-//!     let display_ptr = unsafe {
+//! let display_ptr = unsafe {
 //!         ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_display_connect, ::std::ptr::null())
-//!     };
-//! }
+//! };
 //! ```
 //!
 //! Each module except `common` corresponds to a system library. They all define a function named


### PR DESCRIPTION
The DispatchData mechanism allows global data to be shared by the scope
calling dispatch() with all callbacks that dispatch() invokes, at the
cost of some small runtime checks (basically Any::downcast).