### PR TITLE
backend-server: readd forgotten wl_display_destroy

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix display leaks on system server backend.
+
 ## 0.1.0-alpha5
 
 - Expose `wl_display` pointer on system server backend


### PR DESCRIPTION
This was something not carried over from the previous 0.29.x series of the library.