### PR TITLE
client: Don't lock the queue buffer too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### Bugfixes
 
+- [client] Fix a deadlock when dispatching & reading event queues conccurently from different threads when
+  using the rust implementation of the protocol.
 - [cursor] Don't panic if `load_cursor` fails to find the requested cursor
 - [cursor] Fix buffer content endianness
 


### PR DESCRIPTION
In dispatch_pending(), don't keep the buffer locked for the whole
dispatching, but instead lock it in a per-message basis. Otherwise,
we may conflict with the locks required by read_messages() if called
concurently.

read_messages() locking needs are:

```
-> lock connection
  -> lock map
    -> punctual locks of queue buffers
```

dispatch_pending() locking strategy was, before this commit:

```
-> lock buffer
  -> punctual locks of map
```

This commit changes it to:

```
-> punctual locks of buffer
-> punctual locks if map
```

This means a dispatch_pending() can now be interrupted by a read_event
from an other thread. It'll just resume its dispatching once the read
is finished.