### PR TITLE
Switch default socket name to wayland-1

### DIFF
--- a/wayland-commons/src/wire.rs
+++ b/wayland-commons/src/wire.rs
@@ -52,7 +52,7 @@ pub enum ArgumentType {
 
 /// Enum of possible argument as recognized by the wire, including values
 #[derive(Clone, PartialEq, Debug)]
-#[allow(clippy::box_vec)]
+#[allow(clippy::box_collection)]
 pub enum Argument {
     /// i32
     Int(i32),

--- a/wayland-server/src/display.rs
+++ b/wayland-server/src/display.rs
@@ -171,7 +171,7 @@ impl Display {
     /// `XDG_RUNTIME_DIR`.
     ///
     /// If a name is provided, it is used. Otherwise, if `WAYLAND_DISPLAY` environment
-    /// variable is set, its contents are used as socket name. Otherwise, `wayland-0` is used.
+    /// variable is set, its contents are used as socket name. Otherwise, `wayland-1` is used.
     ///
     /// Errors if `name` contains an interior null, or if `XDG_RUNTIME_DIR` is not set,
     /// or if specified could not be bound (either it is already used or the compositor
@@ -189,7 +189,7 @@ impl Display {
     ///
     /// Socket will be created in the directory specified by the environment variable
     /// `XDG_RUNTIME_DIR`. The directory is scanned for any name in the form `wayland-$d` with
-    /// `0 <= $d < 32` and the first available one is used.
+    /// `1 <= $d < 32` and the first available one is used.
     ///
     /// Errors if `XDG_RUNTIME_DIR` is not set, or all 32 names are already in use.
     pub fn add_socket_auto(&mut self) -> IoResult<OsString> {

--- a/wayland-server/src/native_lib/display.rs
+++ b/wayland-server/src/native_lib/display.rs
@@ -156,7 +156,7 @@ impl DisplayInner {
             let mut socket_name = get_runtime_dir()?;
             match name {
                 Some(s) => socket_name.push(s.as_ref()),
-                None => socket_name.push("wayland-0"),
+                None => socket_name.push("wayland-1"),
             }
             Err(IoError::new(
                 ErrorKind::PermissionDenied,

--- a/wayland-server/src/rust_imp/display.rs
+++ b/wayland-server/src/rust_imp/display.rs
@@ -112,7 +112,7 @@ impl DisplayInner {
                 path.push(name_path);
             }
         } else {
-            path.push("wayland-0");
+            path.push("wayland-1");
         }
 
         let listener = UnixListener::bind(path)?;
@@ -121,7 +121,7 @@ impl DisplayInner {
     }
 
     pub(crate) fn add_socket_auto(&mut self) -> io::Result<OsString> {
-        for i in 0..32 {
+        for i in 1..32 {
             let name = format!("wayland-{}", i);
             match self.add_socket(Some(&name)) {
                 Ok(()) => return Ok(name.into()),
@@ -130,7 +130,7 @@ impl DisplayInner {
         }
         Err(io::Error::new(
             io::ErrorKind::AddrInUse,
-            "All sockets from wayland-0 to wayland-31 are already in use.",
+            "All sockets from wayland-1 to wayland-31 are already in use.",
         ))
     }
 


### PR DESCRIPTION
It has come to my attention a while ago that it seems to be good pratice
now to use `wayland-1` as the default socket name rather than
`wayland-0`.

This should prevent clients from connecting to `wayland-0` even if
`WAYLAND_DISPLAY` is not set, which is why this change should be
exclusive to the wayland-server part.