### PR TITLE
backend/server: simplify client handling

### DIFF
--- a/wayland-backend/src/rs/server_impl/client.rs
+++ b/wayland-backend/src/rs/server_impl/client.rs
@@ -49,7 +49,7 @@ pub(crate) struct Client<D: 'static> {
     last_serial: u32,
     pub(crate) id: InnerClientId,
     pub(crate) killed: bool,
-    pub(crate) data: Arc<dyn ClientData<D>>,
+    pub(crate) data: Arc<dyn ClientData>,
 }
 
 impl<D> Client<D> {
@@ -64,7 +64,7 @@ impl<D> Client<D> {
         stream: UnixStream,
         id: InnerClientId,
         debug: bool,
-        data: Arc<dyn ClientData<D>>,
+        data: Arc<dyn ClientData>,
     ) -> Self {
         let socket = BufferedSocket::new(unsafe { Socket::from_raw_fd(stream.into_raw_fd()) });
         let mut map = ObjectMap::new();
@@ -660,7 +660,7 @@ impl<D> ClientStore<D> {
     pub(crate) fn create_client(
         &mut self,
         stream: UnixStream,
-        data: Arc<dyn ClientData<D>>,
+        data: Arc<dyn ClientData>,
     ) -> InnerClientId {
         let serial = self.next_serial();
         // Find the next free place

--- a/wayland-backend/src/rs/server_impl/common_poll.rs
+++ b/wayland-backend/src/rs/server_impl/common_poll.rs
@@ -57,7 +57,7 @@ impl<D> InnerBackend<D> {
     pub fn insert_client(
         &self,
         stream: UnixStream,
-        data: Arc<dyn ClientData<D>>,
+        data: Arc<dyn ClientData>,
     ) -> std::io::Result<InnerClientId> {
         let mut state = self.state.lock().unwrap();
         let client_fd = stream.as_raw_fd();

--- a/wayland-backend/src/server_api.rs
+++ b/wayland-backend/src/server_api.rs
@@ -236,6 +236,18 @@ impl Handle {
         self.handle.object_info(id.id)
     }
 
+    /// Initializes a connection to a client.
+    ///
+    /// The `data` parameter contains data that will be associated with the client.
+    #[inline]
+    pub fn insert_client(
+        &mut self,
+        stream: UnixStream,
+        data: Arc<dyn ClientData>,
+    ) -> std::io::Result<ClientId> {
+        Ok(ClientId { id: self.handle.insert_client(stream, data)? })
+    }
+
     /// Returns the id of the client which owns the object.
     #[inline]
     pub fn get_client(&self, id: ObjectId) -> Result<ClientId, InvalidId> {
@@ -436,18 +448,6 @@ impl<D> Backend<D> {
     #[inline]
     pub fn new() -> Result<Self, InitError> {
         Ok(Backend { backend: server_impl::InnerBackend::new()? })
-    }
-
-    /// Initializes a connection to a client.
-    ///
-    /// The `data` parameter contains data that will be associated with the client.
-    #[inline]
-    pub fn insert_client(
-        &mut self,
-        stream: UnixStream,
-        data: Arc<dyn ClientData>,
-    ) -> std::io::Result<ClientId> {
-        Ok(ClientId { id: self.backend.insert_client(stream, data)? })
     }
 
     /// Flushes pending events destined for a client.

--- a/wayland-backend/src/test/destructors.rs
+++ b/wayland-backend/src/test/destructors.rs
@@ -193,7 +193,7 @@ struct ServerClientData(AtomicBool);
 
 macro_rules! impl_server_clientdata {
     ($server_backend:tt) => {
-        impl $server_backend::ClientData<()> for ServerClientData {
+        impl $server_backend::ClientData for ServerClientData {
             fn initialized(&self, _: $server_backend::ClientId) {}
 
             fn disconnected(

--- a/wayland-backend/src/test/destructors.rs
+++ b/wayland-backend/src/test/destructors.rs
@@ -76,7 +76,7 @@ impl_client_objectdata!(client_sys);
 expand_test!(destructor_request, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let server_data = Arc::new(ServerData(AtomicBool::new(false)));
@@ -137,7 +137,7 @@ expand_test!(destructor_request, {
 expand_test!(destructor_cleanup, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let server_data = Arc::new(ServerData(AtomicBool::new(false)));
@@ -213,7 +213,7 @@ expand_test!(destructor_client_cleanup, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
     let client_data = Arc::new(ServerClientData(AtomicBool::new(false)));
-    let _client_id = server.insert_client(rx, client_data.clone()).unwrap();
+    let _client_id = server.handle().insert_client(rx, client_data.clone()).unwrap();
 
     std::mem::drop(tx);
 

--- a/wayland-backend/src/test/many_args.rs
+++ b/wayland-backend/src/test/many_args.rs
@@ -109,7 +109,7 @@ clientdata_impls!(client_sys);
 expand_test!(many_args, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let server_data = Arc::new(ServerData(AtomicBool::new(false)));

--- a/wayland-backend/src/test/mod.rs
+++ b/wayland-backend/src/test/mod.rs
@@ -102,12 +102,12 @@ struct DoNothingData;
 
 // Server Client Data
 
-impl<D> server_rs::ClientData<D> for DoNothingData {
+impl server_rs::ClientData for DoNothingData {
     fn initialized(&self, _: server_rs::ClientId) {}
     fn disconnected(&self, _: server_rs::ClientId, _: server_rs::DisconnectReason) {}
 }
 
-impl<D> server_sys::ClientData<D> for DoNothingData {
+impl server_sys::ClientData for DoNothingData {
     fn initialized(&self, _: server_sys::ClientId) {}
     fn disconnected(&self, _: server_sys::ClientId, _: server_rs::DisconnectReason) {}
 }

--- a/wayland-backend/src/test/object_args.rs
+++ b/wayland-backend/src/test/object_args.rs
@@ -113,7 +113,7 @@ impl_client_objectdata!(client_sys);
 expand_test!(create_objects, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let server_data = Arc::new(ServerData(AtomicBool::new(false)));
@@ -212,8 +212,8 @@ expand_test!(create_objects, {
 
 expand_test!(panic bad_interface, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::<()>::new().unwrap();
-    let _client_id = server.insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let server = server_backend::Backend::<()>::new().unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let server_data = Arc::new(ServerData(AtomicBool::new(false)));
@@ -272,8 +272,8 @@ expand_test!(panic bad_interface, {
 
 expand_test!(panic double_null, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::<()>::new().unwrap();
-    let _client_id = server.insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let server = server_backend::Backend::<()>::new().unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let server_data = Arc::new(ServerData(AtomicBool::new(false)));
@@ -329,8 +329,8 @@ expand_test!(panic double_null, {
 
 expand_test!(null_obj_followed_by_interface, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::<()>::new().unwrap();
-    let _client_id = server.insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let server = server_backend::Backend::<()>::new().unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let server_data = Arc::new(ServerData(AtomicBool::new(false)));

--- a/wayland-backend/src/test/protocol_error.rs
+++ b/wayland-backend/src/test/protocol_error.rs
@@ -41,7 +41,7 @@ impl server_sys::GlobalHandler<()> for ServerData<server_sys::ObjectId> {
 expand_test!(protocol_error, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let object_id = Arc::new(Mutex::new(None));
@@ -113,7 +113,7 @@ expand_test!(protocol_error, {
 expand_test!(client_wrong_id, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::<()>::new().unwrap();
-    let _client_id = server.insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
 
     let mut socket = BufferedSocket::new(unsafe { Socket::from_raw_fd(tx.into_raw_fd()) });
 
@@ -139,7 +139,7 @@ expand_test!(client_wrong_id, {
 expand_test!(client_wrong_opcode, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::<()>::new().unwrap();
-    let _client_id = server.insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
 
     let mut socket = BufferedSocket::new(unsafe { Socket::from_raw_fd(tx.into_raw_fd()) });
 
@@ -163,7 +163,7 @@ expand_test!(client_wrong_opcode, {
 expand_test!(client_wrong_sender, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::<()>::new().unwrap();
-    let _client_id = server.insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
 
     let mut socket = BufferedSocket::new(unsafe { Socket::from_raw_fd(tx.into_raw_fd()) });
 
@@ -245,7 +245,7 @@ impl<D> server_sys::ObjectData<D> for ProtocolErrorServerData {
 expand_test!(protocol_error_in_request_without_object_init, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     // Prepare a global

--- a/wayland-backend/src/test/server_created_objects.rs
+++ b/wayland-backend/src/test/server_created_objects.rs
@@ -111,7 +111,7 @@ impl_client_objectdata!(client_sys);
 expand_test!(server_created_object, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let client_data = Arc::new(ClientData(AtomicU32::new(0)));

--- a/wayland-backend/src/test/sync.rs
+++ b/wayland-backend/src/test/sync.rs
@@ -37,7 +37,7 @@ impl client_sys::ObjectData for SyncData {
 expand_test!(sync, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     // send the request
@@ -70,7 +70,7 @@ expand_test!(sync, {
 expand_test!(panic test_bad_placeholder, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     // send the request
@@ -103,7 +103,7 @@ expand_test!(panic test_bad_placeholder, {
 expand_test!(panic test_bad_signature, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     // send the request

--- a/wayland-backend/tests/rs_sys_impls.rs
+++ b/wayland-backend/tests/rs_sys_impls.rs
@@ -117,7 +117,7 @@ mod server {
 
         // ClientData
         assert_impl!(
-            dyn server::ClientData<()>: std::fmt::Debug, downcast_rs::DowncastSync
+            dyn server::ClientData: std::fmt::Debug, downcast_rs::DowncastSync
         );
 
         // ObjectId

--- a/wayland-server/src/client.rs
+++ b/wayland-server/src/client.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use wayland_backend::{
     protocol::ProtocolError,
-    server::{ClientId, DisconnectReason, InvalidId, ObjectData},
+    server::{ClientData, ClientId, DisconnectReason, InvalidId, ObjectData},
 };
 
 use crate::{dispatch::ResourceData, Dispatch, DisplayHandle, Resource};
@@ -10,12 +10,12 @@ use crate::{dispatch::ResourceData, Dispatch, DisplayHandle, Resource};
 #[derive(Debug)]
 pub struct Client {
     pub(crate) id: ClientId,
-    pub(crate) data: Arc<dyn std::any::Any + Send + Sync>,
+    pub(crate) data: Arc<dyn ClientData>,
 }
 
 impl Client {
     pub(crate) fn from_id(handle: &DisplayHandle, id: ClientId) -> Result<Client, InvalidId> {
-        let data = handle.handle.get_client_data_any(id.clone())?;
+        let data = handle.handle.get_client_data(id.clone())?;
         Ok(Client { id, data })
     }
 
@@ -23,7 +23,7 @@ impl Client {
         self.id.clone()
     }
 
-    pub fn get_data<Data: 'static>(&self) -> Option<&Data> {
+    pub fn get_data<Data: ClientData + 'static>(&self) -> Option<&Data> {
         (&*self.data).downcast_ref()
     }
 

--- a/wayland-server/src/display.rs
+++ b/wayland-server/src/display.rs
@@ -27,10 +27,10 @@ impl<D: 'static> Display<D> {
     pub fn insert_client(
         &mut self,
         stream: UnixStream,
-        data: Arc<dyn ClientData<D>>,
+        data: Arc<dyn ClientData>,
     ) -> std::io::Result<Client> {
         let id = self.backend.insert_client(stream, data.clone())?;
-        Ok(Client { id, data: data.into_any_arc() })
+        Ok(Client { id, data })
     }
 
     pub fn dispatch_clients(&mut self, data: &mut D) -> std::io::Result<usize> {

--- a/wayland-server/src/display.rs
+++ b/wayland-server/src/display.rs
@@ -23,16 +23,6 @@ impl<D: 'static> Display<D> {
     pub fn handle(&self) -> DisplayHandle {
         DisplayHandle { handle: self.backend.handle() }
     }
-
-    pub fn insert_client(
-        &mut self,
-        stream: UnixStream,
-        data: Arc<dyn ClientData>,
-    ) -> std::io::Result<Client> {
-        let id = self.backend.insert_client(stream, data.clone())?;
-        Ok(Client { id, data })
-    }
-
     pub fn dispatch_clients(&mut self, data: &mut D) -> std::io::Result<usize> {
         self.backend.dispatch_all_clients(data)
     }
@@ -75,6 +65,15 @@ impl DisplayHandle {
 
     pub fn object_info(&self, id: ObjectId) -> Result<ObjectInfo, InvalidId> {
         self.handle.object_info(id)
+    }
+
+    pub fn insert_client(
+        &mut self,
+        stream: UnixStream,
+        data: Arc<dyn ClientData>,
+    ) -> std::io::Result<Client> {
+        let id = self.handle.insert_client(stream, data.clone())?;
+        Ok(Client { id, data })
     }
 
     pub fn get_client(&self, id: ObjectId) -> Result<Client, InvalidId> {

--- a/wayland-server/src/global.rs
+++ b/wayland-server/src/global.rs
@@ -17,8 +17,8 @@ unsafe impl<I, D, U: Send + Sync> Sync for GlobalData<I, U, D> {}
 impl<I: Resource + 'static, U: Send + Sync + 'static, D: GlobalDispatch<I, U> + 'static>
     GlobalHandler<D> for GlobalData<I, U, D>
 {
-    fn can_view(&self, id: ClientId, data: &Arc<dyn ClientData<D>>, _: GlobalId) -> bool {
-        let client = Client { id, data: data.clone().into_any_arc() };
+    fn can_view(&self, id: ClientId, data: &Arc<dyn ClientData>, _: GlobalId) -> bool {
+        let client = Client { id, data: data.clone() };
         <D as GlobalDispatch<I, U>>::can_view(client, &self.data)
     }
 

--- a/wayland-tests/tests/client_connect_to_env.rs
+++ b/wayland-tests/tests/client_connect_to_env.rs
@@ -27,7 +27,11 @@ fn main() {
 
     // setup server-side
     let client_stream = listening.accept().unwrap().unwrap();
-    server.display.insert_client(client_stream, std::sync::Arc::new(DumbClientData)).unwrap();
+    server
+        .display
+        .handle()
+        .insert_client(client_stream, std::sync::Arc::new(DumbClientData))
+        .unwrap();
 
     roundtrip(&mut client, &mut server, &mut globals, &mut ServerData).unwrap();
     // check that we connected to the right compositor

--- a/wayland-tests/tests/client_connect_to_socket.rs
+++ b/wayland-tests/tests/client_connect_to_socket.rs
@@ -14,7 +14,7 @@ fn main() {
 
     let (s1, s2) = ::std::os::unix::net::UnixStream::pair().unwrap();
 
-    let my_client = server.display.insert_client(s1, Arc::new(DumbClientData)).unwrap();
+    let my_client = server.display.handle().insert_client(s1, Arc::new(DumbClientData)).unwrap();
 
     let fd2 = s2.into_raw_fd();
     ::std::env::set_var("WAYLAND_SOCKET", format!("{}", fd2));

--- a/wayland-tests/tests/destructors.rs
+++ b/wayland-tests/tests/destructors.rs
@@ -118,7 +118,7 @@ fn client_destructor_cleanup() {
 
 struct DestructorClientData(Arc<AtomicBool>);
 
-impl ways::backend::ClientData<ServerHandler> for DestructorClientData {
+impl ways::backend::ClientData for DestructorClientData {
     fn initialized(&self, _: wayland_backend::server::ClientId) {}
 
     fn disconnected(

--- a/wayland-tests/tests/helpers/mod.rs
+++ b/wayland-tests/tests/helpers/mod.rs
@@ -29,7 +29,7 @@ impl<D: 'static> TestServer<D> {
 
     pub fn add_client_with_data<CD>(
         &mut self,
-        data: Arc<dyn ways::backend::ClientData<D>>,
+        data: Arc<dyn ways::backend::ClientData>,
     ) -> (ways::Client, TestClient<CD>) {
         let (server_socket, client_socket) = UnixStream::pair().unwrap();
         let client = self.display.insert_client(server_socket, data).unwrap();
@@ -122,7 +122,7 @@ impl wayc::backend::ObjectData for SyncData {
 
 pub struct DumbClientData;
 
-impl<D> ways::backend::ClientData<D> for DumbClientData {
+impl ways::backend::ClientData for DumbClientData {
     fn initialized(&self, _: ways::backend::ClientId) {}
     fn disconnected(&self, _: ways::backend::ClientId, _: ways::backend::DisconnectReason) {}
 }

--- a/wayland-tests/tests/helpers/mod.rs
+++ b/wayland-tests/tests/helpers/mod.rs
@@ -32,7 +32,7 @@ impl<D: 'static> TestServer<D> {
         data: Arc<dyn ways::backend::ClientData>,
     ) -> (ways::Client, TestClient<CD>) {
         let (server_socket, client_socket) = UnixStream::pair().unwrap();
-        let client = self.display.insert_client(server_socket, data).unwrap();
+        let client = self.display.handle().insert_client(server_socket, data).unwrap();
         let test_client = TestClient::new(client_socket);
         (client, test_client)
     }

--- a/wayland-tests/tests/server_global_filter.rs
+++ b/wayland-tests/tests/server_global_filter.rs
@@ -185,7 +185,7 @@ struct MyClientData {
     privileged: bool,
 }
 
-impl ways::backend::ClientData<ServerHandler> for MyClientData {
+impl ways::backend::ClientData for MyClientData {
     fn initialized(&self, _: wayland_backend::server::ClientId) {}
     fn disconnected(
         &self,


### PR DESCRIPTION
- `ClientData` no longer has a type parameter: it was unused and we cannot easily pass the `&mut D` to its callbacks
- `insert_client` is now a method of `Handle`/`DisplayHandle` rather than the backend