### PR TITLE
client: add EventQueue::sync_roundtrip

### DIFF
--- a/wayland-client/examples/list_globals.rs
+++ b/wayland-client/examples/list_globals.rs
@@ -31,5 +31,5 @@ fn main() {
 
     println!("Advertized globals:");
 
-    event_queue.blocking_dispatch(&mut AppData).unwrap();
+    event_queue.sync_roundtrip(&mut AppData).unwrap();
 }

--- a/wayland-client/src/conn.rs
+++ b/wayland-client/src/conn.rs
@@ -301,8 +301,8 @@ pub enum ConnectError {
     wl_callback object data for wl_display.sync
 */
 
-struct SyncData {
-    done: Arc<AtomicBool>,
+pub(crate) struct SyncData {
+    pub(crate) done: Arc<AtomicBool>,
 }
 
 impl ObjectData for SyncData {


### PR DESCRIPTION
Pretty much a copy of `Connection::roundtrip` for `EventQueue`