### PR TITLE
client: track display lifetime in proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+####
+
+- The minimum supported Rust version is now 1.41.0
+
+#### Fixes
+
+- [client] When using the `use_system_lib` feature, track the lifetime of the `Display` so that attempting
+  to send a request after the connection is dropped results in a noop instead of a `SIGSEGV`.
+
 ## 0.25.0 -- 2020-02-07
 
 #### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The documentation for the releases can be found on [docs.rs](https://docs.rs/):
 
 ## Requirements
 
-Requires at least rust 1.40 to be used, and version 1.15 of the wayland system libraries if using the
+Requires at least rust 1.41 to be used, and version 1.15 of the wayland system libraries if using the
 `use_system_lib` cargo feature.
 
 ## Chat and support

--- a/wayland-client/src/display.rs
+++ b/wayland-client/src/display.rs
@@ -41,7 +41,9 @@ impl ::std::fmt::Display for ConnectError {
         match *self {
             ConnectError::NoWaylandLib => f.write_str("Could not find libwayland-client.so."),
             ConnectError::XdgRuntimeDirNotSet => f.write_str("XDG_RUNTIME_DIR is not set."),
-            ConnectError::NoCompositorListening => f.write_str("Could not find a listening wayland compositor."),
+            ConnectError::NoCompositorListening => {
+                f.write_str("Could not find a listening wayland compositor.")
+            }
             ConnectError::InvalidName => f.write_str("The wayland socket name is invalid."),
             ConnectError::InvalidFd => f.write_str("The FD provided in WAYLAND_SOCKET is invalid."),
         }

--- a/wayland-client/src/display.rs
+++ b/wayland-client/src/display.rs
@@ -92,6 +92,11 @@ impl ::std::fmt::Display for ProtocolError {
 /// primary `WlDisplay` wayland object. As such, it must be kept alive as long
 /// as you are connected. You can access the contained `WlDisplay` via `Deref`
 /// to create all the objects you need.
+///
+/// **Safety note:** If you activate the `use_system_lib` cargo feature and provide pointers
+/// to wayland objects to other libraries, you **must** ensure that these libraries clean up
+/// their state before the last clone of this `Display` is dropped, otherwise these libraries
+/// will access freed memory when doing their cleanup.
 #[derive(Clone)]
 pub struct Display {
     pub(crate) inner: Arc<DisplayInner>,

--- a/wayland-commons/src/wire.rs
+++ b/wayland-commons/src/wire.rs
@@ -120,7 +120,9 @@ impl ::std::error::Error for MessageWriteError {}
 impl ::std::fmt::Display for MessageWriteError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
         match *self {
-            MessageWriteError::BufferTooSmall => f.write_str("The provided buffer is too small to hold message content."),
+            MessageWriteError::BufferTooSmall => {
+                f.write_str("The provided buffer is too small to hold message content.")
+            }
             MessageWriteError::DupFdFailed(_) => {
                 f.write_str("The message contains a file descriptor that could not be dup()-ed.")
             }
@@ -144,7 +146,9 @@ impl ::std::error::Error for MessageParseError {}
 impl ::std::fmt::Display for MessageParseError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
         match *self {
-            MessageParseError::MissingFD => f.write_str("The message references a FD but the buffer FD is empty."),
+            MessageParseError::MissingFD => {
+                f.write_str("The message references a FD but the buffer FD is empty.")
+            }
             MessageParseError::MissingData => f.write_str("More data is needed to deserialize the message"),
             MessageParseError::Malformed => f.write_str("The message is malformed and cannot be parsed"),
         }


### PR DESCRIPTION
When attempting to send a message from a proxy and using the `use_system_lib`, check if the associated `Display` is actually still alive before calling into FFI. If not, behave as a dead proxy.

This should fix a number of crashes associated to destructors and final cleanups in apps, when a component than sends wayland requests from its destructor happened to be dropped after the display.