### PR TITLE
Resolve clippy warnings

### DIFF
--- a/wayland-client/src/display.rs
+++ b/wayland-client/src/display.rs
@@ -34,21 +34,17 @@ pub enum ConnectError {
     InvalidFd,
 }
 
-impl ::std::error::Error for ConnectError {
-    fn description(&self) -> &str {
-        match *self {
-            ConnectError::NoWaylandLib => "Could not find libwayland-client.so.",
-            ConnectError::XdgRuntimeDirNotSet => "XDG_RUNTIME_DIR is not set.",
-            ConnectError::NoCompositorListening => "Could not find a listening wayland compositor.",
-            ConnectError::InvalidName => "The wayland socket name is invalid.",
-            ConnectError::InvalidFd => "The FD provided in WAYLAND_SOCKET is invalid.",
-        }
-    }
-}
+impl ::std::error::Error for ConnectError {}
 
 impl ::std::fmt::Display for ConnectError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
-        f.write_str(::std::error::Error::description(self))
+        match *self {
+            ConnectError::NoWaylandLib => f.write_str("Could not find libwayland-client.so."),
+            ConnectError::XdgRuntimeDirNotSet => f.write_str("XDG_RUNTIME_DIR is not set."),
+            ConnectError::NoCompositorListening => f.write_str("Could not find a listening wayland compositor."),
+            ConnectError::InvalidName => f.write_str("The wayland socket name is invalid."),
+            ConnectError::InvalidFd => f.write_str("The FD provided in WAYLAND_SOCKET is invalid."),
+        }
     }
 }
 

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -29,18 +29,14 @@ pub enum GlobalError {
     VersionTooLow(u32),
 }
 
-impl ::std::error::Error for GlobalError {
-    fn description(&self) -> &str {
-        match *self {
-            GlobalError::Missing => "The requested global was missing.",
-            GlobalError::VersionTooLow(_) => "The requested global's version is too low.",
-        }
-    }
-}
+impl ::std::error::Error for GlobalError {}
 
 impl ::std::fmt::Display for GlobalError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
-        f.write_str(::std::error::Error::description(self))
+        match *self {
+            GlobalError::Missing => f.write_str("The requested global was missing."),
+            GlobalError::VersionTooLow(_) => f.write_str("The requested global's version is too low."),
+        }
     }
 }
 

--- a/wayland-commons/src/wire.rs
+++ b/wayland-commons/src/wire.rs
@@ -115,20 +115,16 @@ pub enum MessageWriteError {
     DupFdFailed(::nix::Error),
 }
 
-impl ::std::error::Error for MessageWriteError {
-    fn description(&self) -> &str {
-        match *self {
-            MessageWriteError::BufferTooSmall => "The provided buffer is too small to hold message content.",
-            MessageWriteError::DupFdFailed(_) => {
-                "The message contains a file descriptor that could not be dup()-ed."
-            }
-        }
-    }
-}
+impl ::std::error::Error for MessageWriteError {}
 
 impl ::std::fmt::Display for MessageWriteError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
-        f.write_str(::std::error::Error::description(self))
+        match *self {
+            MessageWriteError::BufferTooSmall => f.write_str("The provided buffer is too small to hold message content."),
+            MessageWriteError::DupFdFailed(_) => {
+                f.write_str("The message contains a file descriptor that could not be dup()-ed.")
+            }
+        }
     }
 }
 
@@ -143,19 +139,15 @@ pub enum MessageParseError {
     Malformed,
 }
 
-impl ::std::error::Error for MessageParseError {
-    fn description(&self) -> &str {
-        match *self {
-            MessageParseError::MissingFD => "The message references a FD but the buffer FD is empty.",
-            MessageParseError::MissingData => "More data is needed to deserialize the message",
-            MessageParseError::Malformed => "The message is malformed and cannot be parsed",
-        }
-    }
-}
+impl ::std::error::Error for MessageParseError {}
 
 impl ::std::fmt::Display for MessageParseError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
-        f.write_str(::std::error::Error::description(self))
+        match *self {
+            MessageParseError::MissingFD => f.write_str("The message references a FD but the buffer FD is empty."),
+            MessageParseError::MissingData => f.write_str("More data is needed to deserialize the message"),
+            MessageParseError::Malformed => f.write_str("The message is malformed and cannot be parsed"),
+        }
     }
 }
 

--- a/wayland-protocols/build.rs
+++ b/wayland-protocols/build.rs
@@ -4,13 +4,16 @@ use std::env::var;
 use std::path::Path;
 use wayland_scanner::*;
 
-static STABLE_PROTOCOLS: &[(&str, &[(&str, &str)])] = &[
+type StableProtocol<'a> = (&'a str, &'a [(&'a str, &'a str)]);
+type UnstableProtocol<'a> = (&'a str, &'a [(&'a str, &'a [(&'a str, &'a str)])]);
+
+static STABLE_PROTOCOLS: &[StableProtocol] = &[
     ("presentation-time", &[]),
     ("viewporter", &[]),
     ("xdg-shell", &[]),
 ];
 
-static UNSTABLE_PROTOCOLS: &[(&str, &[(&str, &[(&str, &str)])])] = &[
+static UNSTABLE_PROTOCOLS: &[UnstableProtocol] = &[
     ("fullscreen-shell", &[("v1", &[])]),
     ("idle-inhibit", &[("v1", &[])]),
     ("input-method", &[("v1", &[])]),
@@ -40,7 +43,7 @@ static UNSTABLE_PROTOCOLS: &[(&str, &[(&str, &[(&str, &str)])])] = &[
     ("xwayland-keyboard-grab", &[("v1", &[])]),
 ];
 
-static WLR_UNSTABLE_PROTOCOLS: &[(&str, &[(&str, &[(&str, &str)])])] = &[
+static WLR_UNSTABLE_PROTOCOLS: &[UnstableProtocol] = &[
     ("wlr-data-control", &[("v1", &[])]),
     ("wlr-export-dmabuf", &[("v1", &[])]),
     ("wlr-foreign-toplevel-management", &[("v1", &[])]),
@@ -50,7 +53,7 @@ static WLR_UNSTABLE_PROTOCOLS: &[(&str, &[(&str, &[(&str, &str)])])] = &[
     ("wlr-screencopy", &[("v1", &[])]),
 ];
 
-static MISC_PROTOCOLS: &[(&str, &[(&str, &str)])] = &[("gtk-primary-selection", &[])];
+static MISC_PROTOCOLS: &[StableProtocol] = &[("gtk-primary-selection", &[])];
 
 fn generate_protocol(
     name: &str,


### PR DESCRIPTION
 * Abolish deprecated method `description` of `::std::error::Error.`
 * Factorize complex type into `type` definitions in `wayland-protocols/build.rs`