### PR TITLE
backend.rs.client: debug-print of wl_display events

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+#### Bugfixes
+
+- Client-side with the rust backend, `wl_display` events are now properly printed with other events
+  when `WAYLAND_DEBUG=1` is set.
+
 ## 0.1.0-alpha6
 
 #### Changes

--- a/wayland-backend/src/rs/client/mod.rs
+++ b/wayland-backend/src/rs/client/mod.rs
@@ -815,6 +815,14 @@ impl Handle {
     }
 
     fn handle_display_event(&mut self, message: Message<u32>) -> Result<(), WaylandError> {
+        if self.debug {
+            super::debug::print_dispatched_message(
+                "wl_display",
+                message.sender_id,
+                if message.opcode == 0 { "error" } else { "delete_id" },
+                &message.args,
+            );
+        }
         match message.opcode {
             0 => {
                 // wl_display.error


### PR DESCRIPTION
fixes #460 