### PR TITLE
wayland-commons: avoid empty sendmsg on flush

### DIFF
--- a/tests/protocol_errors.rs
+++ b/tests/protocol_errors.rs
@@ -38,8 +38,9 @@ fn client_wrong_id() {
 
     server.answer();
 
-    // server should have killed us due to the error
-    assert_eq!(socket.flush(), Err(nix::Error::Sys(nix::errno::Errno::EPIPE)));
+    // server should have killed us due to the error, but it might send us that error first
+    let err = socket.fill_incoming_buffers().and_then(|_| socket.fill_incoming_buffers());
+    assert_eq!(err, Err(nix::Error::Sys(nix::errno::Errno::EPIPE)));
 }
 
 #[test]
@@ -62,8 +63,9 @@ fn client_wrong_opcode() {
 
     server.answer();
 
-    // server should have killed us due to the error
-    assert_eq!(socket.flush(), Err(nix::Error::Sys(nix::errno::Errno::EPIPE)));
+    // server should have killed us due to the error, but it might send us that error first
+    let err = socket.fill_incoming_buffers().and_then(|_| socket.fill_incoming_buffers());
+    assert_eq!(err, Err(nix::Error::Sys(nix::errno::Errno::EPIPE)));
 }
 
 #[test]
@@ -86,8 +88,9 @@ fn client_wrong_sender() {
 
     server.answer();
 
-    // server should have killed us due to the error
-    assert_eq!(socket.flush(), Err(nix::Error::Sys(nix::errno::Errno::EPIPE)));
+    // server should have killed us due to the error, but it might send us that error first
+    let err = socket.fill_incoming_buffers().and_then(|_| socket.fill_incoming_buffers());
+    assert_eq!(err, Err(nix::Error::Sys(nix::errno::Errno::EPIPE)));
 }
 
 #[test]

--- a/wayland-commons/src/socket.rs
+++ b/wayland-commons/src/socket.rs
@@ -139,6 +139,9 @@ impl BufferedSocket {
     pub fn flush(&mut self) -> NixResult<()> {
         {
             let words = self.out_data.get_contents();
+            if words.is_empty() {
+                return Ok(());
+            }
             let bytes = unsafe {
                 ::std::slice::from_raw_parts(words.as_ptr() as *const u8, words.len() * 4)
             };


### PR DESCRIPTION
If there is nothing to send, there's no point actually making the system call.
The list of FDs is not checked because sending FDs without also sending data is
not permitted anyway.