### PR TITLE
client: export ConnectError

### DIFF
--- a/wayland-client/src/conn.rs
+++ b/wayland-client/src/conn.rs
@@ -271,12 +271,18 @@ impl<'a> ConnectionHandle<'a> {
     }
 }
 
+/// An error when trying to establish a Wayland connection.
 #[derive(thiserror::Error, Debug)]
 pub enum ConnectError {
+    /// The wayland library could not be loaded.
     #[error("The wayland library could not be loaded")]
     NoWaylandLib,
+
+    /// Could not find wayland compositor
     #[error("Could not find wayland compositor")]
     NoCompositor,
+
+    /// `WAYLAND_SOCKET` was set but contained garbage
     #[error("WAYLAND_SOCKET was set but contained garbage")]
     InvalidFd,
 }

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -23,7 +23,7 @@ pub mod backend {
 
 pub use wayland_backend::protocol::WEnum;
 
-pub use conn::{Connection, ConnectionHandle};
+pub use conn::{ConnectError, Connection, ConnectionHandle};
 pub use event_queue::{
     DelegateDispatch, DelegateDispatchBase, Dispatch, EventQueue, QueueHandle, QueueProxyData,
 };


### PR DESCRIPTION
This wasn't public, so an error enum could not contain this.