### PR TITLE
dispatch_pending is &self for both rust/C

### DIFF
--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -154,7 +154,7 @@ impl EventQueue {
     ///
     /// If an error is returned, your connection with the wayland compositor is probably lost.
     /// You may want to check `Display::protocol_error()` to see if it was caused by a protocol error.
-    pub fn dispatch_pending<T: std::any::Any, F>(&mut self, data: &mut T, fallback: F) -> io::Result<u32>
+    pub fn dispatch_pending<T: std::any::Any, F>(&self, data: &mut T, fallback: F) -> io::Result<u32>
     where
         F: FnMut(RawEvent, Main<AnonymousObject>, DispatchData<'_>),
     {


### PR DESCRIPTION
It is useful to allow dispatch_pending(&self, ...).
For example while another reference is kept for prepare_read/read_events polling.