### PR TITLE
backend/scanner: Fix handling of nullable strings

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - all backends: creating null `ObjectId` is now done through the `ObjectId::null()` method, and the
   `null_id()` methods on the backends are removed.
+- `Argument::Str` now contains an `Option`, which is correctly mapped to nullable strings. This fixes
+  segfaults that previously occurred dereferencing the null pointer in the system backend.
 
 #### Additions
 

--- a/wayland-backend/src/protocol.rs
+++ b/wayland-backend/src/protocol.rs
@@ -55,7 +55,7 @@ pub enum Argument<Id> {
     ///
     /// The value is boxed to reduce the stack size of Argument. The performance
     /// impact is negligible as `string` arguments are pretty rare in the protocol.
-    Str(Box<CString>),
+    Str(Option<Box<CString>>),
     /// Id of a wayland object
     Object(Id),
     /// Id of a newly created wayland object

--- a/wayland-backend/src/rs/client_impl/mod.rs
+++ b/wayland-backend/src/rs/client_impl/mod.rs
@@ -543,7 +543,7 @@ impl ProtocolState {
         match message.opcode {
             0 => {
                 // wl_display.error
-                if let [Argument::Object(obj), Argument::Uint(code), Argument::Str(ref message)] =
+                if let [Argument::Object(obj), Argument::Uint(code), Argument::Str(Some(ref message))] =
                     message.args[..]
                 {
                     let object = self.map.find(obj);

--- a/wayland-backend/src/rs/server_impl/client.rs
+++ b/wayland-backend/src/rs/server_impl/client.rs
@@ -276,7 +276,7 @@ impl<D> Client<D> {
                 [
                     Argument::Object(ObjectId { id: object_id.clone() }),
                     Argument::Uint(error_code),
-                    Argument::Str(Box::new(message)),
+                    Argument::Str(Some(Box::new(message))),
                 ],
             ),
             // wl_display.error is not a destructor, this argument will not be used
@@ -481,7 +481,7 @@ impl<D> Client<D> {
         match message.opcode {
             // wl_registry.bind(uint name, str interface, uint version, new id)
             0 => {
-                if let [Argument::Uint(name), Argument::Str(ref interface_name), Argument::Uint(version), Argument::NewId(new_id)] =
+                if let [Argument::Uint(name), Argument::Str(Some(ref interface_name)), Argument::Uint(version), Argument::NewId(new_id)] =
                     message.args[..]
                 {
                     if let Some((interface, global_id, handler)) =

--- a/wayland-backend/src/rs/server_impl/registry.rs
+++ b/wayland-backend/src/rs/server_impl/registry.rs
@@ -231,7 +231,7 @@ fn send_global_to<D>(
             0, // wl_registry.global
             [
                 Argument::Uint(global.id.id),
-                Argument::Str(Box::new(CString::new(global.interface.name).unwrap())),
+                Argument::Str(Some(Box::new(CString::new(global.interface.name).unwrap()))),
                 Argument::Uint(global.version),
             ],
         ),

--- a/wayland-backend/src/rs/socket.rs
+++ b/wayland-backend/src/rs/socket.rs
@@ -375,7 +375,7 @@ mod tests {
             args: smallvec![
                 Argument::Uint(3),
                 Argument::Fixed(-89),
-                Argument::Str(Box::new(CString::new(&b"I like trains!"[..]).unwrap())),
+                Argument::Str(Some(Box::new(CString::new(&b"I like trains!"[..]).unwrap()))),
                 Argument::Array(vec![1, 2, 3, 4, 5, 6, 7, 8, 9].into()),
                 Argument::Object(88),
                 Argument::NewId(56),
@@ -459,7 +459,7 @@ mod tests {
                 opcode: 0,
                 args: smallvec![
                     Argument::Int(42),
-                    Argument::Str(Box::new(CString::new(&b"I like trains"[..]).unwrap())),
+                    Argument::Str(Some(Box::new(CString::new(&b"I like trains"[..]).unwrap()))),
                 ],
             },
             Message {
@@ -520,7 +520,7 @@ mod tests {
             opcode: 0,
             args: smallvec![
                 Argument::Uint(18),
-                Argument::Str(Box::new(CString::new(&b"wl_shell"[..]).unwrap())),
+                Argument::Str(Some(Box::new(CString::new(&b"wl_shell"[..]).unwrap()))),
                 Argument::Uint(1),
             ],
         };

--- a/wayland-backend/src/test/destructors.rs
+++ b/wayland-backend/src/test/destructors.rs
@@ -101,9 +101,9 @@ expand_test!(destructor_request, {
                 0,
                 [
                     Argument::Uint(1),
-                    Argument::Str(Box::new(
+                    Argument::Str(Some(Box::new(
                         CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
-                    )),
+                    ))),
                     Argument::Uint(3),
                     Argument::NewId(client_backend::ObjectId::null()),
                 ],
@@ -162,9 +162,9 @@ expand_test!(destructor_cleanup, {
                 0,
                 [
                     Argument::Uint(1),
-                    Argument::Str(Box::new(
+                    Argument::Str(Some(Box::new(
                         CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
-                    )),
+                    ))),
                     Argument::Uint(3),
                     Argument::NewId(client_backend::ObjectId::null()),
                 ],

--- a/wayland-backend/src/test/many_args.rs
+++ b/wayland-backend/src/test/many_args.rs
@@ -16,7 +16,7 @@ macro_rules! serverdata_impls {
                 -> Option<Arc<dyn $server_backend::ObjectData<()>>>
             {
                 assert_eq!(msg.opcode, 0);
-                if let [Argument::Uint(u), Argument::Int(i), Argument::Fixed(f), Argument::Array(ref a), Argument::Str(ref s), Argument::Fd(fd)] =
+                if let [Argument::Uint(u), Argument::Int(i), Argument::Fixed(f), Argument::Array(ref a), Argument::Str(Some(ref s)), Argument::Fd(fd)] =
                     &msg.args[..]
                 {
                     assert_eq!(*u, 42);
@@ -57,7 +57,7 @@ macro_rules! serverdata_impls {
                             Argument::Int(-53),
                             Argument::Fixed(9823),
                             Argument::Array(Box::new(vec![10, 20, 30, 40, 50, 60, 70, 80, 90])),
-                            Argument::Str(Box::new(CString::new("I want cake".as_bytes()).unwrap())),
+                            Argument::Str(Some(Box::new(CString::new("I want cake".as_bytes()).unwrap()))),
                             Argument::Fd(1), // stdout
                         ],
                     ))
@@ -78,7 +78,7 @@ macro_rules! clientdata_impls {
         impl $client_backend::ObjectData for ClientData {
             fn event(self: Arc<Self>, _handle: & $client_backend::Backend, msg: Message<$client_backend::ObjectId>) -> Option<Arc<dyn $client_backend::ObjectData>> {
                 assert_eq!(msg.opcode, 0);
-                if let [Argument::Uint(u), Argument::Int(i), Argument::Fixed(f), Argument::Array(ref a), Argument::Str(ref s), Argument::Fd(fd)] =
+                if let [Argument::Uint(u), Argument::Int(i), Argument::Fixed(f), Argument::Array(ref a), Argument::Str(Some(ref s)), Argument::Fd(fd)] =
                     &msg.args[..]
                 {
                     assert_eq!(*u, 1337);
@@ -135,9 +135,9 @@ expand_test!(many_args, {
                 0,
                 [
                     Argument::Uint(1),
-                    Argument::Str(Box::new(
+                    Argument::Str(Some(Box::new(
                         CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
-                    )),
+                    ))),
                     Argument::Uint(1),
                     Argument::NewId(client_backend::ObjectId::null()),
                 ],
@@ -164,7 +164,9 @@ expand_test!(many_args, {
                     Argument::Int(-13),
                     Argument::Fixed(4589),
                     Argument::Array(Box::new(vec![1, 2, 3, 4, 5, 6, 7, 8, 9])),
-                    Argument::Str(Box::new(CString::new("I like trains".as_bytes()).unwrap())),
+                    Argument::Str(Some(Box::new(
+                        CString::new("I like trains".as_bytes()).unwrap()
+                    ))),
                     Argument::Fd(0), // stdin
                 ],
             ),

--- a/wayland-backend/src/test/object_args.rs
+++ b/wayland-backend/src/test/object_args.rs
@@ -148,9 +148,9 @@ expand_test!(create_objects, {
                 0,
                 [
                     Argument::Uint(1),
-                    Argument::Str(Box::new(
+                    Argument::Str(Some(Box::new(
                         CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
-                    )),
+                    ))),
                     Argument::Uint(3),
                     Argument::NewId(client_backend::ObjectId::null()),
                 ],
@@ -247,9 +247,9 @@ expand_test!(panic bad_interface, {
                 0,
                 [
                     Argument::Uint(1),
-                    Argument::Str(Box::new(
+                    Argument::Str(Some(Box::new(
                         CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
-                    )),
+                    ))),
                     Argument::Uint(3),
                     Argument::NewId(client_backend::ObjectId::null()),
                 ],
@@ -307,9 +307,9 @@ expand_test!(panic double_null, {
                 0,
                 [
                     Argument::Uint(1),
-                    Argument::Str(Box::new(
+                    Argument::Str(Some(Box::new(
                         CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
-                    )),
+                    ))),
                     Argument::Uint(3),
                     Argument::NewId(client_backend::ObjectId::null()),
                 ],
@@ -364,9 +364,9 @@ expand_test!(null_obj_followed_by_interface, {
                 0,
                 [
                     Argument::Uint(1),
-                    Argument::Str(Box::new(
+                    Argument::Str(Some(Box::new(
                         CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
-                    )),
+                    ))),
                     Argument::Uint(3),
                     Argument::NewId(client_backend::ObjectId::null()),
                 ],
@@ -433,9 +433,9 @@ expand_test!(new_id_null_and_non_null, {
                 0,
                 [
                     Argument::Uint(1),
-                    Argument::Str(Box::new(
+                    Argument::Str(Some(Box::new(
                         CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
-                    )),
+                    ))),
                     Argument::Uint(5),
                     Argument::NewId(client_backend::ObjectId::null()),
                 ],

--- a/wayland-backend/src/test/protocol_error.rs
+++ b/wayland-backend/src/test/protocol_error.rs
@@ -70,9 +70,9 @@ expand_test!(protocol_error, {
                 0,
                 [
                     Argument::Uint(1),
-                    Argument::Str(Box::new(
+                    Argument::Str(Some(Box::new(
                         CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
-                    )),
+                    ))),
                     Argument::Uint(3),
                     Argument::NewId(client_backend::ObjectId::null()),
                 ],
@@ -274,9 +274,9 @@ expand_test!(protocol_error_in_request_without_object_init, {
                 0,
                 [
                     Argument::Uint(1),
-                    Argument::Str(Box::new(
+                    Argument::Str(Some(Box::new(
                         CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
-                    )),
+                    ))),
                     Argument::Uint(3),
                     Argument::NewId(client_backend::ObjectId::null()),
                 ],

--- a/wayland-backend/src/test/server_created_objects.rs
+++ b/wayland-backend/src/test/server_created_objects.rs
@@ -136,9 +136,9 @@ expand_test!(server_created_object, {
                 0,
                 [
                     Argument::Uint(1),
-                    Argument::Str(Box::new(
+                    Argument::Str(Some(Box::new(
                         CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
-                    )),
+                    ))),
                     Argument::Uint(1),
                     Argument::NewId(client_backend::ObjectId::null()),
                 ],

--- a/wayland-scanner/tests/scanner_assets/test-client-code.rs
+++ b/wayland-scanner/tests/scanner_assets/test-client-code.rs
@@ -163,7 +163,10 @@ pub mod wl_display {
                             Event::Error {
                                 object_id: object_id.clone(),
                                 code: *code,
-                                message: String::from_utf8_lossy(message.as_bytes()).into_owned(),
+                                message: String::from_utf8_lossy(
+                                    message.as_ref().unwrap().as_bytes(),
+                                )
+                                .into_owned(),
                             },
                         ))
                     } else {
@@ -380,8 +383,10 @@ pub mod wl_registry {
                             me,
                             Event::Global {
                                 name: *name,
-                                interface: String::from_utf8_lossy(interface.as_bytes())
-                                    .into_owned(),
+                                interface: String::from_utf8_lossy(
+                                    interface.as_ref().unwrap().as_bytes(),
+                                )
+                                .into_owned(),
                                 version: *version,
                             },
                         ))
@@ -409,7 +414,7 @@ pub mod wl_registry {
                     let mut child_spec = None;
                     let args = smallvec::smallvec![
                         Argument::Uint(name),
-                        Argument::Str(Box::new(std::ffi::CString::new(id.0.name).unwrap())),
+                        Argument::Str(Some(Box::new(std::ffi::CString::new(id.0.name).unwrap()))),
                         Argument::Uint(id.1),
                         {
                             child_spec = Some((id.0, id.1));
@@ -750,8 +755,10 @@ pub mod test_global {
                                 signed_int: *signed_int,
                                 fixed_point: (*fixed_point as f64) / 256.,
                                 number_array: *number_array.clone(),
-                                some_text: String::from_utf8_lossy(some_text.as_bytes())
-                                    .into_owned(),
+                                some_text: String::from_utf8_lossy(
+                                    some_text.as_ref().unwrap().as_bytes(),
+                                )
+                                .into_owned(),
                                 file_descriptor: *file_descriptor,
                             },
                         ))
@@ -846,7 +853,7 @@ pub mod test_global {
                         Argument::Int(signed_int),
                         Argument::Fixed((fixed_point * 256.) as i32),
                         Argument::Array(Box::new(number_array)),
-                        Argument::Str(Box::new(std::ffi::CString::new(some_text).unwrap())),
+                        Argument::Str(Some(Box::new(std::ffi::CString::new(some_text).unwrap()))),
                         Argument::Fd(file_descriptor)
                     ];
                     Ok((Message { sender_id: self.id.clone(), opcode: 0u16, args }, child_spec))

--- a/wayland-scanner/tests/scanner_assets/test-server-code.rs
+++ b/wayland-scanner/tests/scanner_assets/test-server-code.rs
@@ -303,8 +303,10 @@ pub mod test_global {
                                 signed_int: *signed_int,
                                 fixed_point: (*fixed_point as f64) / 256.,
                                 number_array: *number_array.clone(),
-                                some_text: String::from_utf8_lossy(some_text.as_bytes())
-                                    .into_owned(),
+                                some_text: String::from_utf8_lossy(
+                                    some_text.as_ref().unwrap().as_bytes(),
+                                )
+                                .into_owned(),
                                 file_descriptor: *file_descriptor,
                             },
                         ))
@@ -535,7 +537,7 @@ pub mod test_global {
                         Argument::Int(signed_int),
                         Argument::Fixed((fixed_point * 256.) as i32),
                         Argument::Array(Box::new(number_array)),
-                        Argument::Str(Box::new(std::ffi::CString::new(some_text).unwrap())),
+                        Argument::Str(Some(Box::new(std::ffi::CString::new(some_text).unwrap()))),
                         Argument::Fd(file_descriptor)
                     ],
                 }),


### PR DESCRIPTION
A `NULL` value in a nullable string is distict from an empty non-`NULL` string. So this changes `Argument::Str` to contain an `Option`, updates `sys` to match how this is represented in libwayland (as a `NULL` pointer), updates `rs` to match the wire protocol for this, and fixes unit tests and `wayland-scanner` accordingly.

Fixes segfault when `NULL` was passed to `wl_data_offer::accept` with the `sys` backend.

I was going to make changes for nullable arrays too, but those appear to be broken in libwayland as well, so that can stay as is for now. (https://gitlab.freedesktop.org/wayland/wayland/-/issues/306)