### PR TITLE
Upgrade to dlib 0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- [sys] Update `dlib` dependency to v0.5 to match new macro fornat. The `dlopen` feature no longer
+  affects other crates using `dlib`.
+
 ## 0.28.4 -- 2020-02-22
 
 #### Bugfixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ members = [
 ]
 
 [features]
-client_native = [ "wayland-client/dlopen" ]
-server_native = [ "wayland-server/dlopen" ]
-both_native = [ "client_native", "server_native" ]
+client_native = ["wayland-client/dlopen"]
+server_native = ["wayland-server/dlopen"]
+both_native = ["client_native", "server_native"]
 
 # Manual list of the tests, required because some need `harness = false`
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ There are two ways to use them:
 
 If you use the `use_system_lib` feature, the crates thus obviously require that the wayland C libs are installed
 on your system. You can however require that they are dynamically loaded at startup rather than directly
-linked by setting the `dlopen` flag. This can be useful if you want to ship a binary that should gracelly
+linked by setting the `dlopen` flag. This can be useful if you want to ship a binary that should gracefully
 handle the absence of these libs (by fallbacking to X11 for example).
 
 This repository actually hosts 8 crates. The 3 main crates you'll likely want to use:

--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -29,5 +29,5 @@ tempfile = ">=2.0, <4.0"
 wayland-protocols = { path = "../wayland-protocols", features = ["client"] }
 
 [features]
-use_system_lib = [ "wayland-sys/client", "scoped-tls"]
+use_system_lib = ["wayland-sys/client", "scoped-tls"]
 dlopen = ["wayland-sys/dlopen", "use_system_lib"]

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -27,5 +27,5 @@ scoped-tls = { version = "1.0", optional = true }
 wayland-scanner = { version = "0.28.4", path = "../wayland-scanner" }
 
 [features]
-use_system_lib = [ "wayland-sys/server", "lazy_static", "scoped-tls", "parking_lot" ]
-dlopen = [ "wayland-sys/dlopen", "use_system_lib" ]
+use_system_lib = ["wayland-sys/server", "lazy_static", "scoped-tls", "parking_lot"]
+dlopen = ["wayland-sys/dlopen", "use_system_lib"]

--- a/wayland-server/README.md
+++ b/wayland-server/README.md
@@ -20,7 +20,7 @@ The crate has different backends to Wayland protocol serialization:
 - Activating the `use_system_lib` makes it instead bind to the system `libwayland-server.so`. This
   allows you to access C pointer versions of the wayland objects, which is necessary for interfacing
   with other non-Rust Wayland-related libraries (such as for OpenGL support, see the `wayland-egl` crate).
-- Activating the `dlopen` implies `use_system_lib`, but additionnaly the crate will not explicitly
+- Activating the `dlopen` implies `use_system_lib`, but additionaly the crate will not explicitly
   link to `libwayland-server.so` and instead try to open it at runtime, and return an error if it cannot
   find it. This allows you to build apps that can gracefully run in non-Wayland environment without needing
   compile-time switches.

--- a/wayland-sys/Cargo.toml
+++ b/wayland-sys/Cargo.toml
@@ -20,10 +20,10 @@ pkg-config = "0.3.7"
 
 [features]
 dlopen = ["dlib/dlopen", "lazy_static"]
-client = [ "dlib" ]
-cursor = [ "client" ]
-egl = [ "client" ]
-server = ["libc", "dlib" ]
+client = ["dlib"]
+cursor = ["client"]
+egl = ["client"]
+server = ["libc", "dlib"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wayland-sys/Cargo.toml
+++ b/wayland-sys/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-dlib = { version = "0.4", optional = true }
+dlib = { version = "0.5", optional = true }
 libc = { version = "0.2", optional = true }
 lazy_static = { version = "1.0.2", optional = true }
 
@@ -19,7 +19,7 @@ lazy_static = { version = "1.0.2", optional = true }
 pkg-config = "0.3.7"
 
 [features]
-dlopen = ["dlib/dlopen", "lazy_static"]
+dlopen = ["dlib", "lazy_static"]
 client = ["dlib"]
 cursor = ["client"]
 egl = ["client"]

--- a/wayland-sys/src/client.rs
+++ b/wayland-sys/src/client.rs
@@ -95,9 +95,9 @@ lazy_static::lazy_static!(
         let versions = ["libwayland-client.so",
                         "libwayland-client.so.0"];
         for ver in &versions {
-            match WaylandClient::open(ver) {
+            match unsafe { WaylandClient::open(ver) } {
                 Ok(h) => return Some(h),
-                Err(::dlib::DlError::NotFound) => continue,
+                Err(::dlib::DlError::CantOpen(_)) => continue,
                 Err(::dlib::DlError::MissingSymbol(s)) => {
                     if ::std::env::var_os("WAYLAND_RS_DEBUG").is_some() {
                         // only print debug messages if WAYLAND_RS_DEBUG is set

--- a/wayland-sys/src/cursor.rs
+++ b/wayland-sys/src/cursor.rs
@@ -51,9 +51,9 @@ lazy_static::lazy_static!(
                         "libwayland-cursor.so.0"];
 
         for ver in &versions {
-            match WaylandCursor::open(ver) {
+            match unsafe { WaylandCursor::open(ver) } {
                 Ok(h) => return Some(h),
-                Err(::dlib::DlError::NotFound) => continue,
+                Err(::dlib::DlError::CantOpen(_)) => continue,
                 Err(::dlib::DlError::MissingSymbol(s)) => {
                     if ::std::env::var_os("WAYLAND_RS_DEBUG").is_some() {
                         // only print debug messages if WAYLAND_RS_DEBUG is set

--- a/wayland-sys/src/egl.rs
+++ b/wayland-sys/src/egl.rs
@@ -30,9 +30,9 @@ lazy_static::lazy_static!(
                         "libwayland-egl.so.1"];
 
         for ver in &versions {
-            match WaylandEgl::open(ver) {
+            match unsafe { WaylandEgl::open(ver) } {
                 Ok(h) => return Some(h),
-                Err(::dlib::DlError::NotFound) => continue,
+                Err(::dlib::DlError::CantOpen(_)) => continue,
                 Err(::dlib::DlError::MissingSymbol(s)) => {
                     if ::std::env::var_os("WAYLAND_RS_DEBUG").is_some() {
                         // only print debug messages if WAYLAND_RS_DEBUG is set

--- a/wayland-sys/src/server.rs
+++ b/wayland-sys/src/server.rs
@@ -156,9 +156,9 @@ lazy_static::lazy_static!(
         let versions = ["libwayland-server.so",
                         "libwayland-server.so.0"];
         for ver in &versions {
-            match WaylandServer::open(ver) {
+            match unsafe { WaylandServer::open(ver) } {
                 Ok(h) => return Some(h),
-                Err(::dlib::DlError::NotFound) => continue,
+                Err(::dlib::DlError::CantOpen(_)) => continue,
                 Err(::dlib::DlError::MissingSymbol(s)) => {
                     if ::std::env::var_os("WAYLAND_RS_DEBUG").is_some() {
                         // only print debug messages if WAYLAND_RS_DEBUG is set


### PR DESCRIPTION
This upgrades wayland-sys' dlib dependency to the new release. Now the dlopen feature won't interfere with other crates using dlib. I have tested this with the `dlopen` feature enabled and disabled on smithay-client-toolkit.