### PR TITLE
simple window xdg

### DIFF
--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -26,6 +26,7 @@ wayland-scanner = { version = "0.28.3", path = "../wayland-scanner" }
 
 [dev-dependencies]
 tempfile = ">=2.0, <4.0"
+wayland-protocols = { path = "../wayland-protocols", features = ["client"] }
 
 [features]
 use_system_lib = [ "wayland-sys/client", "scoped-tls"]


### PR DESCRIPTION
This updates the simple window example to use xdg protocol.

Tested on Fedora 33 and TinyWL.

Resolves https://github.com/Smithay/wayland-rs/issues/315