### PR TITLE
client: early return parsing when encountering a protocol error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### Bugfixes
+
+- [client] Properly print protocol errors to stderr when they occur on the rust backend
+
 ## 0.28.2 -- 2020-11-09
 
 #### Bugfixes


### PR DESCRIPTION
Overwise the event is queued like any other, the  next read triggers a broken pipe, and only that last error is reported to the user.