### PR TITLE
Improve user data support in ObjectData

### DIFF
--- a/wayland-backend/src/client_api.rs
+++ b/wayland-backend/src/client_api.rs
@@ -1,4 +1,5 @@
 use std::{
+    any::Any,
     fmt,
     os::unix::{io::RawFd, net::UnixStream},
     sync::Arc,
@@ -37,6 +38,15 @@ pub trait ObjectData: downcast_rs::DowncastSync {
     #[cfg_attr(coverage, no_coverage)]
     fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ObjectData").finish_non_exhaustive()
+    }
+
+    /// Helper for accessing user data
+    ///
+    /// This function is used to back the `Proxy::data` function in `wayland_client`.  By default,
+    /// it returns `self` (via Downcast), but this may be overridden to allow downcasting user data
+    /// without needing to have access to the full type.
+    fn data_as_any(&self) -> &dyn Any {
+        self.as_any()
     }
 }
 

--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::convert::Infallible;
 use std::pin::Pin;
 use std::sync::{
@@ -602,16 +603,8 @@ fn queue_callback<
     qhandle: &QueueHandle<State>,
 ) -> Result<(), DispatchError> {
     let (proxy, event) = I::parse_event(handle, msg)?;
-    let proxy_data =
-        (&*odata).downcast_ref::<QueueProxyData<I, U>>().expect("Wrong user_data value for object");
-    <State as Dispatch<I, U, State>>::event(
-        data,
-        &proxy,
-        event,
-        &proxy_data.udata,
-        handle,
-        qhandle,
-    );
+    let udata = odata.data_as_any().downcast_ref().expect("Wrong user_data value for object");
+    <State as Dispatch<I, U, State>>::event(data, &proxy, event, udata, handle, qhandle);
     Ok(())
 }
 
@@ -633,6 +626,10 @@ impl<I: Proxy + 'static, U: Send + Sync + 'static> ObjectData for QueueProxyData
     }
 
     fn destroyed(&self, _: ObjectId) {}
+
+    fn data_as_any(&self) -> &dyn Any {
+        &self.udata
+    }
 }
 
 impl<I: Proxy, U: std::fmt::Debug> std::fmt::Debug for QueueProxyData<I, U> {

--- a/wayland-scanner/src/client_gen.rs
+++ b/wayland-scanner/src/client_gen.rs
@@ -102,7 +102,7 @@ fn generate_objects_for(interface: &Interface) -> TokenStream {
 
                 #[inline]
                 fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
-                    self.data.as_ref().and_then(|arc| (&**arc).downcast_ref::<QueueProxyData<Self, U>>()).map(|data| &data.udata)
+                    self.data.as_ref().and_then(|arc| arc.data_as_any().downcast_ref::<U>())
                 }
 
                 fn object_data(&self) -> Option<&Arc<dyn ObjectData>> {

--- a/wayland-scanner/tests/scanner_assets/test-client-code.rs
+++ b/wayland-scanner/tests/scanner_assets/test-client-code.rs
@@ -112,10 +112,7 @@ pub mod wl_display {
         }
         #[inline]
         fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
-            self.data
-                .as_ref()
-                .and_then(|arc| (&**arc).downcast_ref::<QueueProxyData<Self, U>>())
-                .map(|data| &data.udata)
+            self.data.as_ref().and_then(|arc| arc.data_as_any().downcast_ref::<U>())
         }
         fn object_data(&self) -> Option<&Arc<dyn ObjectData>> {
             self.data.as_ref()
@@ -333,10 +330,7 @@ pub mod wl_registry {
         }
         #[inline]
         fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
-            self.data
-                .as_ref()
-                .and_then(|arc| (&**arc).downcast_ref::<QueueProxyData<Self, U>>())
-                .map(|data| &data.udata)
+            self.data.as_ref().and_then(|arc| arc.data_as_any().downcast_ref::<U>())
         }
         fn object_data(&self) -> Option<&Arc<dyn ObjectData>> {
             self.data.as_ref()
@@ -503,10 +497,7 @@ pub mod wl_callback {
         }
         #[inline]
         fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
-            self.data
-                .as_ref()
-                .and_then(|arc| (&**arc).downcast_ref::<QueueProxyData<Self, U>>())
-                .map(|data| &data.udata)
+            self.data.as_ref().and_then(|arc| arc.data_as_any().downcast_ref::<U>())
         }
         fn object_data(&self) -> Option<&Arc<dyn ObjectData>> {
             self.data.as_ref()
@@ -702,10 +693,7 @@ pub mod test_global {
         }
         #[inline]
         fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
-            self.data
-                .as_ref()
-                .and_then(|arc| (&**arc).downcast_ref::<QueueProxyData<Self, U>>())
-                .map(|data| &data.udata)
+            self.data.as_ref().and_then(|arc| arc.data_as_any().downcast_ref::<U>())
         }
         fn object_data(&self) -> Option<&Arc<dyn ObjectData>> {
             self.data.as_ref()
@@ -1113,10 +1101,7 @@ pub mod secondary {
         }
         #[inline]
         fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
-            self.data
-                .as_ref()
-                .and_then(|arc| (&**arc).downcast_ref::<QueueProxyData<Self, U>>())
-                .map(|data| &data.udata)
+            self.data.as_ref().and_then(|arc| arc.data_as_any().downcast_ref::<U>())
         }
         fn object_data(&self) -> Option<&Arc<dyn ObjectData>> {
             self.data.as_ref()
@@ -1237,10 +1222,7 @@ pub mod tertiary {
         }
         #[inline]
         fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
-            self.data
-                .as_ref()
-                .and_then(|arc| (&**arc).downcast_ref::<QueueProxyData<Self, U>>())
-                .map(|data| &data.udata)
+            self.data.as_ref().and_then(|arc| arc.data_as_any().downcast_ref::<U>())
         }
         fn object_data(&self) -> Option<&Arc<dyn ObjectData>> {
             self.data.as_ref()
@@ -1361,10 +1343,7 @@ pub mod quad {
         }
         #[inline]
         fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
-            self.data
-                .as_ref()
-                .and_then(|arc| (&**arc).downcast_ref::<QueueProxyData<Self, U>>())
-                .map(|data| &data.udata)
+            self.data.as_ref().and_then(|arc| arc.data_as_any().downcast_ref::<U>())
         }
         fn object_data(&self) -> Option<&Arc<dyn ObjectData>> {
             self.data.as_ref()


### PR DESCRIPTION
This allows using `Proxy::data` on custom `ObjectData` implementations, and simplifies the implementation of QueueProxyData.