### PR TITLE
client: proper cleanup on send on system impl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Coverage
         uses: actions-rs/tarpaulin@v0.1
         with:
+          version: '0.16.0'
           args: --ignore-tests --features "${{ matrix.features }}" --workspace --exclude wayland-egl --exclude wayland-cursor
       
       - name: Upload to codecov.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
+#### Bugfixes
+
 - [client] Unset WAYLAND\_SOCKET when we use the socket
+- [client] Correctly cleanup internal state on object destruction when usin the system lib backend
 
 ## 0.28.3 -- 2020-12-30
 


### PR DESCRIPTION
This ensures that the user_data associated with a proxy is
correctly cleaned up when sending a destructor request.

Also, the dispatch logic was updated to correctly handle the case where
an object is destroyed from within its own dispatch closure.

Fixes #358