### PR TITLE
Remove reference to non-existent function

### DIFF
--- a/wayland-client/src/display.rs
+++ b/wayland-client/src/display.rs
@@ -192,8 +192,6 @@ impl Display {
     ///
     /// Will write as many pending requests as possible to the server socket. Never blocks: if not all
     /// requests could be written, will return an io error `WouldBlock`.
-    ///
-    /// This function is identical to `EventQueue::flush`
     pub fn flush(&self) -> io::Result<()> {
         self.inner.flush()
     }


### PR DESCRIPTION
The reference function was deleted in b523022401bed89d3d7123d18a17c106e412a6fe