### PR TITLE
client: Fix not found macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [client] Allow invocations of `event_enum!` without prior imports with `use`
+
 ## 0.28.5 -- 2020-02-26
 
 - [sys] Update `dlib` dependency to v0.5 to match new macro fornat. The `dlopen` feature no longer

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -289,7 +289,7 @@ pub struct RawEvent {
 #[macro_export]
 macro_rules! event_enum(
     ($enu:ident | $($evt_name:ident => $iface:ty),*) => {
-        event_enum!($enu | $($evt_name => $iface),* | );
+        $crate::event_enum!($enu | $($evt_name => $iface),* | );
     };
     ($enu:ident | $($evt_name:ident => $iface:ty),* | $($name:ident => $value:ty),*) => {
         pub enum $enu {


### PR DESCRIPTION
Using the `crate::` modifier allows users to invoke this macro with no
`use` import, e.g.

    wayland_client::event_enum! { ... }