### PR TITLE
client: server: scanner: Make crate more debuggable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - [client] Clone implementation for `QueueToken`
 - [client] implement `From<Main<I: Interface>>` impl for `Attached<I: Interface>`
+- [client] std::fmt::Debug implementation for `Proxy`, `Attached`, `Main`
+- [server] std::fmt::Debug implementation for `Resource`, `Main`
+- [scanner] std::fmt::Debug implementation for `Event` and `Request`
 
 #### Bugfixes
 

--- a/tests/scanner_assets/client_code.rs
+++ b/tests/scanner_assets/client_code.rs
@@ -53,6 +53,7 @@ pub mod wl_foo {
             self.bits()
         }
     }
+    #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {
         #[doc = "do some foo\n\nThis will do some foo with its args."]
@@ -168,6 +169,7 @@ pub mod wl_foo {
             }
         }
     }
+    #[derive(Debug)]
     #[non_exhaustive]
     pub enum Event {
         #[doc = "a cake is possible\n\nThe server advertises that a kind of cake is available\n\nOnly available since version 2 of the interface"]
@@ -275,6 +277,11 @@ pub mod wl_foo {
             value.0
         }
     }
+    impl std::fmt::Debug for WlFoo {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_fmt(format_args!("{:?}", self.0))
+        }
+    }
     impl Interface for WlFoo {
         type Request = Request;
         type Event = Event;
@@ -349,6 +356,7 @@ pub mod wl_bar {
         MessageDesc, MessageGroup, Object, ObjectMetadata, Proxy, NULLPTR,
     };
     use std::os::raw::c_char;
+    #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {
         #[doc = "ask for a bar delivery\n\nProceed to a bar delivery of given foo.\n\nOnly available since version 2 of the interface"]
@@ -532,6 +540,7 @@ pub mod wl_bar {
             }
         }
     }
+    #[derive(Debug)]
     #[non_exhaustive]
     pub enum Event {
         #[doc = "ask for erronous bindings from wayland-scanner\n\nThis event tests argument names which can break wayland-scanner.\n\nOnly available since version 2 of the interface"]
@@ -705,6 +714,11 @@ pub mod wl_bar {
             value.0
         }
     }
+    impl std::fmt::Debug for WlBar {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_fmt(format_args!("{:?}", self.0))
+        }
+    }
     impl Interface for WlBar {
         type Request = Request;
         type Event = Event;
@@ -813,6 +827,7 @@ pub mod wl_display {
         MessageDesc, MessageGroup, Object, ObjectMetadata, Proxy, NULLPTR,
     };
     use std::os::raw::c_char;
+    #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {}
     impl super::MessageGroup for Request {
@@ -856,6 +871,7 @@ pub mod wl_display {
             match self {}
         }
     }
+    #[derive(Debug)]
     #[non_exhaustive]
     pub enum Event {}
     impl super::MessageGroup for Event {
@@ -923,6 +939,11 @@ pub mod wl_display {
             value.0
         }
     }
+    impl std::fmt::Debug for WlDisplay {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_fmt(format_args!("{:?}", self.0))
+        }
+    }
     impl Interface for WlDisplay {
         type Request = Request;
         type Event = Event;
@@ -952,6 +973,7 @@ pub mod wl_registry {
         MessageDesc, MessageGroup, Object, ObjectMetadata, Proxy, NULLPTR,
     };
     use std::os::raw::c_char;
+    #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {
         #[doc = "bind an object to the display\n\nThis request is a special code-path, as its new-id argument as no target type."]
@@ -1032,6 +1054,7 @@ pub mod wl_registry {
             }
         }
     }
+    #[derive(Debug)]
     #[non_exhaustive]
     pub enum Event {}
     impl super::MessageGroup for Event {
@@ -1099,6 +1122,11 @@ pub mod wl_registry {
             value.0
         }
     }
