### PR TITLE
backend: fix state lock release

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### Bugfixes
+
+- backend/sys: the inner lock is no longer held when destructors are invoked
+
 ## 0.1.0-beta.6
 
 #### Additions

--- a/wayland-backend/src/sys/server_impl/mod.rs
+++ b/wayland-backend/src/sys/server_impl/mod.rs
@@ -345,9 +345,9 @@ impl<D> InnerBackend<D> {
             ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_event_loop_dispatch, evl_ptr, 0)
         });
 
-        for (object, client_id, object_id) in
-            std::mem::take(&mut self.state.lock().unwrap().pending_destructors)
-        {
+        let pending_destructors =
+            std::mem::take(&mut self.state.lock().unwrap().pending_destructors);
+        for (object, client_id, object_id) in pending_destructors {
             object.destroyed(data, client_id, object_id);
         }
 


### PR DESCRIPTION
the previous fix did not properly release the lock before calling the pending destructors