### PR TITLE
Fix segfault during egl surface creation

### DIFF
--- a/wayland-egl/Cargo.toml
+++ b/wayland-egl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wayland-egl"
 version = "0.30.0-alpha7"
-documentation = "https://smithay.github.io/wayland-rs/wayland_client/"
+documentation = "https://smithay.github.io/wayland-rs/wayland_egl/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Victor Berger <victor.berger@m4x.org>"]
 license = "MIT"
@@ -14,3 +14,4 @@ readme = "README.md"
 [dependencies]
 wayland-backend = { version = "0.1.0-alpha7", path = "../wayland-backend", features = ["client_system"] }
 wayland-sys = { version = "0.30.0-alpha7", path="../wayland-sys", features = ["egl"] }
+thiserror = "1.0.30"


### PR DESCRIPTION
When creating an EGL surface with a width or height of 0, libwayland
will return null as an error. Since `wayland-egl` did not handle this
error, it would lead to a segfault when the surface was dropped.

To resolve this, the surface creation now returns an error, which
indicates that the dimensions are invalid. While using a NonZeroU16
would resolve the need for an error, it comes with a big complexity
overhead for the callee and would restrict some gigantic but possibly
valid surface dimensions.

The only other case where libwayland-egl returns null in the
`wl_egl_window_create` function is when an allocation failure occurs,
which is handled in this patch through a panic. This should also prevent
any other future `null` return values from causing a segfault, though it
might require adjusting the panic message.

Fixes #467.