### PR TITLE
protocols: update to 1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+#### Additions
+
+* [protocols] Update wayland-protocols to 1.21.
+* [protocols] Add new feature to enable staging protocols.
+* [protocols] `xdg-activation-v1` is now generated under staging protocols feature.
+
+#### Protocol changes breaking the bindings
+
+A few protocols broke in the rust bindings but not in the C-api. A few of these changes to the generated bindings due
+to the protocol now properly declaring bitsets and enums include:
+* Events and Requests now taking a bitflag struct or enum instead of a raw `u32`.
+* Bitflags now properly declared as a bitflag struct vs the old method which involved some enums and converting the enums to `u32`.
+
+Effected protocols by above changes include:
+* `fullscreen-shell`
+* `linux-dmabuf-v1`
+* `pointer-constraints-v1`
+* `pointer-gestures-v1`
+* `presentation-time`
+* `text-input-v1`
+* `text-input-v3`
+
 ## 0.28.6 -- 2021-06-29
 
 #### Additions

--- a/wayland-protocols/Cargo.toml
+++ b/wayland-protocols/Cargo.toml
@@ -24,6 +24,7 @@ wayland-scanner = { version = "0.28.6", path = "../wayland-scanner" }
 [features]
 client = ["wayland-client"]
 server = ["wayland-server"]
+staging_protocols = []
 unstable_protocols = []
 
 [package.metadata.docs.rs]

--- a/wayland-protocols/README.md
+++ b/wayland-protocols/README.md
@@ -19,6 +19,7 @@ The provided objects are controlled by cargo features:
 
 - the `client` and `server` cargo features respectively enable the generation of client-side
   and server-side objects
+- the `staging_protocols` enable the generation of protocols in the staging process and will soon become stable.
 - the `unstable_protocols` enable the generation of not-yet-stabilized protocols
 
 If you wish for other protocols to be integrated, please open an issue on Github. Only protocols that

--- a/wayland-protocols/src/lib.rs
+++ b/wayland-protocols/src/lib.rs
@@ -22,6 +22,9 @@ extern crate bitflags;
 #[macro_use]
 mod protocol_macro;
 
+#[cfg(feature = "staging_protocols")]
+pub mod staging;
+
 #[cfg(feature = "unstable_protocols")]
 pub mod unstable;
 

--- a/wayland-protocols/src/protocol_macro.rs
+++ b/wayland-protocols/src/protocol_macro.rs
@@ -47,7 +47,7 @@ macro_rules! wayland_protocol(
     }
 );
 
-#[cfg(feature = "unstable_protocols")]
+#[cfg(any(feature = "staging_protocols", feature = "unstable_protocols"))]
 #[macro_escape]
 macro_rules! wayland_protocol_versioned(
     ($name: expr, [$($version: ident),*], $std_imports:tt, $prot_imports:tt) => {

--- a/wayland-protocols/src/staging.rs
+++ b/wayland-protocols/src/staging.rs
@@ -1,0 +1,41 @@
+//! Staging protocols from wayland-protocols
+//!
+//! The protocols described this module are in the staging process and will soon be made part of a
+//! release. Staging protocols are guaranteed to have no backwards incompatible changes introduced.
+//!
+//! These protocols are ready for wider adoption and clients and compositors are encouraged to
+//! implement staging protocol extensions where a protocol's functionality is desired.
+//!
+//! Although these protocols should be stable, the protocols may be completely replaced in a new
+//! major version or with a completely different protocol.
+
+#![cfg_attr(rustfmt, rustfmt_skip)]
+
+pub mod xdg_activation {
+    //! The way for a client to pass focus to another toplevel is as follows.
+    //!
+    //! The client that intends to activate another toplevel uses the
+    //! xdg_activation_v1.get_activation_token request to get an activation token.
+    //! This token is then passed to the client to be activated through a separate
+    //! band of communication. The client to be activated will then pass the token
+    //! it received to the xdg_activation_v1.activate request. The compositor can
+    //! then use this token to decide how to react to the activation request.
+    //!
+    //! The token the activating client gets may be ineffective either already at
+    //! the time it receives it, for example if it was not focused, for focus
+    //! stealing prevention. The activating client will have no way to discover
+    //! the validity of the token, and may still forward it to the to be activated
+    //! client.
+    //!
+    //! The created activation token may optionally get information attached to it
+    //! that can be used by the compositor to identify the application that we
+    //! intend to activate. This can for example be used to display a visual hint
+    //! about what application is being started.
+
+    wayland_protocol_versioned!(
+        "xdg-activation",
+        [v1],
+        [(wl_seat, wl_seat_interface), (wl_surface, wl_surface_interface)],
+        []
+    );
+}

--- a/wayland-protocols/src/unstable.rs
+++ b/wayland-protocols/src/unstable.rs
@@ -1,7 +1,7 @@
 //! Unstable protocols from wayland-protocols
 //!
 //! The protocols described in this module are experimental and
-//! provide no guarantee of forward support. They may be abandonned
+//! provide no guarantee of forward support. They may be abandoned
 //! or never widely implemented.
 //!
 //! Backward compatible changes may be added together with the


### PR DESCRIPTION
Updates wayland-protocols to 1.21.

This also adds a module and feature to enable `staging` modules.