### PR TITLE
Added `PartialEq` implementation for the `Client` structure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   updating `wlr-layer-shell` to version 4.
 - [client] Added the possibility to handle attributes for `event_enum!` macro.
 - [server] Added the possibility to handle attributes for `request_enum!` macro.
+- [server] Added `PartialEq` implementation for `Client` structure.
 
 #### Bugfixes
 

--- a/wayland-server/src/client.rs
+++ b/wayland-server/src/client.rs
@@ -10,7 +10,7 @@ use crate::{Interface, Main, Resource, UserDataMap};
 /// A handle to a client connected to your server
 ///
 /// There can be several handles referring to the same client.
-#[derive(Clone)]
+#[derive(Clone,PartialEq)]
 pub struct Client {
     inner: ClientInner,
 }

--- a/wayland-server/src/client.rs
+++ b/wayland-server/src/client.rs
@@ -10,7 +10,7 @@ use crate::{Interface, Main, Resource, UserDataMap};
 /// A handle to a client connected to your server
 ///
 /// There can be several handles referring to the same client.
-#[derive(Clone,PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct Client {
     inner: ClientInner,
 }

--- a/wayland-server/src/native_lib/client.rs
+++ b/wayland-server/src/native_lib/client.rs
@@ -166,6 +166,11 @@ impl ClientInner {
         }
     }
 }
+impl PartialEq for ClientInner {
+    fn eq(&self, other: &Self) -> bool {
+        self.equals(other)
+    }
+}
 
 unsafe extern "C" fn client_destroy(listener: *mut wl_listener, _data: *mut c_void) {
     let internal =

--- a/wayland-server/src/rust_imp/clients.rs
+++ b/wayland-server/src/rust_imp/clients.rs
@@ -340,6 +340,11 @@ impl ClientInner {
         }
     }
 }
+impl PartialEq for ClientInner {
+    fn eq(&self, other: &Self) -> bool {
+        self.equals(other)
+    }
+}
 
 pub(crate) struct ClientManager {
     epoll_mgr: Rc<FdManager>,


### PR DESCRIPTION
Hi,

this little patch add `PartialEq` implementation for the `Client` structure by just using the already implemented `equals` function. Implementing `PartialEq` allow to integrate `Client` with other standard rust components that rely on that trait.

Thanks for the attention,
Have a good day