### PR TITLE
client: Summon dead Proxies for dead arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [sys] Use pkg-config for compile time linking (fixes FreeBSD build without dlopen)
 - [scanner] Force the use of `proc_macro2` fallback implementation, so that the scanner doesn't panic
   when ran with `RUSTFLAGS="-Cpanic=abort"`.
+- [client] Fix a crash when receiving an event with a dead object argument (can happen due to protocol races).
 
 ## 0.26.6 -- 2020-05-23
 

--- a/wayland-client/src/native_lib/mod.rs
+++ b/wayland-client/src/native_lib/mod.rs
@@ -21,6 +21,11 @@ impl ProxyMap {
     }
 
     /// Unusable method only existing for type-level compatibility
+    pub fn get_or_dead<I: Interface>(&mut self, _: u32) -> Proxy<I> {
+        match *self {}
+    }
+
+    /// Unusable method only existing for type-level compatibility
     pub fn get_new<I: Interface + AsRef<Proxy<I>> + From<Proxy<I>>>(
         &mut self,
         _: u32,

--- a/wayland-client/src/rust_imp/mod.rs
+++ b/wayland-client/src/rust_imp/mod.rs
@@ -51,6 +51,16 @@ impl ProxyMap {
         })
     }
 
+    /// Returns the Proxy corresponding to a given id, and create a dead one if none is found
+    pub fn get_or_dead<I: Interface + AsRef<Proxy<I>> + From<Proxy<I>>>(
+        &mut self,
+        id: u32,
+    ) -> Proxy<I> {
+        self.get(id).unwrap_or_else(|| {
+            Proxy::wrap(ProxyInner::dead::<I>(id, self.map.clone(), self.connection.clone()))
+        })
+    }
+
     /// Creates a new proxy for given id
     pub fn get_new<I: Interface + AsRef<Proxy<I>> + From<Proxy<I>>>(
         &mut self,

--- a/wayland-client/src/rust_imp/proxy.rs
+++ b/wayland-client/src/rust_imp/proxy.rs
@@ -85,6 +85,20 @@ impl ProxyInner {
         })
     }
 
+    pub(crate) fn dead<I: Interface>(
+        id: u32,
+        map: Arc<Mutex<ObjectMap<ObjectMeta>>>,
+        connection: Arc<Mutex<Connection>>,
+    ) -> ProxyInner {
+        ProxyInner {
+            map,
+            connection,
+            id,
+            queue: None,
+            object: Object::from_interface::<I>(1, ObjectMeta::dead()),
+        }
+    }
+
     pub(crate) fn is_interface<I: Interface>(&self) -> bool {
         self.object.is_interface::<I>()
     }

--- a/wayland-commons/src/lib.rs
+++ b/wayland-commons/src/lib.rs
@@ -113,7 +113,7 @@ pub trait Interface: 'static {
 /// An empty enum representing a MessageGroup with no messages
 pub enum NoMessage {}
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 impl MessageGroup for NoMessage {
     const MESSAGES: &'static [wire::MessageDesc] = &[];
     type Map = ();

--- a/wayland-scanner/src/common_gen.rs
+++ b/wayland-scanner/src/common_gen.rs
@@ -422,7 +422,11 @@ pub(crate) fn gen_messagegroup(
                             }
                             Type::Fd => quote!(val),
                             Type::Object => {
-                                let map_lookup = quote!(map.get(val).ok_or(())?.into());
+                                let map_lookup = if side == Side::Client {
+                                    quote!(map.get_or_dead(val).into())
+                                } else {
+                                    quote!(map.get(val).ok_or(())?.into())
+                                };
                                 if arg.allow_null {
                                     quote!(if val == 0 { None } else { Some(#map_lookup) })
                                 } else {


### PR DESCRIPTION
When we receive an event with a non-nullable object argument which
points to a non-existing object, summon a dead object to replace it
rather than crashing.

This can happen if we destroyed the target object conccurently with the
server sending us this event, and we should not crash due to that.

Fixes #334