### PR TITLE
cursor: account for both width and height when picking nearest cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### Bugfixes
+
+- [cursor] Account for both width and height when picking nearest cursor.
+
 ## 0.28.1 -- 2020-10-12
 
 #### Bugfixes


### PR DESCRIPTION
Cursors don't have square form in general, so we should match
both width and height when picking nearest images.