### PR TITLE
Link to wlr, plasma and misc protocols in the wayland_protocol docs

### DIFF
--- a/wayland-protocols/src/lib.rs
+++ b/wayland-protocols/src/lib.rs
@@ -34,6 +34,13 @@
 //! This category has now been deprecated and is no longer supposed to be used, however several protocols
 //! are still under that umbrella. We can expect them to be replaced by staging and stable protocols in the
 //! long term, but in the meantime you can enable them with the `unstable` cargo feature.
+//!
+//! ## Other protocols
+//! 
+//! Additionally, more protocol extensions are provided here:
+//! - <https://smithay.github.io/wayland-rs/wayland_protocols_wlr/index.html>
+//! - <https://smithay.github.io/wayland-rs/wayland_protocols_plasma/index.html>
+//! - <https://smithay.github.io/wayland-rs/wayland_protocols_misc/index.html>
 
 #![warn(missing_docs)]
 #![forbid(improper_ctypes, unsafe_op_in_unsafe_fn)]

--- a/wayland-protocols/src/lib.rs
+++ b/wayland-protocols/src/lib.rs
@@ -36,7 +36,7 @@
 //! long term, but in the meantime you can enable them with the `unstable` cargo feature.
 //!
 //! ## Other protocols
-//! 
+//!
 //! Additionally, more protocol extensions are provided here:
 //! - <https://smithay.github.io/wayland-rs/wayland_protocols_wlr/index.html>
 //! - <https://smithay.github.io/wayland-rs/wayland_protocols_plasma/index.html>

--- a/wayland-protocols/src/lib.rs
+++ b/wayland-protocols/src/lib.rs
@@ -38,9 +38,9 @@
 //! ## Other protocols
 //!
 //! Additionally, more protocol extensions are provided here:
-//! - <https://smithay.github.io/wayland-rs/wayland_protocols_wlr/index.html>
-//! - <https://smithay.github.io/wayland-rs/wayland_protocols_plasma/index.html>
-//! - <https://smithay.github.io/wayland-rs/wayland_protocols_misc/index.html>
+//! - [wayland-protocols-wlr](https://docs.rs/wayland-protocols-wlr)
+//! - [wayland-protocols-plasma](https://docs.rs/wayland-protocols-plasma)
+//! - [wayland-protocols-misc](https://docs.rs/wayland-protocols-misc)
 
 #![warn(missing_docs)]
 #![forbid(improper_ctypes, unsafe_op_in_unsafe_fn)]


### PR DESCRIPTION
Users of releases prior to 0.30.0 won't expect these protocols to be split into their own crates.
This will make it easier for them to find the protocols they are looking for.