+    impl std::fmt::Debug for WlRegistry {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_fmt(format_args!("{:?}", self.0))
+        }
+    }
     impl Interface for WlRegistry {
         type Request = Request;
         type Event = Event;
@@ -1146,6 +1174,7 @@ pub mod wl_callback {
         MessageDesc, MessageGroup, Object, ObjectMetadata, Proxy, NULLPTR,
     };
     use std::os::raw::c_char;
+    #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {}
     impl super::MessageGroup for Request {
@@ -1189,6 +1218,7 @@ pub mod wl_callback {
             match self {}
         }
     }
+    #[derive(Debug)]
     #[non_exhaustive]
     pub enum Event {
         #[doc = "done event\n\nThis event is actually a destructor, but the protocol XML has no way of specifying it.\nAs such, the scanner should consider wl_callback.done as a special case.\n\nThis is a destructor, once received this object cannot be used any longer."]
@@ -1284,6 +1314,11 @@ pub mod wl_callback {
         #[inline]
         fn from(value: WlCallback) -> Self {
             value.0
+        }
+    }
+    impl std::fmt::Debug for WlCallback {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_fmt(format_args!("{:?}", self.0))
         }
     }
     impl Interface for WlCallback {

--- a/tests/scanner_assets/server_code.rs
+++ b/tests/scanner_assets/server_code.rs
@@ -53,6 +53,7 @@ pub mod wl_foo {
             self.bits()
         }
     }
+    #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {
         #[doc = "do some foo\n\nThis will do some foo with its args."]
@@ -213,6 +214,7 @@ pub mod wl_foo {
             panic!("Request::as_raw_c_in can not be used Server-side.")
         }
     }
+    #[derive(Debug)]
     #[non_exhaustive]
     pub enum Event {
         #[doc = "a cake is possible\n\nThe server advertises that a kind of cake is available\n\nOnly available since version 2 of the interface"]
@@ -303,6 +305,11 @@ pub mod wl_foo {
             value.0
         }
     }
+    impl std::fmt::Debug for WlFoo {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_fmt(format_args!("{:?}", self.0))
+        }
+    }
     impl Interface for WlFoo {
         type Request = Request;
         type Event = Event;
@@ -365,6 +372,7 @@ pub mod wl_bar {
         MessageDesc, MessageGroup, Object, ObjectMetadata, Resource, NULLPTR,
     };
     use std::os::raw::c_char;
+    #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {
         #[doc = "ask for a bar delivery\n\nProceed to a bar delivery of given foo.\n\nOnly available since version 2 of the interface"]
@@ -607,6 +615,7 @@ pub mod wl_bar {
             panic!("Request::as_raw_c_in can not be used Server-side.")
         }
     }
+    #[derive(Debug)]
     #[non_exhaustive]
     pub enum Event {
         #[doc = "ask for erronous bindings from wayland-scanner\n\nThis event tests argument names which can break wayland-scanner.\n\nOnly available since version 2 of the interface"]
@@ -748,6 +757,11 @@ pub mod wl_bar {
             value.0
         }
     }
+    impl std::fmt::Debug for WlBar {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_fmt(format_args!("{:?}", self.0))
+        }
+    }
     impl Interface for WlBar {
         type Request = Request;
         type Event = Event;
@@ -840,6 +854,7 @@ pub mod wl_callback {
         MessageDesc, MessageGroup, Object, ObjectMetadata, Resource, NULLPTR,
     };
     use std::os::raw::c_char;
+    #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {}
     impl super::MessageGroup for Request {
@@ -887,6 +902,7 @@ pub mod wl_callback {
             panic!("Request::as_raw_c_in can not be used Server-side.")
         }
     }
+    #[derive(Debug)]
     #[non_exhaustive]
     pub enum Event {
         #[doc = "done event\n\nThis event is actually a destructor, but the protocol XML has no way of specifying it.\nAs such, the scanner should consider wl_callback.done as a special case.\n\nThis is a destructor, once sent this object cannot be used any longer."]
@@ -974,6 +990,11 @@ pub mod wl_callback {
         #[inline]
         fn from(value: WlCallback) -> Self {
             value.0
+        }
+    }
+    impl std::fmt::Debug for WlCallback {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_fmt(format_args!("{:?}", self.0))
         }
     }
     impl Interface for WlCallback {

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -148,6 +148,7 @@ pub mod protocol {
 
 mod anonymous_object {
     use super::{Interface, NoMessage, Proxy};
+    use std::fmt::{self, Debug, Formatter};
 
     /// Anonymous interface
     ///
@@ -162,7 +163,7 @@ mod anonymous_object {
         const NAME: &'static str = "<anonymous>";
         const VERSION: u32 = 0;
         fn c_interface() -> *const crate::sys::common::wl_interface {
-            ::std::ptr::null()
+            std::ptr::null()
         }
     }
 
@@ -184,9 +185,15 @@ mod anonymous_object {
             value.0
         }
     }
+    impl Debug for AnonymousObject {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+            f.write_fmt(format_args!("{:?}", self.0))
+        }
+    }
 }
 
 /// Enum of possible argument in an event
+#[derive(Debug)]
 pub enum Argument {
     /// i32
     Int(i32),
@@ -207,6 +214,7 @@ pub enum Argument {
 }
 
 /// An generic event
+#[derive(Debug)]
 pub struct RawEvent {
     /// Interface of the associated object
     pub interface: &'static str,

--- a/wayland-client/src/proxy.rs
+++ b/wayland-client/src/proxy.rs
@@ -1,3 +1,4 @@
+use std::fmt::{self, Debug, Formatter};
 use std::ops::Deref;
 
 use super::AnonymousObject;
@@ -48,6 +49,12 @@ where
 {
     fn eq(&self, other: &Proxy<I>) -> bool {
         self.equals(other)
+    }
+}
+
+impl<I: Interface> Debug for Proxy<I> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}@{}", I::NAME, self.inner.id())
     }
 }
 
