### PR TITLE
protocols: introduce misc/virtual-keyboard-unstable-v1

### DIFF
--- a/wayland-protocols-misc/CHANGELOG.md
+++ b/wayland-protocols-misc/CHANGELOG.md
@@ -1,3 +1,7 @@
 # CHANGELOG: wayland-protocols-misc
 
 ## Unreleased
+
+### Additions
+
+- Introduce protocol `virtual-keyboard-unstable-v1`.

--- a/wayland-protocols-misc/protocols/virtual-keyboard-unstable-v1.xml
+++ b/wayland-protocols-misc/protocols/virtual-keyboard-unstable-v1.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="virtual_keyboard_unstable_v1">
+  <copyright>
+    Copyright © 2008-2011  Kristian Høgsberg
+    Copyright © 2010-2013  Intel Corporation
+    Copyright © 2012-2013  Collabora, Ltd.
+    Copyright © 2018       Purism SPC
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="zwp_virtual_keyboard_v1" version="1">
+    <description summary="virtual keyboard">
+      The virtual keyboard provides an application with requests which emulate
+      the behaviour of a physical keyboard.
+
+      This interface can be used by clients on its own to provide raw input
+      events, or it can accompany the input method protocol.
+    </description>
+
+    <request name="keymap">
+      <description summary="keyboard mapping">
+        Provide a file descriptor to the compositor which can be
+        memory-mapped to provide a keyboard mapping description.
+
+        Format carries a value from the keymap_format enumeration.
+      </description>
+      <arg name="format" type="uint" summary="keymap format"/>
+      <arg name="fd" type="fd" summary="keymap file descriptor"/>
+      <arg name="size" type="uint" summary="keymap size, in bytes"/>
+    </request>
+
+    <enum name="error">
+      <entry name="no_keymap" value="0" summary="No keymap was set"/>
+    </enum>
+
+    <request name="key">
+      <description summary="key event">
+        A key was pressed or released.
+        The time argument is a timestamp with millisecond granularity, with an
+        undefined base. All requests regarding a single object must share the
+        same clock.
+
+        Keymap must be set before issuing this request.
+
+        State carries a value from the key_state enumeration.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="key" type="uint" summary="key that produced the event"/>
+      <arg name="state" type="uint" summary="physical state of the key"/>
+    </request>
+
+    <request name="modifiers">
+      <description summary="modifier and group state">
+        Notifies the compositor that the modifier and/or group state has
+        changed, and it should update state.
+
+        The client should use wl_keyboard.modifiers event to synchronize its
+        internal state with seat state.
+
+        Keymap must be set before issuing this request.
+      </description>
+      <arg name="mods_depressed" type="uint" summary="depressed modifiers"/>
+      <arg name="mods_latched" type="uint" summary="latched modifiers"/>
+      <arg name="mods_locked" type="uint" summary="locked modifiers"/>
+      <arg name="group" type="uint" summary="keyboard layout"/>
+    </request>
+
+    <request name="destroy" type="destructor" since="1">
+      <description summary="destroy the virtual keyboard keyboard object"/>
+    </request>
+  </interface>
+
+  <interface name="zwp_virtual_keyboard_manager_v1" version="1">
+    <description summary="virtual keyboard manager">
+      A virtual keyboard manager allows an application to provide keyboard
+      input events as if they came from a physical keyboard.
+    </description>
+
+    <enum name="error">
+      <entry name="unauthorized" value="0" summary="client not authorized to use the interface"/>
+    </enum>
+
+    <request name="create_virtual_keyboard">
+      <description summary="Create a new virtual keyboard">
+        Creates a new virtual keyboard associated to a seat.
+
+        If the compositor enables a keyboard to perform arbitrary actions, it
+        should present an error when an untrusted client requests a new
+        keyboard.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat"/>
+      <arg name="id" type="new_id" interface="zwp_virtual_keyboard_v1"/>
+    </request>
+  </interface>
+</protocol>

--- a/wayland-protocols-misc/src/lib.rs
+++ b/wayland-protocols-misc/src/lib.rs
@@ -89,6 +89,19 @@ pub mod zwp_input_method_v2 {
     wayland_protocol!("./protocols/input-method-unstable-v2.xml", [wayland_protocols::wp::text_input::zv3]);
 }
 
+#[cfg(feature = "unstable_protocols")]
+pub mod zwp_virtual_keyboard_v1 {
+    //! Virtual keyboard v1 unstable
+    //!
+    //! The virtual keyboard provides an application with requests which emulate
+    //! the behaviour of a physical keyboard.
+    //!
+    //! This interface can be used by clients on its own to provide raw input
+    //! events, or it can accompany the input method protocol.
+
+    wayland_protocol!("./protocols/virtual-keyboard-unstable-v1.xml", []);
+}
+
 pub mod server_decoration {
     //! KDE server decoration protocol
     //!
@@ -99,5 +112,6 @@ pub mod server_decoration {
     //! side decorations.
     //!
     //! Use in conjunction with zxdg_decoration_manager_v1 is undefined.
+
     wayland_protocol!("./protocols/server-decoration.xml", []);
 }


### PR DESCRIPTION
[`virtual_keyboard_unstable_v1` protocol][1] provides an application with requests which emulate the behavior of a physical keyboard. I'm not sure how up-to-date this is, but there is a table which lists clients and compositors with the input protocols they support at which version ([view here][2]). There is [an MR to add the protocol to `wayland-protocols`][3], but my only hesitancy is that there is a note that work is ["Stalled because of use case is not clear and technically a virtual seat might be preferred"][4]. In any case, I created this PR because adding this protocol here would replace the [`zwp-virtual-keyboard` crate][5], and any other one-off implementations.

I also cleaned up some formatting 😊 

[1]: https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/e279266f714c7122e9ad97d56d047313f78cfdbe/protocol/virtual-keyboard-unstable-v1.xml
[2]: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/issues/39#implementation-matrix
[3]: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/11
[4]: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/issues/39#virtual-keyboard-unstable-v1-1
[5]: https://crates.io/crates/zwp-virtual-keyboard