### PR TITLE
Unset WAYLAND_SOCKET when we use the socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [client] Unset WAYLAND\_SOCKET when we use the socket
+
 ## 0.28.3 -- 2020-12-30
 
 #### Additions

--- a/wayland-client/src/display.rs
+++ b/wayland-client/src/display.rs
@@ -118,6 +118,8 @@ impl Display {
         if let Ok(txt) = env::var("WAYLAND_SOCKET") {
             // We should connect to the provided WAYLAND_SOCKET
             let fd = txt.parse::<i32>().map_err(|_| ConnectError::InvalidFd)?;
+            // remove the variable so any child processes don't see it
+            env::remove_var("WAYLAND_SOCKET");
             // set the CLOEXEC flag on this FD
             let flags = fcntl::fcntl(fd, fcntl::FcntlArg::F_GETFD);
             let result = flags


### PR DESCRIPTION
Since we are either taking ownership of the socket or closing it at this point,
we should not retain the environment variable as it will only confuse child
processes.