### PR TITLE
Promote client dispatch data

### DIFF
--- a/wayland-client/examples/list_globals.rs
+++ b/wayland-client/examples/list_globals.rs
@@ -2,14 +2,12 @@ use wayland_client::{protocol::wl_registry, Connection, Dispatch, QueueHandle};
 
 struct AppData;
 
-impl Dispatch<wl_registry::WlRegistry> for AppData {
-    type UserData = ();
-
+impl Dispatch<wl_registry::WlRegistry, ()> for AppData {
     fn event(
         &mut self,
         _: &wl_registry::WlRegistry,
         event: wl_registry::Event,
-        _: &Self::UserData,
+        _: &(),
         _: &Connection,
         _: &QueueHandle<AppData>,
     ) {

--- a/wayland-client/examples/simple_window.rs
+++ b/wayland-client/examples/simple_window.rs
@@ -44,9 +44,7 @@ struct State {
     configured: bool,
 }
 
-impl Dispatch<wl_registry::WlRegistry> for State {
-    type UserData = ();
-
+impl Dispatch<wl_registry::WlRegistry, ()> for State {
     fn event(
         &mut self,
         registry: &wl_registry::WlRegistry,
@@ -58,8 +56,9 @@ impl Dispatch<wl_registry::WlRegistry> for State {
         if let wl_registry::Event::Global { name, interface, .. } = event {
             match &interface[..] {
                 "wl_compositor" => {
-                    let compositor =
-                        registry.bind::<wl_compositor::WlCompositor, _>(name, 1, qh, ()).unwrap();
+                    let compositor = registry
+                        .bind::<wl_compositor::WlCompositor, _, _>(name, 1, qh, ())
+                        .unwrap();
                     let surface = compositor.create_surface(qh, ()).unwrap();
                     self.base_surface = Some(surface);
 
@@ -68,7 +67,7 @@ impl Dispatch<wl_registry::WlRegistry> for State {
                     }
                 }
                 "wl_shm" => {
-                    let shm = registry.bind::<wl_shm::WlShm, _>(name, 1, qh, ()).unwrap();
+                    let shm = registry.bind::<wl_shm::WlShm, _, _>(name, 1, qh, ()).unwrap();
 
                     let (init_w, init_h) = (320, 240);
 
@@ -97,11 +96,11 @@ impl Dispatch<wl_registry::WlRegistry> for State {
                     }
                 }
                 "wl_seat" => {
-                    registry.bind::<wl_seat::WlSeat, _>(name, 1, qh, ()).unwrap();
+                    registry.bind::<wl_seat::WlSeat, _, _>(name, 1, qh, ()).unwrap();
                 }
                 "xdg_wm_base" => {
                     let wm_base =
-                        registry.bind::<xdg_wm_base::XdgWmBase, _>(name, 1, qh, ()).unwrap();
+                        registry.bind::<xdg_wm_base::XdgWmBase, _, _>(name, 1, qh, ()).unwrap();
                     self.wm_base = Some(wm_base);
 
                     if self.base_surface.is_some() && self.xdg_surface.is_none() {
@@ -114,14 +113,12 @@ impl Dispatch<wl_registry::WlRegistry> for State {
     }
 }
 
-impl Dispatch<wl_compositor::WlCompositor> for State {
-    type UserData = ();
-
+impl Dispatch<wl_compositor::WlCompositor, ()> for State {
     fn event(
         &mut self,
         _: &wl_compositor::WlCompositor,
         _: wl_compositor::Event,
-        _: &Self::UserData,
+        _: &(),
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
@@ -129,14 +126,12 @@ impl Dispatch<wl_compositor::WlCompositor> for State {
     }
 }
 
-impl Dispatch<wl_surface::WlSurface> for State {
-    type UserData = ();
-
+impl Dispatch<wl_surface::WlSurface, ()> for State {
     fn event(
         &mut self,
         _: &wl_surface::WlSurface,
         _: wl_surface::Event,
-        _: &Self::UserData,
+        _: &(),
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
@@ -144,14 +139,12 @@ impl Dispatch<wl_surface::WlSurface> for State {
     }
 }
 
-impl Dispatch<wl_shm::WlShm> for State {
-    type UserData = ();
-
+impl Dispatch<wl_shm::WlShm, ()> for State {
     fn event(
         &mut self,
         _: &wl_shm::WlShm,
         _: wl_shm::Event,
-        _: &Self::UserData,
+        _: &(),
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
@@ -159,14 +152,12 @@ impl Dispatch<wl_shm::WlShm> for State {
     }
 }
 
-impl Dispatch<wl_shm_pool::WlShmPool> for State {
-    type UserData = ();
-
+impl Dispatch<wl_shm_pool::WlShmPool, ()> for State {
     fn event(
         &mut self,
         _: &wl_shm_pool::WlShmPool,
         _: wl_shm_pool::Event,
-        _: &Self::UserData,
+        _: &(),
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
@@ -174,14 +165,12 @@ impl Dispatch<wl_shm_pool::WlShmPool> for State {
     }
 }
 
-impl Dispatch<wl_buffer::WlBuffer> for State {
-    type UserData = ();
-
+impl Dispatch<wl_buffer::WlBuffer, ()> for State {
     fn event(
         &mut self,
         _: &wl_buffer::WlBuffer,
         _: wl_buffer::Event,
-        _: &Self::UserData,
+        _: &(),
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
@@ -221,9 +210,7 @@ impl State {
     }
 }
 
-impl Dispatch<xdg_wm_base::XdgWmBase> for State {
-    type UserData = ();
-
+impl Dispatch<xdg_wm_base::XdgWmBase, ()> for State {
     fn event(
         &mut self,
         wm_base: &xdg_wm_base::XdgWmBase,
@@ -238,9 +225,7 @@ impl Dispatch<xdg_wm_base::XdgWmBase> for State {
     }
 }
 
-impl Dispatch<xdg_surface::XdgSurface> for State {
-    type UserData = ();
-
+impl Dispatch<xdg_surface::XdgSurface, ()> for State {
     fn event(
         &mut self,
         xdg_surface: &xdg_surface::XdgSurface,
@@ -261,9 +246,7 @@ impl Dispatch<xdg_surface::XdgSurface> for State {
     }
 }
 
-impl Dispatch<xdg_toplevel::XdgToplevel> for State {
-    type UserData = ();
-
+impl Dispatch<xdg_toplevel::XdgToplevel, ()> for State {
     fn event(
         &mut self,
         _: &xdg_toplevel::XdgToplevel,
@@ -278,9 +261,7 @@ impl Dispatch<xdg_toplevel::XdgToplevel> for State {
     }
 }
 
-impl Dispatch<wl_seat::WlSeat> for State {
-    type UserData = ();
-
+impl Dispatch<wl_seat::WlSeat, ()> for State {
     fn event(
         &mut self,
         seat: &wl_seat::WlSeat,
@@ -297,9 +278,7 @@ impl Dispatch<wl_seat::WlSeat> for State {
     }
 }
 
-impl Dispatch<wl_keyboard::WlKeyboard> for State {
-    type UserData = ();
-
+impl Dispatch<wl_keyboard::WlKeyboard, ()> for State {
     fn event(
         &mut self,
         _: &wl_keyboard::WlKeyboard,

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -2,10 +2,7 @@
 
 use std::ops::Range;
 
-use crate::{
-    protocol::wl_registry, Connection, DelegateDispatch, DelegateDispatchBase, Dispatch, Proxy,
-    QueueHandle,
-};
+use crate::{protocol::wl_registry, Connection, DelegateDispatch, Dispatch, Proxy, QueueHandle};
 
 /// Description of an advertized global
 #[derive(Debug)]
@@ -27,10 +24,6 @@ pub struct GlobalDescription {
 #[derive(Debug)]
 pub struct GlobalList {
     globals: Vec<GlobalDescription>,
-}
-
-impl DelegateDispatchBase<wl_registry::WlRegistry> for GlobalList {
-    type UserData = ();
 }
 
 impl<D> DelegateDispatch<wl_registry::WlRegistry, (), D> for GlobalList

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -33,7 +33,7 @@ impl DelegateDispatchBase<wl_registry::WlRegistry> for GlobalList {
     type UserData = ();
 }
 
-impl<D> DelegateDispatch<wl_registry::WlRegistry, D> for GlobalList
+impl<D> DelegateDispatch<wl_registry::WlRegistry, (), D> for GlobalList
 where
     D: Dispatch<wl_registry::WlRegistry, ()> + AsMut<GlobalList>,
 {
@@ -73,7 +73,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for GlobalList {
         conn: &Connection,
         qhandle: &QueueHandle<Self>,
     ) {
-        <Self as DelegateDispatch<wl_registry::WlRegistry, Self>>::event(
+        <Self as DelegateDispatch<wl_registry::WlRegistry, (), Self>>::event(
             self, proxy, event, data, conn, qhandle,
         )
     }

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -27,9 +27,7 @@ pub mod backend {
 pub use wayland_backend::protocol::WEnum;
 
 pub use conn::{ConnectError, Connection};
-pub use event_queue::{
-    DelegateDispatch, DelegateDispatchBase, Dispatch, EventQueue, QueueHandle, QueueProxyData,
-};
+pub use event_queue::{DelegateDispatch, Dispatch, EventQueue, QueueHandle, QueueProxyData};
 
 /// Generated protocol definitions
 ///

--- a/wayland-tests/tests/attach_to_surface.rs
+++ b/wayland-tests/tests/attach_to_surface.rs
@@ -33,7 +33,7 @@ fn attach_null() {
 
     let compositor = client_ddata
         .globals
-        .bind::<wayc::protocol::wl_compositor::WlCompositor, _>(
+        .bind::<wayc::protocol::wl_compositor::WlCompositor, _, _>(
             &client.event_queue.handle(),
             &registry,
             1..2,
@@ -69,7 +69,12 @@ fn attach_buffer() {
 
     let shm = client_ddata
         .globals
-        .bind::<wayc::protocol::wl_shm::WlShm, _>(&client.event_queue.handle(), &registry, 1..2, ())
+        .bind::<wayc::protocol::wl_shm::WlShm, _, _>(
+            &client.event_queue.handle(),
+            &registry,
+            1..2,
+            (),
+        )
         .unwrap();
 
     let mut file = tempfile::tempfile().unwrap();
@@ -81,7 +86,7 @@ fn attach_buffer() {
 
     let compositor = client_ddata
         .globals
-        .bind::<wayc::protocol::wl_compositor::WlCompositor, _>(
+        .bind::<wayc::protocol::wl_compositor::WlCompositor, _, _>(
             &client.event_queue.handle(),
             &registry,
             1..2,

--- a/wayland-tests/tests/attach_to_surface.rs
+++ b/wayland-tests/tests/attach_to_surface.rs
@@ -225,7 +225,7 @@ impl AsMut<wayc::globals::GlobalList> for ClientHandler {
 }
 
 wayc::delegate_dispatch!(ClientHandler:
-    [wayc::protocol::wl_registry::WlRegistry] => wayc::globals::GlobalList
+    [wayc::protocol::wl_registry::WlRegistry: ()] => wayc::globals::GlobalList
 );
 
 client_ignore_impl!(ClientHandler => [

--- a/wayland-tests/tests/client_bad_requests.rs
+++ b/wayland-tests/tests/client_bad_requests.rs
@@ -86,7 +86,7 @@ impl AsMut<wayc::globals::GlobalList> for ClientHandler {
 }
 
 wayc::delegate_dispatch!(ClientHandler:
-    [wayc::protocol::wl_registry::WlRegistry] => wayc::globals::GlobalList
+    [wayc::protocol::wl_registry::WlRegistry: ()] => wayc::globals::GlobalList
 );
 
 client_ignore_impl!(ClientHandler => [

--- a/wayland-tests/tests/client_bad_requests.rs
+++ b/wayland-tests/tests/client_bad_requests.rs
@@ -18,7 +18,7 @@ fn constructor_dead() {
 
     let seat = client_ddata
         .globals
-        .bind::<wayc::protocol::wl_seat::WlSeat, _>(
+        .bind::<wayc::protocol::wl_seat::WlSeat, _, _>(
             &client.event_queue.handle(),
             &registry,
             1..2,
@@ -45,7 +45,7 @@ fn send_constructor_wrong_type() {
 
     let seat = client_ddata
         .globals
-        .bind::<wayc::protocol::wl_seat::WlSeat, _>(
+        .bind::<wayc::protocol::wl_seat::WlSeat, _, _>(
             &client.event_queue.handle(),
             &registry,
             1..2,
@@ -62,7 +62,7 @@ fn send_constructor_wrong_type() {
                 client
                     .event_queue
                     .handle()
-                    .make_data::<wayc::protocol::wl_keyboard::WlKeyboard>(()),
+                    .make_data::<wayc::protocol::wl_keyboard::WlKeyboard, _>(()),
             ),
         )
         .unwrap();

--- a/wayland-tests/tests/client_proxies.rs
+++ b/wayland-tests/tests/client_proxies.rs
@@ -22,7 +22,7 @@ fn proxy_equals() {
 
     let compositor1 = client_ddata
         .globals
-        .bind::<wayc::protocol::wl_compositor::WlCompositor, _>(
+        .bind::<wayc::protocol::wl_compositor::WlCompositor, _, _>(
             &client.event_queue.handle(),
             &registry,
             1..2,
@@ -32,7 +32,7 @@ fn proxy_equals() {
 
     let compositor2 = client_ddata
         .globals
-        .bind::<wayc::protocol::wl_compositor::WlCompositor, _>(
+        .bind::<wayc::protocol::wl_compositor::WlCompositor, _, _>(
             &client.event_queue.handle(),
             &registry,
             1..2,
@@ -62,7 +62,7 @@ fn proxy_user_data() {
 
     let compositor1 = client_ddata
         .globals
-        .bind::<wayc::protocol::wl_compositor::WlCompositor, _>(
+        .bind::<wayc::protocol::wl_compositor::WlCompositor, _, _>(
             &client.event_queue.handle(),
             &registry,
             1..2,
@@ -72,7 +72,7 @@ fn proxy_user_data() {
 
     let compositor2 = client_ddata
         .globals
-        .bind::<wayc::protocol::wl_compositor::WlCompositor, _>(
+        .bind::<wayc::protocol::wl_compositor::WlCompositor, _, _>(
             &client.event_queue.handle(),
             &registry,
             1..2,
@@ -103,7 +103,7 @@ fn dead_proxies() {
 
     let output = client_ddata
         .globals
-        .bind::<wayc::protocol::wl_output::WlOutput, _>(
+        .bind::<wayc::protocol::wl_output::WlOutput, _, _>(
             &client.event_queue.handle(),
             &registry,
             3..4,
@@ -144,7 +144,7 @@ fn dead_object_argument() {
 
     let output = client_ddata
         .globals
-        .bind::<wayc::protocol::wl_output::WlOutput, _>(
+        .bind::<wayc::protocol::wl_output::WlOutput, _, _>(
             &client.event_queue.handle(),
             &registry,
             3..4,
@@ -153,7 +153,7 @@ fn dead_object_argument() {
         .unwrap();
     let compositor = client_ddata
         .globals
-        .bind::<wayc::protocol::wl_compositor::WlCompositor, _>(
+        .bind::<wayc::protocol::wl_compositor::WlCompositor, _, _>(
             &client.event_queue.handle(),
             &registry,
             1..2,
@@ -238,9 +238,7 @@ wayc::delegate_dispatch!(ClientHandler:
     [wayc::protocol::wl_registry::WlRegistry] => wayc::globals::GlobalList
 );
 
-impl wayc::Dispatch<wayc::protocol::wl_compositor::WlCompositor> for ClientHandler {
-    type UserData = usize;
-
+impl wayc::Dispatch<wayc::protocol::wl_compositor::WlCompositor, usize> for ClientHandler {
     fn event(
         &mut self,
         _: &wayc::protocol::wl_compositor::WlCompositor,
@@ -252,9 +250,7 @@ impl wayc::Dispatch<wayc::protocol::wl_compositor::WlCompositor> for ClientHandl
     }
 }
 
-impl wayc::Dispatch<wayc::protocol::wl_surface::WlSurface> for ClientHandler {
-    type UserData = ();
-
+impl wayc::Dispatch<wayc::protocol::wl_surface::WlSurface, ()> for ClientHandler {
     fn event(
         &mut self,
         _: &wayc::protocol::wl_surface::WlSurface,

--- a/wayland-tests/tests/client_proxies.rs
+++ b/wayland-tests/tests/client_proxies.rs
@@ -235,7 +235,7 @@ impl AsMut<wayc::globals::GlobalList> for ClientHandler {
 }
 
 wayc::delegate_dispatch!(ClientHandler:
-    [wayc::protocol::wl_registry::WlRegistry] => wayc::globals::GlobalList
+    [wayc::protocol::wl_registry::WlRegistry: ()] => wayc::globals::GlobalList
 );
 
 impl wayc::Dispatch<wayc::protocol::wl_compositor::WlCompositor, usize> for ClientHandler {

--- a/wayland-tests/tests/destructors.rs
+++ b/wayland-tests/tests/destructors.rs
@@ -182,7 +182,7 @@ impl AsMut<wayc::globals::GlobalList> for ClientHandler {
 }
 
 wayc::delegate_dispatch!(ClientHandler:
-    [wayc::protocol::wl_registry::WlRegistry] => wayc::globals::GlobalList
+    [wayc::protocol::wl_registry::WlRegistry: ()] => wayc::globals::GlobalList
 );
 
 client_ignore_impl!(ClientHandler => [

--- a/wayland-tests/tests/destructors.rs
+++ b/wayland-tests/tests/destructors.rs
@@ -23,7 +23,7 @@ fn resource_destructor_request() {
 
     let output = client_ddata
         .globals
-        .bind::<wayc::protocol::wl_output::WlOutput, _>(
+        .bind::<wayc::protocol::wl_output::WlOutput, _, _>(
             &client.event_queue.handle(),
             &registry,
             3..4,
@@ -55,7 +55,7 @@ fn resource_destructor_cleanup() {
 
     client_ddata
         .globals
-        .bind::<wayc::protocol::wl_output::WlOutput, _>(
+        .bind::<wayc::protocol::wl_output::WlOutput, _, _>(
             &client.event_queue.handle(),
             &registry,
             3..4,
@@ -90,7 +90,7 @@ fn client_destructor_cleanup() {
 
     client_ddata
         .globals
-        .bind::<wayc::protocol::wl_output::WlOutput, _>(
+        .bind::<wayc::protocol::wl_output::WlOutput, _, _>(
             &client.event_queue.handle(),
             &registry,
             3..4,

--- a/wayland-tests/tests/globals.rs
+++ b/wayland-tests/tests/globals.rs
@@ -267,7 +267,7 @@ impl AsMut<wayc::globals::GlobalList> for ClientHandler {
 }
 
 wayc::delegate_dispatch!(ClientHandler:
-    [wayc::protocol::wl_registry::WlRegistry] => wayc::globals::GlobalList
+    [wayc::protocol::wl_registry::WlRegistry: ()] => wayc::globals::GlobalList
 );
 
 client_ignore_impl!(ClientHandler => [

--- a/wayland-tests/tests/globals.rs
+++ b/wayland-tests/tests/globals.rs
@@ -102,17 +102,17 @@ fn range_instantiate() {
 
     let compositor = client_ddata
         .globals
-        .bind::<WlCompositor, _>(&client.event_queue.handle(), &registry, 1..5, ())
+        .bind::<WlCompositor, _, _>(&client.event_queue.handle(), &registry, 1..5, ())
         .unwrap();
     assert!(compositor.version() == 4);
     let shell = client_ddata
         .globals
-        .bind::<WlShell, _>(&client.event_queue.handle(), &registry, 1..3, ())
+        .bind::<WlShell, _, _>(&client.event_queue.handle(), &registry, 1..3, ())
         .unwrap();
     assert!(shell.version() == 1);
 
     assert!(matches!(
-        client_ddata.globals.bind::<WlCompositor, _>(
+        client_ddata.globals.bind::<WlCompositor, _, _>(
             &client.event_queue.handle(),
             &registry,
             5..6,
@@ -125,7 +125,12 @@ fn range_instantiate() {
         })
     ));
     assert!(matches!(
-        client_ddata.globals.bind::<WlOutput, _>(&client.event_queue.handle(), &registry, 1..4, ()),
+        client_ddata.globals.bind::<WlOutput, _, _>(
+            &client.event_queue.handle(),
+            &registry,
+            1..4,
+            ()
+        ),
         Err(BindError::MissingGlobal { interface: "wl_output" })
     ));
 }
@@ -152,7 +157,7 @@ fn wrong_global() {
     // instantiate a wrong global, this should kill the client
     // but currently does not fail on native_lib
 
-    registry.bind::<WlOutput, _>(1, 1, &client.event_queue.handle(), ()).unwrap();
+    registry.bind::<WlOutput, _, _>(1, 1, &client.event_queue.handle(), ()).unwrap();
 
     assert!(roundtrip(&mut client, &mut server, &mut client_ddata, &mut ServerHandler).is_err());
 }
@@ -171,7 +176,7 @@ fn wrong_global_version() {
 
     // instantiate a global with wrong version, this should kill the client
 
-    registry.bind::<WlCompositor, _>(1, 2, &client.event_queue.handle(), ()).unwrap();
+    registry.bind::<WlCompositor, _, _>(1, 2, &client.event_queue.handle(), ()).unwrap();
 
     assert!(roundtrip(&mut client, &mut server, &mut client_ddata, &mut ServerHandler).is_err());
 }
@@ -190,7 +195,7 @@ fn invalid_global_version() {
 
     // instantiate a global with version 0, which is invalid this should kill the client
 
-    registry.bind::<WlCompositor, _>(1, 0, &client.event_queue.handle(), ()).unwrap();
+    registry.bind::<WlCompositor, _, _>(1, 0, &client.event_queue.handle(), ()).unwrap();
 
     assert!(roundtrip(&mut client, &mut server, &mut client_ddata, &mut ServerHandler).is_err());
 }
@@ -209,7 +214,7 @@ fn wrong_global_id() {
 
     // instantiate a global with version 0, which is invalid this should kill the client
 
-    registry.bind::<WlCompositor, _>(3, 1, &client.event_queue.handle(), ()).unwrap();
+    registry.bind::<WlCompositor, _, _>(3, 1, &client.event_queue.handle(), ()).unwrap();
 
     assert!(roundtrip(&mut client, &mut server, &mut client_ddata, &mut ServerHandler).is_err());
 }
@@ -235,12 +240,12 @@ fn two_step_binding() {
 
     client_ddata
         .globals
-        .bind::<WlCompositor, _>(&client.event_queue.handle(), &registry, 1..2, ())
+        .bind::<WlCompositor, _, _>(&client.event_queue.handle(), &registry, 1..2, ())
         .unwrap();
 
     client_ddata
         .globals
-        .bind::<WlOutput, _>(&client.event_queue.handle(), &registry, 1..2, ())
+        .bind::<WlOutput, _, _>(&client.event_queue.handle(), &registry, 1..2, ())
         .unwrap();
 
     roundtrip(&mut client, &mut server, &mut client_ddata, &mut ServerHandler).unwrap();

--- a/wayland-tests/tests/helpers/mod.rs
+++ b/wayland-tests/tests/helpers/mod.rs
@@ -130,13 +130,12 @@ impl<D> ways::backend::ClientData<D> for DumbClientData {
 macro_rules! client_ignore_impl {
     ($handler:ty => [$($iface:ty),*]) => {
         $(
-            impl $crate::helpers::wayc::Dispatch<$iface> for $handler {
-                type UserData = ();
+            impl $crate::helpers::wayc::Dispatch<$iface, ()> for $handler {
                 fn event(
                     &mut self,
                     _: &$iface,
                     _: <$iface as $crate::helpers::wayc::Proxy>::Event,
-                    _: &Self::UserData,
+                    _: &(),
                     _: &$crate::helpers::wayc::Connection,
                     _: &$crate::helpers::wayc::QueueHandle<Self>,
                 ) {

--- a/wayland-tests/tests/protocol_errors.rs
+++ b/wayland-tests/tests/protocol_errors.rs
@@ -71,7 +71,7 @@ impl AsMut<wayc::globals::GlobalList> for ClientHandler {
 }
 
 wayc::delegate_dispatch!(ClientHandler:
-    [wayc::protocol::wl_registry::WlRegistry] => wayc::globals::GlobalList
+    [wayc::protocol::wl_registry::WlRegistry: ()] => wayc::globals::GlobalList
 );
 
 client_ignore_impl!(ClientHandler => [

--- a/wayland-tests/tests/protocol_errors.rs
+++ b/wayland-tests/tests/protocol_errors.rs
@@ -20,7 +20,7 @@ fn client_receive_generic_error() {
     // Instantiate the globals
     client_ddata
         .globals
-        .bind::<wayc::protocol::wl_compositor::WlCompositor, _>(
+        .bind::<wayc::protocol::wl_compositor::WlCompositor, _, _>(
             &client.event_queue.handle(),
             &registry,
             1..2,

--- a/wayland-tests/tests/server_clients.rs
+++ b/wayland-tests/tests/server_clients.rs
@@ -25,7 +25,7 @@ fn client_user_data() {
     // Instantiate the globals
     client_ddata
         .globals
-        .bind::<wayc::protocol::wl_output::WlOutput, _>(
+        .bind::<wayc::protocol::wl_output::WlOutput, _, _>(
             &client.event_queue.handle(),
             &registry,
             1..2,
@@ -43,7 +43,7 @@ fn client_user_data() {
 
     client_ddata
         .globals
-        .bind::<wayc::protocol::wl_compositor::WlCompositor, _>(
+        .bind::<wayc::protocol::wl_compositor::WlCompositor, _, _>(
             &client.event_queue.handle(),
             &registry,
             1..2,

--- a/wayland-tests/tests/server_clients.rs
+++ b/wayland-tests/tests/server_clients.rs
@@ -106,7 +106,7 @@ impl AsMut<wayc::globals::GlobalList> for ClientHandler {
 }
 
 wayc::delegate_dispatch!(ClientHandler:
-    [wayc::protocol::wl_registry::WlRegistry] => wayc::globals::GlobalList
+    [wayc::protocol::wl_registry::WlRegistry: ()] => wayc::globals::GlobalList
 );
 
 client_ignore_impl!(ClientHandler => [

--- a/wayland-tests/tests/server_created_object.rs
+++ b/wayland-tests/tests/server_created_object.rs
@@ -361,7 +361,7 @@ impl AsMut<wayc::globals::GlobalList> for ClientHandler {
 }
 
 wayc::delegate_dispatch!(ClientHandler:
-    [wayc::protocol::wl_registry::WlRegistry] => wayc::globals::GlobalList
+    [wayc::protocol::wl_registry::WlRegistry: ()] => wayc::globals::GlobalList
 );
 client_ignore_impl!(ClientHandler => [
     ClientSeat,

--- a/wayland-tests/tests/server_created_object.rs
+++ b/wayland-tests/tests/server_created_object.rs
@@ -33,11 +33,11 @@ fn data_offer() {
 
     let seat = client_ddata
         .globals
-        .bind::<ClientSeat, _>(&client.event_queue.handle(), &registry, 1..2, ())
+        .bind::<ClientSeat, _, _>(&client.event_queue.handle(), &registry, 1..2, ())
         .unwrap();
     let ddmgr = client_ddata
         .globals
-        .bind::<ClientDDMgr, _>(&client.event_queue.handle(), &registry, 3..4, ())
+        .bind::<ClientDDMgr, _, _>(&client.event_queue.handle(), &registry, 3..4, ())
         .unwrap();
 
     ddmgr.get_data_device(&seat, &client.event_queue.handle(), ()).unwrap();
@@ -79,11 +79,11 @@ fn server_id_reuse() {
 
     let seat = client_ddata
         .globals
-        .bind::<ClientSeat, _>(&client.event_queue.handle(), &registry, 1..2, ())
+        .bind::<ClientSeat, _, _>(&client.event_queue.handle(), &registry, 1..2, ())
         .unwrap();
     let ddmgr = client_ddata
         .globals
-        .bind::<ClientDDMgr, _>(&client.event_queue.handle(), &registry, 3..4, ())
+        .bind::<ClientDDMgr, _, _>(&client.event_queue.handle(), &registry, 3..4, ())
         .unwrap();
 
     ddmgr.get_data_device(&seat, &client.event_queue.handle(), ()).unwrap();
@@ -160,11 +160,11 @@ fn server_created_race() {
 
     let seat = client_ddata
         .globals
-        .bind::<ClientSeat, _>(&client.event_queue.handle(), &registry, 1..2, ())
+        .bind::<ClientSeat, _, _>(&client.event_queue.handle(), &registry, 1..2, ())
         .unwrap();
     let ddmgr = client_ddata
         .globals
-        .bind::<ClientDDMgr, _>(&client.event_queue.handle(), &registry, 3..4, ())
+        .bind::<ClientDDMgr, _, _>(&client.event_queue.handle(), &registry, 3..4, ())
         .unwrap();
 
     ddmgr.get_data_device(&seat, &client.event_queue.handle(), ()).unwrap();
@@ -223,11 +223,11 @@ fn creation_destruction_race() {
 
     let seat = client_ddata
         .globals
-        .bind::<ClientSeat, _>(&client.event_queue.handle(), &registry, 1..2, ())
+        .bind::<ClientSeat, _, _>(&client.event_queue.handle(), &registry, 1..2, ())
         .unwrap();
     let ddmgr = client_ddata
         .globals
-        .bind::<ClientDDMgr, _>(&client.event_queue.handle(), &registry, 3..4, ())
+        .bind::<ClientDDMgr, _, _>(&client.event_queue.handle(), &registry, 3..4, ())
         .unwrap();
 
     // client creates two data devices
@@ -294,11 +294,11 @@ fn creation_destruction_queue_dispatch_race() {
 
     let seat = client_ddata
         .globals
-        .bind::<ClientSeat, _>(&client.event_queue.handle(), &registry, 1..2, ())
+        .bind::<ClientSeat, _, _>(&client.event_queue.handle(), &registry, 1..2, ())
         .unwrap();
     let ddmgr = client_ddata
         .globals
-        .bind::<ClientDDMgr, _>(&client.event_queue.handle(), &registry, 3..4, ())
+        .bind::<ClientDDMgr, _, _>(&client.event_queue.handle(), &registry, 3..4, ())
         .unwrap();
 
     let client_dd = ddmgr.get_data_device(&seat, &client.event_queue.handle(), ()).unwrap();
@@ -368,13 +368,12 @@ client_ignore_impl!(ClientHandler => [
     ClientDDMgr
 ]);
 
-impl wayc::Dispatch<wayc::protocol::wl_data_device::WlDataDevice> for ClientHandler {
-    type UserData = ();
+impl wayc::Dispatch<wayc::protocol::wl_data_device::WlDataDevice, ()> for ClientHandler {
     fn event(
         &mut self,
         data_device: &wayc::protocol::wl_data_device::WlDataDevice,
         event: wayc::protocol::wl_data_device::Event,
-        _: &Self::UserData,
+        _: &(),
         conn: &wayc::Connection,
         _: &wayc::QueueHandle<Self>,
     ) {
@@ -394,14 +393,12 @@ impl wayc::Dispatch<wayc::protocol::wl_data_device::WlDataDevice> for ClientHand
     ]);
 }
 
-impl wayc::Dispatch<ClientDO> for ClientHandler {
-    type UserData = ();
-
+impl wayc::Dispatch<ClientDO, ()> for ClientHandler {
     fn event(
         &mut self,
         _: &ClientDO,
         event: wayc::protocol::wl_data_offer::Event,
-        _: &Self::UserData,
+        _: &(),
         _: &wayc::Connection,
         _: &wayc::QueueHandle<Self>,
     ) {

--- a/wayland-tests/tests/server_global_filter.rs
+++ b/wayland-tests/tests/server_global_filter.rs
@@ -111,7 +111,7 @@ impl AsMut<wayc::globals::GlobalList> for ClientHandler {
 }
 
 wayc::delegate_dispatch!(ClientHandler:
-    [wayc::protocol::wl_registry::WlRegistry] => wayc::globals::GlobalList
+    [wayc::protocol::wl_registry::WlRegistry: ()] => wayc::globals::GlobalList
 );
 
 client_ignore_impl!(ClientHandler => [

--- a/wayland-tests/tests/server_global_filter.rs
+++ b/wayland-tests/tests/server_global_filter.rs
@@ -76,14 +76,19 @@ fn global_filter_try_force() {
     let priv_registry =
         priv_client.display.get_registry(&priv_client.event_queue.handle(), ()).unwrap();
     priv_registry
-        .bind::<wayc::protocol::wl_output::WlOutput, _>(1, 1, &priv_client.event_queue.handle(), ())
+        .bind::<wayc::protocol::wl_output::WlOutput, _, _>(
+            1,
+            1,
+            &priv_client.event_queue.handle(),
+            (),
+        )
         .unwrap();
     roundtrip(&mut priv_client, &mut server, &mut priv_client_ddata, &mut server_ddata).unwrap();
 
     // unprivileged client cannot
     let registry = client.display.get_registry(&client.event_queue.handle(), ()).unwrap();
     registry
-        .bind::<wayc::protocol::wl_output::WlOutput, _>(1, 1, &client.event_queue.handle(), ())
+        .bind::<wayc::protocol::wl_output::WlOutput, _, _>(1, 1, &client.event_queue.handle(), ())
         .unwrap();
 
     assert!(roundtrip(&mut client, &mut server, &mut client_ddata, &mut server_ddata).is_err());

--- a/wayland-tests/tests/server_resources.rs
+++ b/wayland-tests/tests/server_resources.rs
@@ -204,7 +204,7 @@ impl AsMut<wayc::globals::GlobalList> for ClientHandler {
 }
 
 wayc::delegate_dispatch!(ClientHandler:
-    [wayc::protocol::wl_registry::WlRegistry] => wayc::globals::GlobalList
+    [wayc::protocol::wl_registry::WlRegistry: ()] => wayc::globals::GlobalList
 );
 
 client_ignore_impl!(ClientHandler => [ClientOutput]);

--- a/wayland-tests/tests/server_resources.rs
+++ b/wayland-tests/tests/server_resources.rs
@@ -26,7 +26,7 @@ fn resource_equals() {
     // create two outputs
     client_ddata
         .globals
-        .bind::<wayc::protocol::wl_output::WlOutput, _>(
+        .bind::<wayc::protocol::wl_output::WlOutput, _, _>(
             &client.event_queue.handle(),
             &registry,
             3..4,
@@ -35,7 +35,7 @@ fn resource_equals() {
         .unwrap();
     client_ddata
         .globals
-        .bind::<wayc::protocol::wl_output::WlOutput, _>(
+        .bind::<wayc::protocol::wl_output::WlOutput, _, _>(
             &client.event_queue.handle(),
             &registry,
             3..4,
@@ -70,7 +70,7 @@ fn resource_user_data() {
     // create two outputs
     client_ddata
         .globals
-        .bind::<wayc::protocol::wl_output::WlOutput, _>(
+        .bind::<wayc::protocol::wl_output::WlOutput, _, _>(
             &client.event_queue.handle(),
             &registry,
             3..4,
@@ -79,7 +79,7 @@ fn resource_user_data() {
         .unwrap();
     client_ddata
         .globals
-        .bind::<wayc::protocol::wl_output::WlOutput, _>(
+        .bind::<wayc::protocol::wl_output::WlOutput, _, _>(
             &client.event_queue.handle(),
             &registry,
             3..4,
@@ -111,7 +111,7 @@ fn dead_resources() {
     // create two outputs
     let client_output_1 = client_ddata
         .globals
-        .bind::<wayc::protocol::wl_output::WlOutput, _>(
+        .bind::<wayc::protocol::wl_output::WlOutput, _, _>(
             &client.event_queue.handle(),
             &registry,
             3..4,
@@ -120,7 +120,7 @@ fn dead_resources() {
         .unwrap();
     client_ddata
         .globals
-        .bind::<wayc::protocol::wl_output::WlOutput, _>(
+        .bind::<wayc::protocol::wl_output::WlOutput, _, _>(
             &client.event_queue.handle(),
             &registry,
             3..4,
@@ -160,7 +160,7 @@ fn get_resource() {
     // create an outputs
     client_ddata
         .globals
-        .bind::<wayc::protocol::wl_output::WlOutput, _>(
+        .bind::<wayc::protocol::wl_output::WlOutput, _, _>(
             &client.event_queue.handle(),
             &registry,
             3..4,

--- a/wayland-tests/tests/xdg_shell_ping.rs
+++ b/wayland-tests/tests/xdg_shell_ping.rs
@@ -93,7 +93,7 @@ impl AsMut<wayc::globals::GlobalList> for ClientHandler {
 }
 
 wayc::delegate_dispatch!(ClientHandler:
-    [wayc::protocol::wl_registry::WlRegistry] => wayc::globals::GlobalList
+    [wayc::protocol::wl_registry::WlRegistry: ()] => wayc::globals::GlobalList
 );
 
 impl wayc::Dispatch<xs_client::xdg_wm_base::XdgWmBase, ()> for ClientHandler {

--- a/wayland-tests/tests/xdg_shell_ping.rs
+++ b/wayland-tests/tests/xdg_shell_ping.rs
@@ -20,7 +20,7 @@ fn xdg_ping() {
 
     client_ddata
         .globals
-        .bind::<xs_client::xdg_wm_base::XdgWmBase, _>(
+        .bind::<xs_client::xdg_wm_base::XdgWmBase, _, _>(
             &client.event_queue.handle(),
             &registry,
             1..2,
@@ -96,9 +96,7 @@ wayc::delegate_dispatch!(ClientHandler:
     [wayc::protocol::wl_registry::WlRegistry] => wayc::globals::GlobalList
 );
 
-impl wayc::Dispatch<xs_client::xdg_wm_base::XdgWmBase> for ClientHandler {
-    type UserData = ();
-
+impl wayc::Dispatch<xs_client::xdg_wm_base::XdgWmBase, ()> for ClientHandler {
     fn event(
         &mut self,
         wm_base: &xs_client::xdg_wm_base::XdgWmBase,


### PR DESCRIPTION
This promotes the `UserData` associated type to a full generic parameter (on the client only).