### PR TITLE
client & server: Expose underling `Handle` types

### DIFF
--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -209,7 +209,7 @@ impl<D> EventQueue<D> {
         qhandle: &QueueHandle<D>,
         data: &mut D,
     ) -> Result<usize, DispatchError> {
-        let mut handle = ConnectionHandle::from_handle(backend.handle());
+        let mut handle = ConnectionHandle::from(backend.handle());
         let mut dispatched = 0;
 
         while let Ok(Some(QueueEvent(cb, msg, odata))) = rx.try_next() {

--- a/wayland-server/src/dispatch.rs
+++ b/wayland-server/src/dispatch.rs
@@ -160,7 +160,7 @@ impl<I: Resource + 'static, U: Send + Sync + 'static, D: Dispatch<I, UserData = 
         client_id: wayland_backend::server::ClientId,
         msg: wayland_backend::protocol::Message<wayland_backend::server::ObjectId>,
     ) -> Option<Arc<dyn ObjectData<D>>> {
-        let mut dhandle = DisplayHandle::from_handle(handle);
+        let mut dhandle = DisplayHandle::from(handle);
         let client = match Client::from_id(&mut dhandle, client_id) {
             Ok(v) => v,
             Err(_) => {

--- a/wayland-server/src/global.rs
+++ b/wayland-server/src/global.rs
@@ -27,7 +27,7 @@ impl<I: Resource + 'static, D: GlobalDispatch<I> + 'static> GlobalHandler<D> for
         _: GlobalId,
         object_id: ObjectId,
     ) -> Arc<dyn ObjectData<D>> {
-        let mut handle = DisplayHandle::from_handle(handle);
+        let mut handle = DisplayHandle::from(handle);
         let client = Client::from_id(&mut handle, client_id).expect("Dead client in bind ?!");
         let resource = <I as Resource>::from_id(&mut handle, object_id)
             .expect("Wrong object_id in GlobalHandler ?!");


### PR DESCRIPTION
In order to create a resource in wayland-server using some `ObjectData` implementation, the underlying handle needs to be exposed.

The client is also made available for consistency.