### PR TITLE
Added to `request_enum` and `event_enum` the possibility to handle attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.28.6 -- 2020-06-3
+
+- [client] Added the possibility to handle attributes for `event_enum!` macro.
+- [server] Added the possibility to handle attributes for `request_enum!` macro.
+
 ## 0.28.5 -- 2020-02-26
 
 - [sys] Update `dlib` dependency to v0.5 to match new macro fornat. The `dlopen` feature no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## 0.28.6 -- 2020-06-3
-
 - [client] Added the possibility to handle attributes for `event_enum!` macro.
 - [server] Added the possibility to handle attributes for `request_enum!` macro.
 

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -288,11 +288,11 @@ pub struct RawEvent {
 /// directly be provided into a `Filter<MyEnum>`.
 #[macro_export]
 macro_rules! event_enum(
-    ($(#[$attrs:meta])? $enu:ident | $($evt_name:ident => $iface:ty),*) => {
-        event_enum!($(#[$attrs])? $enu | $($evt_name => $iface),* | );
+    ($(#[$attrs:meta])* $enu:ident | $($evt_name:ident => $iface:ty),*) => {
+        event_enum!($(#[$attrs])* $enu | $($evt_name => $iface),* | );
     };
-    ($(#[$attrs:meta])? $enu:ident | $($evt_name:ident => $iface:ty),* | $($name:ident => $value:ty),*) => {
-        $(#[$attrs])?
+    ($(#[$attrs:meta])* $enu:ident | $($evt_name:ident => $iface:ty),* | $($name:ident => $value:ty),*) => {
+        $(#[$attrs])*
         pub enum $enu {
             $(
                 $evt_name { event: <$iface as $crate::Interface>::Event, object: $crate::Main<$iface> },

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -289,7 +289,7 @@ pub struct RawEvent {
 #[macro_export]
 macro_rules! event_enum(
     ($(#[$attrs:meta])? $enu:ident | $($evt_name:ident => $iface:ty),*) => {
-        event_enum!($enu | $($evt_name => $iface),* | );
+        event_enum!($(#[$attrs])? $enu | $($evt_name => $iface),* | );
     };
     ($(#[$attrs:meta])? $enu:ident | $($evt_name:ident => $iface:ty),* | $($name:ident => $value:ty),*) => {
         $(#[$attrs])?

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -288,10 +288,11 @@ pub struct RawEvent {
 /// directly be provided into a `Filter<MyEnum>`.
 #[macro_export]
 macro_rules! event_enum(
-    ($enu:ident | $($evt_name:ident => $iface:ty),*) => {
+    ($(#[$attrs:meta])? $enu:ident | $($evt_name:ident => $iface:ty),*) => {
         event_enum!($enu | $($evt_name => $iface),* | );
     };
-    ($enu:ident | $($evt_name:ident => $iface:ty),* | $($name:ident => $value:ty),*) => {
+    ($(#[$attrs:meta])? $enu:ident | $($evt_name:ident => $iface:ty),* | $($name:ident => $value:ty),*) => {
+        $(#[$attrs])?
         pub enum $enu {
             $(
                 $evt_name { event: <$iface as $crate::Interface>::Event, object: $crate::Main<$iface> },

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -234,10 +234,11 @@ mod anonymous_object {
 
 #[macro_export]
 macro_rules! request_enum(
-    ($enu:ident | $($evt_name:ident => $iface:ty),*) => {
+    ($(#[$attrs:meta])? $enu:ident | $($evt_name:ident => $iface:ty),*) => {
         $crate::request_enum!($enu | $($evt_name => $iface),* | );
     };
-    ($enu:ident | $($evt_name:ident => $iface:ty),* | $($name:ident => $value:ty),*) => {
+    ($(#[$attrs:meta])? $enu:ident | $($evt_name:ident => $iface:ty),* | $($name:ident => $value:ty),*) => {
+        $(#[$attrs])?
         pub enum $enu {
             $(
                 $evt_name { request: <$iface as $crate::Interface>::Request, object: $crate::Main<$iface> },

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -234,11 +234,11 @@ mod anonymous_object {
 
 #[macro_export]
 macro_rules! request_enum(
-    ($(#[$attrs:meta])? $enu:ident | $($evt_name:ident => $iface:ty),*) => {
-        $crate::request_enum!($(#[$attrs])? $enu | $($evt_name => $iface),* | );
+    ($(#[$attrs:meta])* $enu:ident | $($evt_name:ident => $iface:ty),*) => {
+        $crate::request_enum!($(#[$attrs])* $enu | $($evt_name => $iface),* | );
     };
-    ($(#[$attrs:meta])? $enu:ident | $($evt_name:ident => $iface:ty),* | $($name:ident => $value:ty),*) => {
-        $(#[$attrs])?
+    ($(#[$attrs:meta])* $enu:ident | $($evt_name:ident => $iface:ty),* | $($name:ident => $value:ty),*) => {
+        $(#[$attrs])*
         pub enum $enu {
             $(
                 $evt_name { request: <$iface as $crate::Interface>::Request, object: $crate::Main<$iface> },

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -235,7 +235,7 @@ mod anonymous_object {
 #[macro_export]
 macro_rules! request_enum(
     ($(#[$attrs:meta])? $enu:ident | $($evt_name:ident => $iface:ty),*) => {
-        $crate::request_enum!($enu | $($evt_name => $iface),* | );
+        $crate::request_enum!($(#[$attrs])? $enu | $($evt_name => $iface),* | );
     };
     ($(#[$attrs:meta])? $enu:ident | $($evt_name:ident => $iface:ty),* | $($name:ident => $value:ty),*) => {
         $(#[$attrs])?


### PR DESCRIPTION
Hi,
with some help from the matrix chat, i have added with this tiny change the possibility to use attributes  for `request_enum!` and `event_enum!` macros. The attributes can be added just before the enum name, for example:
```rust
request_enum!(
    #[derive(Debug)]WaylandRequest |
    Compositor => WlCompositor,
    Subcompositor => WlSubcompositor,
    Shm => WlShm,
    Seat => WlSeat
);
```
The macro will copy everything inside `#[...]`, so it will works also for all the the attributes. 
Thanks for the attention and for the effort involved into the project!