### PR TITLE
scanner: parse event type from xml

### DIFF
--- a/wayland-scanner/src/parse.rs
+++ b/wayland-scanner/src/parse.rs
@@ -186,6 +186,7 @@ fn parse_event<R: Read>(reader: &mut EventReader<R>, attrs: Vec<OwnedAttribute>)
     for attr in attrs {
         match &attr.name.local_name[..] {
             "name" => event.name = attr.value,
+            "type" => event.typ = Some(parse_type(&attr.value)),
             "since" => event.since = attr.value.parse().unwrap(),
             _ => {}
         }


### PR DESCRIPTION
See https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/82.

Once protocol files are updated, this will remove the need for workarounds to specify these separately.