### PR TITLE
Add cargo-deny to CI to verify licenses and more

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,5 +102,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
       - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,3 +97,10 @@ jobs:
       
       - name: Clippy native lib
         run: cargo clippy --all --features "both_native" -- -D warnings
+
+  cargo-deny:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: EmbarkStudios/cargo-deny-action@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ autotests = false
 
 [dependencies]
 wayland-commons = { path = "./wayland-commons" }
+wayland-cursor = { path = "./wayland-cursor" }
 wayland-scanner = { path = "./wayland-scanner" }
 wayland-client = { path = "./wayland-client", default-features = false }
 wayland-server = { path = "./wayland-server", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -10,11 +10,6 @@ deny = [
 skip = [
 ]
 
-[sources]
-unknown-registry = "deny"
-unknown-git = "deny"
-allow-git = []
-
 [licenses]
 unlicensed = "deny"
 allow-osi-fsf-free = "neither"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,28 @@
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+notice = "deny"
+
+[bans]
+multiple-versions = "deny"
+deny = [
+]
+skip = [
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-git = []
+
+[licenses]
+unlicensed = "deny"
+allow-osi-fsf-free = "neither"
+copyleft = "deny"
+confidence-threshold = 0.93 # We want really high confidence when inferring licenses from text
+allow = [
+    "Apache-2.0",
+    "MIT",
+    "ISC",
+    "BSD-2-Clause",
+]


### PR DESCRIPTION
Enabled the current permissive licenses that were used but disallowed copyleft licenses. Issues like #319 should not be able to happen again with this, will be detected in the PR and fail the build.

Also enabled some other standard security settings we usually use such as:
- Verify no dependencies have RUSTSEC advisories for them for vulnerabilities, unmaintained status and general notices
- Disallow bringing in multiple versions of the same crate, to make it leaner and keep compile times good. This can require some tweaking occasionally and in some crate upgrade scenarios temporarily allow ("skip") some crates to have multiple versions of them. 

Feel free to tweak and configure `deny.toml` further, the [cargo-deny book](https://embarkstudios.github.io/cargo-deny/) has quite in-depth descriptions of it.
