### PR TITLE
Conditionally exclude the socket layer to port to other network stacks

### DIFF
--- a/wayland-commons/Cargo.toml
+++ b/wayland-commons/Cargo.toml
@@ -16,3 +16,7 @@ wayland-sys = { version = "0.29.0", path = "../wayland-sys" }
 nix = "0.22"
 once_cell = "1.1"
 smallvec = "1"
+
+[features]
+default = ["socket"]
+socket = []

--- a/wayland-commons/src/lib.rs
+++ b/wayland-commons/src/lib.rs
@@ -24,6 +24,7 @@ use wayland_sys::common as syscom;
 pub mod debug;
 pub mod filter;
 pub mod map;
+#[cfg(feature = "socket")]
 pub mod socket;
 pub mod user_data;
 pub mod wire;


### PR DESCRIPTION
I am working on porting some wayland based code to a new platform (using webassembly and the browser); the network layer is necessarily different, and there's no way CLOEXEC sockets will be supported. I'd like to re-use wayland-commons however, so I'd love to get this conditional compilation included, especially considering wayland-protocols depends on it.