@@ -156,6 +163,12 @@ impl Proxy<AnonymousObject> {
         } else {
             Err(self)
         }
+    }
+}
+
+impl<I: Interface + Debug> Debug for Attached<I> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}[ATTACHED]", self.inner)
     }
 }
 
@@ -297,6 +310,15 @@ where
 {
     fn from(main: Main<I>) -> Attached<I> {
         main.inner
+    }
+}
+
+impl<I: Interface> Debug for Main<I>
+where
+    I: Debug + AsRef<Proxy<I>> + From<Proxy<I>>,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}[MAIN]", self.inner.inner)
     }
 }
 

--- a/wayland-cursor/rustfmt.toml
+++ b/wayland-cursor/rustfmt.toml
@@ -1,1 +1,0 @@
-../rustfmt.toml

--- a/wayland-scanner/src/common_gen.rs
+++ b/wayland-scanner/src/common_gen.rs
@@ -601,6 +601,7 @@ pub(crate) fn gen_messagegroup(
     };
 
     quote! {
+        #[derive(Debug)]
         #[non_exhaustive]
         pub enum #name {
             #(#variants,)*
@@ -682,6 +683,12 @@ pub(crate) fn gen_interface(
             #[inline]
             fn from(value: #name) -> Self {
                 value.0
+            }
+        }
+
+        impl std::fmt::Debug for #name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_fmt(format_args!("{:?}", self.0))
             }
         }
 

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -127,6 +127,7 @@ pub mod protocol {
 
 mod anonymous_object {
     use super::{Interface, NoMessage, Resource};
+    use std::fmt::{self, Debug, Formatter};
 
     /// Anonymous interface
     ///
@@ -161,6 +162,11 @@ mod anonymous_object {
         #[inline]
         fn from(value: AnonymousObject) -> Self {
             value.0
+        }
+    }
+    impl Debug for AnonymousObject {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+            f.write_fmt(format_args!("{:?}", self.0))
         }
     }
 }

--- a/wayland-server/src/resource.rs
+++ b/wayland-server/src/resource.rs
@@ -1,3 +1,5 @@
+use std::fmt::{self, Debug, Formatter};
+
 use wayland_commons::user_data::UserData;
 use wayland_commons::{Interface, MessageGroup};
 
@@ -249,6 +251,12 @@ impl<I: Interface> Clone for Resource<I> {
     }
 }
 
+impl<I: Interface> Debug for Resource<I> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}@{}", I::NAME, self.inner.id())
+    }
+}
+
 /// A main handle to a proxy
 #[derive(Clone, PartialEq)]
 pub struct Main<I: Interface + AsRef<Resource<I>> + From<Resource<I>>> {
@@ -353,5 +361,14 @@ where
     type Target = I;
     fn deref(&self) -> &I {
         &self.inner
+    }
+}
+
+impl<I: Interface> Debug for Main<I>
+where
+    I: Debug + AsRef<Resource<I>> + From<Resource<I>>,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}[MAIN]", self.inner)
     }
 }


### PR DESCRIPTION
Implement std::fmt::Debug on various server and client core wrappers and
and so make Event/Request to derive std::fmt::Debug impl.

Fixes #311.