### PR TITLE
server: Allow to receive `ClientId` from `Resource`

### DIFF
--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -3,7 +3,7 @@
 
 use wayland_backend::{
     protocol::{Interface, Message},
-    server::{InvalidId, ObjectId},
+    server::{ClientId, InvalidId, ObjectId},
 };
 
 mod client;
@@ -44,6 +44,10 @@ pub trait Resource: Sized {
     fn interface() -> &'static Interface;
 
     fn id(&self) -> ObjectId;
+
+    fn client_id(&self) -> Option<ClientId> {
+        self.handle().upgrade().and_then(|dh| dh.get_client(self.id()).ok())
+    }
 
     fn version(&self) -> u32;
 


### PR DESCRIPTION
Allows to re-implement things like smithay's [`keyboard::has_focus`](https://github.com/Smithay/smithay/blob/f061ced7aa3366df091ab2b8af03d1730fb967fa/src/wayland/seat/keyboard/mod.rs#L503-L516) on 0.30.