### PR TITLE
backend: do not lock state on destruction

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### Bugfixes
+
+- backend/sys: the inner lock is no longer held when destructors are invoked
+
 ## 0.1.0-beta.5
 
 #### Additions

--- a/wayland-backend/src/sys/server_impl/mod.rs
+++ b/wayland-backend/src/sys/server_impl/mod.rs
@@ -322,7 +322,7 @@ impl<D> InnerBackend<D> {
         });
 
         for (object, client_id, object_id) in
-            self.state.lock().unwrap().pending_destructors.drain(..)
+            std::mem::take(&mut self.state.lock().unwrap().pending_destructors)
         {
             object.destroyed(data, client_id, object_id);
         }


### PR DESCRIPTION
locking the state when invoking the pending
destructors can lead to deadlocks if a
destructor tries to send an event