### PR TITLE
scanner: change OPCODE constants to u16

### DIFF
--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -164,7 +164,8 @@ where
 /// ```
 #[macro_export]
 macro_rules! event_created_child {
-    ($selftype:ty, $iface:ty, [$($opcode:expr => ($child_iface:ty, $child_udata:expr)),* $(,)?]) => {
+    // Must match `pat` to allow paths `wl_data_device::EVT_DONE_OPCODE` and expressions `0` to both work.
+    ($selftype:ty, $iface:ty, [$($opcode:pat => ($child_iface:ty, $child_udata:expr)),* $(,)?]) => {
         fn event_created_child(
             opcode: u16,
             qhandle: &$crate::QueueHandle<$selftype>
@@ -180,7 +181,7 @@ macro_rules! event_created_child {
                 },
             }
         }
-    }
+    };
 }
 
 type QueueCallback<State> = fn(

--- a/wayland-scanner/src/common.rs
+++ b/wayland-scanner/src/common.rs
@@ -126,24 +126,24 @@ pub(crate) fn gen_msg_constants(requests: &[Message], events: &[Message]) -> Tok
         let since_cstname = format_ident!("REQ_{}_SINCE", msg.name.to_ascii_uppercase());
         let opcode_cstname = format_ident!("REQ_{}_OPCODE", msg.name.to_ascii_uppercase());
         let since = msg.since;
-        let opcode = opcode as u32;
+        let opcode = opcode as u16;
         quote! {
             /// The minimal object version supporting this request
             pub const #since_cstname: u32 = #since;
             /// The wire opcode for this request
-            pub const #opcode_cstname: u32 = #opcode;
+            pub const #opcode_cstname: u16 = #opcode;
         }
     });
     let evt_constants = events.iter().enumerate().map(|(opcode, msg)| {
         let since_cstname = format_ident!("EVT_{}_SINCE", msg.name.to_ascii_uppercase());
         let opcode_cstname = format_ident!("EVT_{}_OPCODE", msg.name.to_ascii_uppercase());
         let since = msg.since;
-        let opcode = opcode as u32;
+        let opcode = opcode as u16;
         quote! {
             /// The minimal object version supporting this event
             pub const #since_cstname: u32 = #since;
             /// The wire opcode for this event
-            pub const #opcode_cstname: u32 = #opcode;
+            pub const #opcode_cstname: u16 = #opcode;
         }
     });
 

