### PR TITLE
client/server: fuse DelegateDispatch into Dispatch

### DIFF
--- a/wayland-client/CHANGELOG.md
+++ b/wayland-client/CHANGELOG.md
@@ -7,6 +7,8 @@
 - `Connection::null_id()` has been removed, instead use `ObjectId::null()`.
 - `EventQueue::sync_roundtrip()` has been renamed to `EventQueue::roundtrip()`.
 - Module `globals` has been removed as the abstractions it provide are not deemed useful.
+- The trait `DelegateDispatch` as been removed, its functionnality being fused into a more generic
+  version of the `Dispatch` trait.
 
 ## 0.30.0-beta.6
 

--- a/wayland-client/examples/list_globals.rs
+++ b/wayland-client/examples/list_globals.rs
@@ -16,7 +16,7 @@ struct AppData;
 // the `Dispatch` documentation for more details about this.
 impl Dispatch<wl_registry::WlRegistry, ()> for AppData {
     fn event(
-        &mut self,
+        _: &mut Self,
         _: &wl_registry::WlRegistry,
         event: wl_registry::Event,
         _: &(),

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -70,7 +70,7 @@
 //! // the `Dispatch` documentation for more details about this.
 //! impl Dispatch<wl_registry::WlRegistry, ()> for AppData {
 //!     fn event(
-//!         &mut self,
+//!         _state: &mut Self,
 //!         _: &wl_registry::WlRegistry,
 //!         event: wl_registry::Event,
 //!         _: &(),
@@ -186,7 +186,7 @@ pub mod backend {
 pub use wayland_backend::protocol::WEnum;
 
 pub use conn::{ConnectError, Connection};
-pub use event_queue::{DelegateDispatch, Dispatch, EventQueue, QueueHandle, QueueProxyData};
+pub use event_queue::{Dispatch, EventQueue, QueueHandle, QueueProxyData};
 
 /// Generated protocol definitions
 ///

--- a/wayland-server/CHANGELOG.md
+++ b/wayland-server/CHANGELOG.md
@@ -5,6 +5,8 @@
 #### Breaking changes
 
 - `Connection::null_id()` has been removed, instead use `ObjectId::null()`.
+- The traits `DelegateDispatch` and `DelegeteGlobalDispatch` have been removed, their functionnality being
+  fused into more generic versions of the `Dispatch` and `GlobalDispatch` traits.
 
 ## 0.30.0-beta.4
 

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -13,9 +13,9 @@ mod global;
 pub mod socket;
 
 pub use client::Client;
-pub use dispatch::{DataInit, DelegateDispatch, Dispatch, New, ResourceData};
+pub use dispatch::{DataInit, Dispatch, New, ResourceData};
 pub use display::{Display, DisplayHandle};
-pub use global::{DelegateGlobalDispatch, GlobalDispatch};
+pub use global::GlobalDispatch;
 
 pub mod backend {
     pub use wayland_backend::protocol;

--- a/wayland-tests/tests/attach_to_surface.rs
+++ b/wayland-tests/tests/attach_to_surface.rs
@@ -127,7 +127,7 @@ struct ServerHandler {
 
 impl ways::Dispatch<ways::protocol::wl_compositor::WlCompositor, ()> for ServerHandler {
     fn request(
-        &mut self,
+        _: &mut Self,
         _: &ways::Client,
         _: &ways::protocol::wl_compositor::WlCompositor,
         request: ways::protocol::wl_compositor::Request,
@@ -145,7 +145,7 @@ impl ways::Dispatch<ways::protocol::wl_compositor::WlCompositor, ()> for ServerH
 
 impl ways::Dispatch<ways::protocol::wl_surface::WlSurface, ()> for ServerHandler {
     fn request(
-        &mut self,
+        state: &mut Self,
         _: &ways::Client,
         _: &ways::protocol::wl_surface::WlSurface,
         request: ways::protocol::wl_surface::Request,
@@ -156,8 +156,8 @@ impl ways::Dispatch<ways::protocol::wl_surface::WlSurface, ()> for ServerHandler
         if let ways::protocol::wl_surface::Request::Attach { buffer, x, y } = request {
             assert_eq!(x, 0);
             assert_eq!(y, 0);
-            assert!(self.buffer_found.is_none());
-            self.buffer_found = Some(buffer);
+            assert!(state.buffer_found.is_none());
+            state.buffer_found = Some(buffer);
         } else {
             panic!("Unexpected request!");
         }
@@ -166,7 +166,7 @@ impl ways::Dispatch<ways::protocol::wl_surface::WlSurface, ()> for ServerHandler
 
 impl ways::Dispatch<ways::protocol::wl_shm::WlShm, ()> for ServerHandler {
     fn request(
-        &mut self,
+        state: &mut Self,
         _: &ways::Client,
         _: &ways::protocol::wl_shm::WlShm,
         request: ways::protocol::wl_shm::Request,
@@ -176,8 +176,8 @@ impl ways::Dispatch<ways::protocol::wl_shm::WlShm, ()> for ServerHandler {
     ) {
         if let ways::protocol::wl_shm::Request::CreatePool { fd, size, id } = request {
             assert_eq!(size, 42);
-            assert!(self.buffer_found.is_none());
-            self.fd_found = Some((fd, None));
+            assert!(state.buffer_found.is_none());
+            state.fd_found = Some((fd, None));
             init.init(id, ());
         } else {
             panic!("Unexpected request!");
@@ -187,7 +187,7 @@ impl ways::Dispatch<ways::protocol::wl_shm::WlShm, ()> for ServerHandler {
 
 impl ways::Dispatch<ways::protocol::wl_shm_pool::WlShmPool, ()> for ServerHandler {
     fn request(
-        &mut self,
+        state: &mut Self,
         _: &ways::Client,
         _: &ways::protocol::wl_shm_pool::WlShmPool,
         request: ways::protocol::wl_shm_pool::Request,
@@ -196,7 +196,7 @@ impl ways::Dispatch<ways::protocol::wl_shm_pool::WlShmPool, ()> for ServerHandle
         init: &mut ways::DataInit<'_, Self>,
     ) {
         if let ways::protocol::wl_shm_pool::Request::CreateBuffer { id, .. } = request {
-            let fd_found = self.fd_found.as_mut().unwrap();
+            let fd_found = state.fd_found.as_mut().unwrap();
             assert!(fd_found.1.is_none());
             fd_found.1 = Some(init.init(id, ()));
         }

--- a/wayland-tests/tests/client_connect_to_env.rs
+++ b/wayland-tests/tests/client_connect_to_env.rs
@@ -22,7 +22,7 @@ fn main() {
 
     // connect the client
     let mut client = TestClient::new_from_env();
-    let mut globals = globals::GlobalList::new();
+    let mut client_data = ClientHandler::new();
     client.display.get_registry(&client.event_queue.handle(), ()).unwrap();
 
     // setup server-side
@@ -33,10 +33,10 @@ fn main() {
         .insert_client(client_stream, std::sync::Arc::new(DumbClientData))
         .unwrap();
 
-    roundtrip(&mut client, &mut server, &mut globals, &mut ServerData).unwrap();
+    roundtrip(&mut client, &mut server, &mut client_data, &mut ServerData).unwrap();
     // check that we connected to the right compositor
-    assert!(globals.list().len() == 1);
-    let output = &globals.list()[0];
+    assert!(client_data.globals.list().len() == 1);
+    let output = &client_data.globals.list()[0];
     assert_eq!(output.name, 1);
     assert_eq!(output.interface, "wl_output");
     assert_eq!(output.version, 1);
@@ -46,3 +46,23 @@ struct ServerData;
 
 server_ignore_impl!(ServerData => [ServerOutput]);
 server_ignore_global_impl!(ServerData => [ServerOutput]);
+
+struct ClientHandler {
+    globals: globals::GlobalList,
+}
+
+impl ClientHandler {
+    fn new() -> ClientHandler {
+        ClientHandler { globals: Default::default() }
+    }
+}
+
+impl AsMut<globals::GlobalList> for ClientHandler {
+    fn as_mut(&mut self) -> &mut globals::GlobalList {
+        &mut self.globals
+    }
+}
+
+wayc::delegate_dispatch!(ClientHandler:
+    [wayc::protocol::wl_registry::WlRegistry: ()] => globals::GlobalList
+);

--- a/wayland-tests/tests/client_connect_to_socket.rs
+++ b/wayland-tests/tests/client_connect_to_socket.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 mod helpers;
 
-use helpers::{globals, roundtrip, ways, DumbClientData, TestClient, TestServer};
+use helpers::{globals, roundtrip, wayc, ways, DumbClientData, TestClient, TestServer};
 
 use ways::protocol::wl_output::WlOutput as ServerOutput;
 
@@ -21,14 +21,14 @@ fn main() {
 
     let mut client = TestClient::new_from_env();
 
-    let mut globals = globals::GlobalList::new();
+    let mut client_data = ClientHandler::new();
 
     client.display.get_registry(&client.event_queue.handle(), ()).unwrap();
 
-    roundtrip(&mut client, &mut server, &mut globals, &mut ServerData).unwrap();
+    roundtrip(&mut client, &mut server, &mut client_data, &mut ServerData).unwrap();
     // check that we connected to the right compositor
-    assert!(globals.list().len() == 1);
-    let output = &globals.list()[0];
+    assert!(client_data.globals.list().len() == 1);
+    let output = &client_data.globals.list()[0];
     assert_eq!(output.name, 1);
     assert_eq!(output.interface, "wl_output");
     assert_eq!(output.version, 2);
@@ -43,10 +43,30 @@ fn main() {
         },
     );
 
-    assert!(roundtrip(&mut client, &mut server, &mut globals, &mut ServerData).is_err());
+    assert!(roundtrip(&mut client, &mut server, &mut client_data, &mut ServerData).is_err());
 }
 
 struct ServerData;
 
 server_ignore_impl!(ServerData => [ServerOutput]);
 server_ignore_global_impl!(ServerData => [ServerOutput]);
+
+struct ClientHandler {
+    globals: globals::GlobalList,
+}
+
+impl ClientHandler {
+    fn new() -> ClientHandler {
+        ClientHandler { globals: Default::default() }
+    }
+}
+
+impl AsMut<globals::GlobalList> for ClientHandler {
+    fn as_mut(&mut self) -> &mut globals::GlobalList {
+        &mut self.globals
+    }
+}
+
+wayc::delegate_dispatch!(ClientHandler:
+    [wayc::protocol::wl_registry::WlRegistry: ()] => globals::GlobalList
+);

--- a/wayland-tests/tests/client_proxies.rs
+++ b/wayland-tests/tests/client_proxies.rs
@@ -190,7 +190,7 @@ struct ServerHandler {
 
 impl ways::GlobalDispatch<ways::protocol::wl_output::WlOutput, ()> for ServerHandler {
     fn bind(
-        &mut self,
+        state: &mut Self,
         _: &ways::DisplayHandle,
         _: &ways::Client,
         output: ways::New<ways::protocol::wl_output::WlOutput>,
@@ -198,13 +198,13 @@ impl ways::GlobalDispatch<ways::protocol::wl_output::WlOutput, ()> for ServerHan
         data_init: &mut ways::DataInit<'_, Self>,
     ) {
         let output = data_init.init(output, ());
-        self.output = Some(output);
+        state.output = Some(output);
     }
 }
 
 impl ways::Dispatch<ways::protocol::wl_compositor::WlCompositor, ()> for ServerHandler {
     fn request(
-        &mut self,
+        state: &mut Self,
         _: &ways::Client,
         _: &ways::protocol::wl_compositor::WlCompositor,
         request: ways::protocol::wl_compositor::Request,
@@ -214,7 +214,7 @@ impl ways::Dispatch<ways::protocol::wl_compositor::WlCompositor, ()> for ServerH
     ) {
         if let ways::protocol::wl_compositor::Request::CreateSurface { id } = request {
             let surface = data_init.init(id, ());
-            let output = self.output.clone().unwrap();
+            let output = state.output.clone().unwrap();
             assert!(dhandle.object_info(output.id()).is_ok());
             surface.enter(&output);
         }
@@ -253,7 +253,7 @@ wayc::delegate_dispatch!(ClientHandler:
 
 impl wayc::Dispatch<wayc::protocol::wl_compositor::WlCompositor, usize> for ClientHandler {
     fn event(
-        &mut self,
+        _: &mut Self,
         _: &wayc::protocol::wl_compositor::WlCompositor,
         _: wayc::protocol::wl_compositor::Event,
         _: &usize,
@@ -265,7 +265,7 @@ impl wayc::Dispatch<wayc::protocol::wl_compositor::WlCompositor, usize> for Clie
 
 impl wayc::Dispatch<wayc::protocol::wl_surface::WlSurface, ()> for ClientHandler {
     fn event(
-        &mut self,
+        state: &mut Self,
         _: &wayc::protocol::wl_surface::WlSurface,
         event: wayc::protocol::wl_surface::Event,
         _: &(),
@@ -274,7 +274,7 @@ impl wayc::Dispatch<wayc::protocol::wl_surface::WlSurface, ()> for ClientHandler
     ) {
         if let wayc::protocol::wl_surface::Event::Enter { output } = event {
             assert!(conn.get_object_data(output.id()).is_err());
-            self.entered = true;
+            state.entered = true;
         } else {
             panic!("Unexpected event: {:?}", event);
         }

--- a/wayland-tests/tests/destructors.rs
+++ b/wayland-tests/tests/destructors.rs
@@ -138,20 +138,20 @@ struct ServerUData(Arc<AtomicBool>);
 
 impl ways::GlobalDispatch<ways::protocol::wl_output::WlOutput, ()> for ServerHandler {
     fn bind(
-        &mut self,
+        state: &mut Self,
         _: &ways::DisplayHandle,
         _: &ways::Client,
         output: ways::New<ways::protocol::wl_output::WlOutput>,
         _: &(),
         data_init: &mut ways::DataInit<'_, Self>,
     ) {
-        data_init.init(output, ServerUData(self.destructor_called.clone()));
+        data_init.init(output, ServerUData(state.destructor_called.clone()));
     }
 }
 
 impl ways::Dispatch<ways::protocol::wl_output::WlOutput, ServerUData> for ServerHandler {
     fn request(
-        &mut self,
+        _: &mut Self,
         _: &ways::Client,
         _: &ways::protocol::wl_output::WlOutput,
         _: ways::protocol::wl_output::Request,
@@ -162,7 +162,7 @@ impl ways::Dispatch<ways::protocol::wl_output::WlOutput, ServerUData> for Server
     }
 
     fn destroyed(
-        &mut self,
+        _: &mut Self,
         _client: wayland_backend::server::ClientId,
         _resource: wayland_backend::server::ObjectId,
         data: &ServerUData,

--- a/wayland-tests/tests/helpers/globals.rs
+++ b/wayland-tests/tests/helpers/globals.rs
@@ -2,9 +2,7 @@
 
 use std::ops::Range;
 
-use wayland_client::{
-    protocol::wl_registry, Connection, DelegateDispatch, Dispatch, Proxy, QueueHandle,
-};
+use wayland_client::{protocol::wl_registry, Connection, Dispatch, Proxy, QueueHandle};
 
 /// Description of an advertized global
 #[derive(Debug)]
@@ -28,7 +26,7 @@ pub struct GlobalList {
     globals: Vec<GlobalDescription>,
 }
 
-impl<D> DelegateDispatch<wl_registry::WlRegistry, (), D> for GlobalList
+impl<D> Dispatch<wl_registry::WlRegistry, (), D> for GlobalList
 where
     D: Dispatch<wl_registry::WlRegistry, ()> + AsMut<GlobalList>,
 {
@@ -58,22 +56,6 @@ where
 impl AsMut<GlobalList> for GlobalList {
     fn as_mut(&mut self) -> &mut GlobalList {
         self
-    }
-}
-
-impl Dispatch<wl_registry::WlRegistry, ()> for GlobalList {
-    #[inline]
-    fn event(
-        &mut self,
-        proxy: &wl_registry::WlRegistry,
-        event: wl_registry::Event,
-        data: &(),
-        conn: &Connection,
-        qhandle: &QueueHandle<Self>,
-    ) {
-        <Self as DelegateDispatch<wl_registry::WlRegistry, (), Self>>::event(
-            self, proxy, event, data, conn, qhandle,
-        )
     }
 }
 

--- a/wayland-tests/tests/helpers/mod.rs
+++ b/wayland-tests/tests/helpers/mod.rs
@@ -134,7 +134,7 @@ macro_rules! client_ignore_impl {
         $(
             impl $crate::helpers::wayc::Dispatch<$iface, ()> for $handler {
                 fn event(
-                    &mut self,
+                    _: &mut Self,
                     _: &$iface,
                     _: <$iface as $crate::helpers::wayc::Proxy>::Event,
                     _: &(),
@@ -152,7 +152,7 @@ macro_rules! server_ignore_impl {
         $(
             impl $crate::helpers::ways::Dispatch<$iface, ()> for $handler {
                 fn request(
-                    &mut self,
+                    _: &mut Self,
                     _: &$crate::helpers::ways::Client,
                     _: &$iface,
                     _: <$iface as $crate::helpers::ways::Resource>::Request,
@@ -172,7 +172,7 @@ macro_rules! server_ignore_global_impl {
             impl $crate::helpers::ways::GlobalDispatch<$iface, ()> for $handler {
 
                 fn bind(
-                    &mut self,
+                    _: &mut Self,
                     _: &$crate::helpers::ways::DisplayHandle,
                     _: &$crate::helpers::ways::Client,
                     new_id: $crate::helpers::ways::New<$iface>,

--- a/wayland-tests/tests/server_clients.rs
+++ b/wayland-tests/tests/server_clients.rs
@@ -147,7 +147,7 @@ server_ignore_impl!(ServerHandler => [
 
 impl ways::GlobalDispatch<ways::protocol::wl_output::WlOutput, ()> for ServerHandler {
     fn bind(
-        &mut self,
+        _: &mut Self,
         _: &ways::DisplayHandle,
         client: &ways::Client,
         resource: ways::New<ways::protocol::wl_output::WlOutput>,
@@ -161,7 +161,7 @@ impl ways::GlobalDispatch<ways::protocol::wl_output::WlOutput, ()> for ServerHan
 
 impl ways::GlobalDispatch<ways::protocol::wl_compositor::WlCompositor, ()> for ServerHandler {
     fn bind(
-        &mut self,
+        _: &mut Self,
         _: &ways::DisplayHandle,
         client: &ways::Client,
         resource: ways::New<ways::protocol::wl_compositor::WlCompositor>,

--- a/wayland-tests/tests/server_created_object.rs
+++ b/wayland-tests/tests/server_created_object.rs
@@ -370,7 +370,7 @@ client_ignore_impl!(ClientHandler => [
 
 impl wayc::Dispatch<wayc::protocol::wl_data_device::WlDataDevice, ()> for ClientHandler {
     fn event(
-        &mut self,
+        state: &mut Self,
         data_device: &wayc::protocol::wl_data_device::WlDataDevice,
         event: wayc::protocol::wl_data_device::Event,
         _: &(),
@@ -378,11 +378,11 @@ impl wayc::Dispatch<wayc::protocol::wl_data_device::WlDataDevice, ()> for Client
         _: &wayc::QueueHandle<Self>,
     ) {
         if conn.object_info(data_device.id()).is_err() {
-            self.received_dead = true;
+            state.received_dead = true;
         }
         match event {
             CDDEvt::DataOffer { id } => {
-                self.data_offer = Some(id);
+                state.data_offer = Some(id);
             }
             _ => unimplemented!(),
         }
@@ -395,7 +395,7 @@ impl wayc::Dispatch<wayc::protocol::wl_data_device::WlDataDevice, ()> for Client
 
 impl wayc::Dispatch<ClientDO, ()> for ClientHandler {
     fn event(
-        &mut self,
+        state: &mut Self,
         _: &ClientDO,
         event: wayc::protocol::wl_data_offer::Event,
         _: &(),
@@ -404,7 +404,7 @@ impl wayc::Dispatch<ClientDO, ()> for ClientHandler {
     ) {
         match event {
             wayc::protocol::wl_data_offer::Event::Offer { mime_type } => {
-                self.received = Some(mime_type);
+                state.received = Some(mime_type);
             }
             _ => unimplemented!(),
         }
@@ -428,7 +428,7 @@ server_ignore_global_impl!(ServerHandler => [
 
 impl ways::Dispatch<ServerDDMgr, ()> for ServerHandler {
     fn request(
-        &mut self,
+        state: &mut Self,
         _: &ways::Client,
         _: &ServerDDMgr,
         request: SDDMReq,
@@ -439,7 +439,7 @@ impl ways::Dispatch<ServerDDMgr, ()> for ServerHandler {
         match request {
             SDDMReq::GetDataDevice { id, .. } => {
                 let dd = data_init.init(id, ());
-                self.data_device = Some(dd);
+                state.data_device = Some(dd);
             }
             _ => {
                 unimplemented!()

--- a/wayland-tests/tests/server_global_filter.rs
+++ b/wayland-tests/tests/server_global_filter.rs
@@ -132,7 +132,7 @@ struct ServerHandler;
 
 impl ways::GlobalDispatch<wl_compositor::WlCompositor, ()> for ServerHandler {
     fn bind(
-        &mut self,
+        _: &mut Self,
         _: &ways::DisplayHandle,
         _: &ways::Client,
         resource: ways::New<wl_compositor::WlCompositor>,
@@ -149,7 +149,7 @@ impl ways::GlobalDispatch<wl_compositor::WlCompositor, ()> for ServerHandler {
 
 impl ways::GlobalDispatch<wl_shm::WlShm, ()> for ServerHandler {
     fn bind(
-        &mut self,
+        _: &mut Self,
         _: &ways::DisplayHandle,
         _: &ways::Client,
         resource: ways::New<wl_shm::WlShm>,
@@ -166,7 +166,7 @@ impl ways::GlobalDispatch<wl_shm::WlShm, ()> for ServerHandler {
 
 impl ways::GlobalDispatch<wl_output::WlOutput, ()> for ServerHandler {
     fn bind(
-        &mut self,
+        _: &mut Self,
         _: &ways::DisplayHandle,
         _: &ways::Client,
         resource: ways::New<wl_output::WlOutput>,

--- a/wayland-tests/tests/server_resources.rs
+++ b/wayland-tests/tests/server_resources.rs
@@ -227,15 +227,15 @@ struct ServerHandler {
 
 impl ways::GlobalDispatch<wl_output::WlOutput, ()> for ServerHandler {
     fn bind(
-        &mut self,
+        state: &mut Self,
         _: &ways::DisplayHandle,
         _: &ways::Client,
         output: ways::New<ways::protocol::wl_output::WlOutput>,
         _: &(),
         data_init: &mut ways::DataInit<'_, Self>,
     ) {
-        let output = data_init.init(output, UData(1000 + self.outputs.len()));
-        self.outputs.push(output);
+        let output = data_init.init(output, UData(1000 + state.outputs.len()));
+        state.outputs.push(output);
     }
 }
 
@@ -243,7 +243,7 @@ struct UData(usize);
 
 impl ways::Dispatch<wl_output::WlOutput, UData> for ServerHandler {
     fn request(
-        &mut self,
+        _: &mut Self,
         _: &ways::Client,
         _: &wl_output::WlOutput,
         _: wl_output::Request,

--- a/wayland-tests/tests/xdg_shell_ping.rs
+++ b/wayland-tests/tests/xdg_shell_ping.rs
@@ -43,7 +43,7 @@ struct ServerHandler {
 
 impl ways::GlobalDispatch<xs_server::xdg_wm_base::XdgWmBase, ()> for ServerHandler {
     fn bind(
-        &mut self,
+        _: &mut Self,
         _: &ways::DisplayHandle,
         _: &ways::Client,
         resource: ways::New<xs_server::xdg_wm_base::XdgWmBase>,
@@ -57,7 +57,7 @@ impl ways::GlobalDispatch<xs_server::xdg_wm_base::XdgWmBase, ()> for ServerHandl
 
 impl ways::Dispatch<xs_server::xdg_wm_base::XdgWmBase, ()> for ServerHandler {
     fn request(
-        &mut self,
+        state: &mut Self,
         _: &ways::Client,
         _: &xs_server::xdg_wm_base::XdgWmBase,
         request: xs_server::xdg_wm_base::Request,
@@ -68,7 +68,7 @@ impl ways::Dispatch<xs_server::xdg_wm_base::XdgWmBase, ()> for ServerHandler {
         match request {
             xs_server::xdg_wm_base::Request::Pong { serial } => {
                 assert_eq!(serial, 42);
-                self.received_pong = true;
+                state.received_pong = true;
             }
             _ => unreachable!(),
         }
@@ -97,7 +97,7 @@ wayc::delegate_dispatch!(ClientHandler:
 
 impl wayc::Dispatch<xs_client::xdg_wm_base::XdgWmBase, ()> for ClientHandler {
     fn event(
-        &mut self,
+        _: &mut Self,
         wm_base: &xs_client::xdg_wm_base::XdgWmBase,
         event: xs_client::xdg_wm_base::Event,
         _: &(),


### PR DESCRIPTION
This reworks the `Dispatch` traits on both client and server side to have a generic third parameter, essentially making them identical to the `DelegateDispatch` trait, which is now removed.

That third type parameter has a default value `=Self`, meaning that its usage for end user is almost unaffected. For provides of `DelegateDispatch` impls, the update is essentially a `s/DelegateDispatch/Dispatch/`.

**Pros:** Makes the whole thing simpler as there is only a single trait now.

**Cons:** `Dispatch` is now slightly less convenient to manually implement at the end of the chain, as you must write `state: &mut Self` instead of `&mut self` in the method prototype. Though that is largely mitigated by the fact that most implementations are done using macros.