### PR TITLE
client: remove unneeded Default bound for DelegateDispatch::UserData

### DIFF
--- a/wayland-backend/src/protocol.rs
+++ b/wayland-backend/src/protocol.rs
@@ -41,7 +41,7 @@ impl ArgumentType {
 
 /// Enum of possible argument of the protocol
 #[derive(Clone, PartialEq, Eq, Debug)]
-#[allow(clippy::box_vec)]
+#[allow(clippy::box_collection)]
 pub enum Argument<Id> {
     /// An integer argument. Represented by a [`i32`].
     Int(i32),

--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -239,7 +239,7 @@ impl ObjectData for TemporaryData {
  */
 
 pub trait DelegateDispatchBase<I: Proxy> {
-    type UserData: Default + Send + Sync + 'static;
+    type UserData: Send + Sync + 'static;
 }
 
 pub trait DelegateDispatch<


### PR DESCRIPTION
DataInit has made this bound redundant.