--- a/wayland-scanner/src/server_gen.rs
+++ b/wayland-scanner/src/server_gen.rs
@@ -24,7 +24,7 @@ fn generate_objects_for(interface: &Interface) -> TokenStream {
     let iface_const_name = format_ident!("{}_INTERFACE", interface.name.to_ascii_uppercase());
 
     let enums = crate::common::generate_enums_for(interface);
-    let sinces = crate::common::gen_msg_constants(&interface.requests, &interface.events);
+    let msg_constants = crate::common::gen_msg_constants(&interface.requests, &interface.events);
 
     let requests = crate::common::gen_message_enum(
         &format_ident!("Request"),
@@ -65,7 +65,7 @@ fn generate_objects_for(interface: &Interface) -> TokenStream {
             };
 
             #enums
-            #sinces
+            #msg_constants
             #requests
             #events
 

--- a/wayland-scanner/tests/scanner_assets/test-client-code.rs
+++ b/wayland-scanner/tests/scanner_assets/test-client-code.rs
@@ -42,19 +42,19 @@ pub mod wl_display {
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_SYNC_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_SYNC_OPCODE: u32 = 0u32;
+    pub const REQ_SYNC_OPCODE: u16 = 0u16;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_GET_REGISTRY_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_GET_REGISTRY_OPCODE: u32 = 1u32;
+    pub const REQ_GET_REGISTRY_OPCODE: u16 = 1u16;
     #[doc = r" The minimal object version supporting this event"]
     pub const EVT_ERROR_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this event"]
-    pub const EVT_ERROR_OPCODE: u32 = 0u32;
+    pub const EVT_ERROR_OPCODE: u16 = 0u16;
     #[doc = r" The minimal object version supporting this event"]
     pub const EVT_DELETE_ID_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this event"]
-    pub const EVT_DELETE_ID_OPCODE: u32 = 1u32;
+    pub const EVT_DELETE_ID_OPCODE: u16 = 1u16;
     #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {
@@ -264,15 +264,15 @@ pub mod wl_registry {
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_BIND_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_BIND_OPCODE: u32 = 0u32;
+    pub const REQ_BIND_OPCODE: u16 = 0u16;
     #[doc = r" The minimal object version supporting this event"]
     pub const EVT_GLOBAL_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this event"]
-    pub const EVT_GLOBAL_OPCODE: u32 = 0u32;
+    pub const EVT_GLOBAL_OPCODE: u16 = 0u16;
     #[doc = r" The minimal object version supporting this event"]
     pub const EVT_GLOBAL_REMOVE_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this event"]
-    pub const EVT_GLOBAL_REMOVE_OPCODE: u32 = 1u32;
+    pub const EVT_GLOBAL_REMOVE_OPCODE: u16 = 1u16;
     #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {
@@ -459,7 +459,7 @@ pub mod wl_callback {
     #[doc = r" The minimal object version supporting this event"]
     pub const EVT_DONE_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this event"]
-    pub const EVT_DONE_OPCODE: u32 = 0u32;
+    pub const EVT_DONE_OPCODE: u16 = 0u16;
     #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {}
@@ -577,43 +577,43 @@ pub mod test_global {
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_MANY_ARGS_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_MANY_ARGS_OPCODE: u32 = 0u32;
+    pub const REQ_MANY_ARGS_OPCODE: u16 = 0u16;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_GET_SECONDARY_SINCE: u32 = 2u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_GET_SECONDARY_OPCODE: u32 = 1u32;
+    pub const REQ_GET_SECONDARY_OPCODE: u16 = 1u16;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_GET_TERTIARY_SINCE: u32 = 3u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_GET_TERTIARY_OPCODE: u32 = 2u32;
+    pub const REQ_GET_TERTIARY_OPCODE: u16 = 2u16;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_LINK_SINCE: u32 = 3u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_LINK_OPCODE: u32 = 3u32;
+    pub const REQ_LINK_OPCODE: u16 = 3u16;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 4u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_DESTROY_OPCODE: u32 = 4u32;
+    pub const REQ_DESTROY_OPCODE: u16 = 4u16;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_REVERSE_LINK_SINCE: u32 = 5u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_REVERSE_LINK_OPCODE: u32 = 5u32;
+    pub const REQ_REVERSE_LINK_OPCODE: u16 = 5u16;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_NEWID_AND_ALLOW_NULL_SINCE: u32 = 5u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_NEWID_AND_ALLOW_NULL_OPCODE: u32 = 6u32;
+    pub const REQ_NEWID_AND_ALLOW_NULL_OPCODE: u16 = 6u16;
     #[doc = r" The minimal object version supporting this event"]
     pub const EVT_MANY_ARGS_EVT_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this event"]
-    pub const EVT_MANY_ARGS_EVT_OPCODE: u32 = 0u32;
+    pub const EVT_MANY_ARGS_EVT_OPCODE: u16 = 0u16;
     #[doc = r" The minimal object version supporting this event"]
     pub const EVT_ACK_SECONDARY_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this event"]
-    pub const EVT_ACK_SECONDARY_OPCODE: u32 = 1u32;
+    pub const EVT_ACK_SECONDARY_OPCODE: u16 = 1u16;
     #[doc = r" The minimal object version supporting this event"]
     pub const EVT_CYCLE_QUAD_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this event"]
-    pub const EVT_CYCLE_QUAD_OPCODE: u32 = 2u32;
+    pub const EVT_CYCLE_QUAD_OPCODE: u16 = 2u16;
     #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {
@@ -1072,7 +1072,7 @@ pub mod secondary {
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 2u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_DESTROY_OPCODE: u32 = 0u32;
+    pub const REQ_DESTROY_OPCODE: u16 = 0u16;
     #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {
@@ -1196,7 +1196,7 @@ pub mod tertiary {
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 3u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_DESTROY_OPCODE: u32 = 0u32;
+    pub const REQ_DESTROY_OPCODE: u16 = 0u16;
     #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {
@@ -1320,7 +1320,7 @@ pub mod quad {
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 3u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_DESTROY_OPCODE: u32 = 0u32;
+    pub const REQ_DESTROY_OPCODE: u16 = 0u16;
     #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {

--- a/wayland-scanner/tests/scanner_assets/test-server-code.rs
+++ b/wayland-scanner/tests/scanner_assets/test-server-code.rs
@@ -11,7 +11,7 @@ pub mod wl_callback {
     #[doc = r" The minimal object version supporting this event"]
     pub const EVT_DONE_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this event"]
-    pub const EVT_DONE_OPCODE: u32 = 0u32;
+    pub const EVT_DONE_OPCODE: u16 = 0u16;
     #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {}
@@ -129,43 +129,43 @@ pub mod test_global {
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_MANY_ARGS_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_MANY_ARGS_OPCODE: u32 = 0u32;
+    pub const REQ_MANY_ARGS_OPCODE: u16 = 0u16;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_GET_SECONDARY_SINCE: u32 = 2u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_GET_SECONDARY_OPCODE: u32 = 1u32;
+    pub const REQ_GET_SECONDARY_OPCODE: u16 = 1u16;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_GET_TERTIARY_SINCE: u32 = 3u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_GET_TERTIARY_OPCODE: u32 = 2u32;
+    pub const REQ_GET_TERTIARY_OPCODE: u16 = 2u16;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_LINK_SINCE: u32 = 3u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_LINK_OPCODE: u32 = 3u32;
+    pub const REQ_LINK_OPCODE: u16 = 3u16;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 4u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_DESTROY_OPCODE: u32 = 4u32;
+    pub const REQ_DESTROY_OPCODE: u16 = 4u16;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_REVERSE_LINK_SINCE: u32 = 5u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_REVERSE_LINK_OPCODE: u32 = 5u32;
+    pub const REQ_REVERSE_LINK_OPCODE: u16 = 5u16;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_NEWID_AND_ALLOW_NULL_SINCE: u32 = 5u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_NEWID_AND_ALLOW_NULL_OPCODE: u32 = 6u32;
+    pub const REQ_NEWID_AND_ALLOW_NULL_OPCODE: u16 = 6u16;
     #[doc = r" The minimal object version supporting this event"]
     pub const EVT_MANY_ARGS_EVT_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this event"]
-    pub const EVT_MANY_ARGS_EVT_OPCODE: u32 = 0u32;
+    pub const EVT_MANY_ARGS_EVT_OPCODE: u16 = 0u16;
     #[doc = r" The minimal object version supporting this event"]
     pub const EVT_ACK_SECONDARY_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this event"]
-    pub const EVT_ACK_SECONDARY_OPCODE: u32 = 1u32;
+    pub const EVT_ACK_SECONDARY_OPCODE: u16 = 1u16;
     #[doc = r" The minimal object version supporting this event"]
     pub const EVT_CYCLE_QUAD_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this event"]
-    pub const EVT_CYCLE_QUAD_OPCODE: u32 = 2u32;
+    pub const EVT_CYCLE_QUAD_OPCODE: u16 = 2u16;
     #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {
@@ -621,7 +621,7 @@ pub mod secondary {
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 2u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_DESTROY_OPCODE: u32 = 0u32;
+    pub const REQ_DESTROY_OPCODE: u16 = 0u16;
     #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {
@@ -731,7 +731,7 @@ pub mod tertiary {
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 3u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_DESTROY_OPCODE: u32 = 0u32;
+    pub const REQ_DESTROY_OPCODE: u16 = 0u16;
     #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {
@@ -841,7 +841,7 @@ pub mod quad {
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 3u32;
     #[doc = r" The wire opcode for this request"]
-    pub const REQ_DESTROY_OPCODE: u32 = 0u32;
+    pub const REQ_DESTROY_OPCODE: u16 = 0u16;
     #[derive(Debug)]
     #[non_exhaustive]
     pub enum Request {

--- a/wayland-tests/tests/server_created_object.rs
+++ b/wayland-tests/tests/server_created_object.rs
@@ -389,7 +389,7 @@ impl wayc::Dispatch<wayc::protocol::wl_data_device::WlDataDevice, ()> for Client
     }
 
     wayc::event_created_child!(ClientHandler, wayc::protocol::wl_data_device::WlDataDevice, [
-        0 => (ClientDO, ())
+        wayc::protocol::wl_data_device::EVT_DATA_OFFER_OPCODE => (ClientDO, ())
     ]);
 }
 


### PR DESCRIPTION
This also fixes the event_created_child macro to match a `pat` to allow paths and expressions to work.