### PR TITLE
scanner: automatically use common wayland-rs deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### Additions
+
+- [scanner] automatically use common wayland-rs dependencies in generated code
+
 ## 0.28.1 -- 2020-10-12
 
 #### Bugfixes

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -137,12 +137,7 @@ pub mod protocol {
     #![allow(non_upper_case_globals, non_snake_case, unused_imports)]
     #![allow(missing_docs, clippy::all)]
 
-    pub(crate) use crate::{AnonymousObject, Attached, Main, Proxy, ProxyMap};
-    pub(crate) use wayland_commons::map::{Object, ObjectMetadata};
-    pub(crate) use wayland_commons::smallvec;
-    pub(crate) use wayland_commons::wire::{Argument, ArgumentType, Message, MessageDesc};
-    pub(crate) use wayland_commons::{Interface, MessageGroup};
-    pub(crate) use wayland_sys as sys;
+    use crate as wayland_client;
     include!(concat!(env!("OUT_DIR"), "/wayland_api.rs"));
 }
 

--- a/wayland-scanner/src/c_code_gen.rs
+++ b/wayland-scanner/src/c_code_gen.rs
@@ -141,12 +141,12 @@ pub(crate) fn generate_protocol_server(protocol: Protocol) -> TokenStream {
                 #doc_attr
                 pub mod #mod_name {
                     use std::os::raw::c_char;
-                    use super::{
+                    use wayland_client::{
                         Resource, AnonymousObject, Interface, MessageGroup, MessageDesc, Main, smallvec,
                         ArgumentType, Object, Message, Argument, ObjectMetadata, types_null, NULLPTR
                     };
-                    use super::sys::common::{wl_argument, wl_interface, wl_array, wl_message};
-                    use super::sys::server::*;
+                    use wayland_sys::common::{wl_argument, wl_interface, wl_array, wl_message};
+                    use wayland_sys::server::*;
 
                     #(#enums)*
                     #requests

--- a/wayland-scanner/src/c_interface_gen.rs
+++ b/wayland-scanner/src/c_interface_gen.rs
@@ -33,6 +33,13 @@ pub(crate) fn generate_interfaces_prefix(protocol: &Protocol) -> TokenStream {
     quote! {
         use std::os::raw::{c_char, c_void};
 
+        use wayland_client::{AnonymousObject, Attached, Main, Proxy, ProxyMap};
+        use wayland_commons::map::{Object, ObjectMetadata};
+        use wayland_commons::smallvec;
+        use wayland_commons::wire::{Argument, ArgumentType, Message, MessageDesc};
+        use wayland_commons::{Interface, MessageGroup};
+        use wayland_sys as sys;
+
         const NULLPTR: *const c_void = 0 as *const c_void;
         static mut types_null: [*const sys::common::wl_interface; #types_null_len] = [
             #(#nulls,)*

--- a/wayland-scanner/src/lib.rs
+++ b/wayland-scanner/src/lib.rs
@@ -67,17 +67,10 @@
 //!     #![allow(non_upper_case_globals,non_snake_case,unused_imports)]
 //!
 //!     pub mod client {
-//!         // These imports are used by the generated code
-//!         pub(crate) use wayland_client::{Main, Attached, Proxy, ProxyMap, AnonymousObject};
-//!         pub(crate) use wayland_commons::map::{Object, ObjectMetadata};
-//!         pub(crate) use wayland_commons::{Interface, MessageGroup};
-//!         pub(crate) use wayland_commons::wire::{Argument, MessageDesc, ArgumentType, Message};
-//!         pub(crate) use wayland_commons::smallvec;
-//!         pub(crate) use wayland_client::protocol::{$($import),*};
-//!         pub(crate) use wayland_client::sys;
 //!         // If you protocol interacts with objects from other protocols, you'll need to import
 //!         // their modules, like so:
 //!         pub(crate) use wayland_client::protocol::{wl_surface, wl_region};
+//!
 //!         include!(concat!(env!("OUT_DIR"), "/my_protocol_code.rs"));
 //!     }
 //! }


### PR DESCRIPTION
wayland-scanner implies the use of wayland-rs, so include
necessary 'use' statements in resulted generated code.