### PR TITLE
Make crates buildable with minimal dependency versions

### DIFF
--- a/wayland-commons/Cargo.toml
+++ b/wayland-commons/Cargo.toml
@@ -14,5 +14,5 @@ readme = "README.md"
 [dependencies]
 wayland-sys = { version = "0.28.3", path = "../wayland-sys" }
 nix = "0.18"
-once_cell = "1.0"
+once_cell = "1.1"
 smallvec = "1"

--- a/wayland-cursor/Cargo.toml
+++ b/wayland-cursor/Cargo.toml
@@ -13,5 +13,5 @@ readme = "README.md"
 
 [dependencies]
 wayland-client = { version = "0.28.3", path = "../wayland-client" }
-xcursor = "0.3"
+xcursor = "0.3.1"
 nix = "0.18.0"

--- a/wayland-scanner/Cargo.toml
+++ b/wayland-scanner/Cargo.toml
@@ -12,6 +12,6 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-proc-macro2 = "1.0"
+proc-macro2 = "1.0.11"
 quote = "1.0"
 xml-rs = ">=0.7, <0.9"

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -19,7 +19,7 @@ bitflags = "1.0"
 downcast-rs = "1.0"
 libc = "0.2"
 nix = "0.18"
-lazy_static = { version = "1.0", optional = true }
+lazy_static = { version = "1.0.2", optional = true }
 parking_lot = { version = "0.11", optional = true }
 scoped-tls = { version = "1.0", optional = true }
 

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 wayland-commons = { version = "0.28.3", path = "../wayland-commons" }
 wayland-sys = { version = "0.28.3", path = "../wayland-sys" }
 bitflags = "1.0"
-downcast-rs = "1.0"
+downcast-rs = "1.0.4"
 libc = "0.2"
 nix = "0.18"
 lazy_static = { version = "1.0.2", optional = true }

--- a/wayland-sys/Cargo.toml
+++ b/wayland-sys/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 [dependencies]
 dlib = { version = "0.4", optional = true }
 libc = { version = "0.2", optional = true }
-lazy_static = { version = "1", optional = true }
+lazy_static = { version = "1.0.2", optional = true }
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = "0.3.7"
 
 [features]
 dlopen = ["dlib/dlopen", "lazy_static"]


### PR DESCRIPTION
Some dependencies seems outdated, and does not compile with rustc 1.49.0.
This pull request bumps some dependencies in order to all crates compile with minimal dependency versions.

You can generate `Cargo.lock` with minimal dependency versions by `cargo +nightly update -Z minimal-versions`.
(Once `Cargo.lock` is generated, build and test can be proceeded by stable rustc.)

This PR chose literally minimum compilable deps versions to minimize unexpected side effects, but it results in compiler warnings in some crates (for example, `lazy-static v1.0.2` uses `std::sync::ONCE_INIT` internally, [which is now deprecated](https://doc.rust-lang.org/stable/std/sync/constant.ONCE_INIT.html)).
I think some dependencies should be updated to more recent versions, but it is out of scope of this PR.