### PR TITLE
[WIP] Make the `cursor` feature full rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ####
 
 - The minimum supported Rust version is now 1.41.0
+- `wayland-cursor` is now fully implemented in Rust
 
 #### Fixes
 

--- a/wayland-cursor/Cargo.toml
+++ b/wayland-cursor/Cargo.toml
@@ -16,3 +16,6 @@ travis-ci = { repository = "Smithay/wayland-rs" }
 [dependencies]
 wayland-client = { version = "0.25.0", path = "../wayland-client", features = ["use_system_lib"] }
 wayland-sys = { version = "0.25.0", path="../wayland-sys", features = ["cursor"] }
+tempfile = "3.1.0"
+xcursor = "0.1"
+xcur = "0.1"

--- a/wayland-cursor/Cargo.toml
+++ b/wayland-cursor/Cargo.toml
@@ -14,8 +14,7 @@ description = "Bindings to libwayland-cursor."
 travis-ci = { repository = "Smithay/wayland-rs" }
 
 [dependencies]
-wayland-client = { version = "0.25.0", path = "../wayland-client", features = ["use_system_lib"] }
-wayland-sys = { version = "0.25.0", path="../wayland-sys", features = ["cursor"] }
+wayland-client = { version = "0.25.0", path = "../wayland-client" }
 xcursor = "0.1"
 xcur = "0.1"
 nix = "0.17.0"

--- a/wayland-cursor/Cargo.toml
+++ b/wayland-cursor/Cargo.toml
@@ -16,6 +16,6 @@ travis-ci = { repository = "Smithay/wayland-rs" }
 [dependencies]
 wayland-client = { version = "0.25.0", path = "../wayland-client", features = ["use_system_lib"] }
 wayland-sys = { version = "0.25.0", path="../wayland-sys", features = ["cursor"] }
-tempfile = "3.1.0"
 xcursor = "0.1"
 xcur = "0.1"
+nix = "0.17.0"


### PR DESCRIPTION
~~This PR inserts a Rust implementation into the wayland-cursor crate, but allowing to fallback to the system wayland-cursor.so, for interoperability with other libraries.
The rust implementation is backwards compatible for the most part (except for some lifetimes that aren't needed anymore).~~

This PR reimplements in Rust the `wayland-cursor` crate. The API is changed to be hopefully more Rust-y, since we don't have the c library to follow anymore.