### PR TITLE
Add feature flag unstable protocols

### DIFF
--- a/wayland-protocols-misc/Cargo.toml
+++ b/wayland-protocols-misc/Cargo.toml
@@ -24,6 +24,7 @@ bitflags = "1.0"
 [features]
 client = ["wayland-client", "wayland-protocols/client"]
 server = ["wayland-server", "wayland-protocols/server"]
+unstable_protocols = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wayland-protocols-misc/Cargo.toml
+++ b/wayland-protocols-misc/Cargo.toml
@@ -24,7 +24,6 @@ bitflags = "1.0"
 [features]
 client = ["wayland-client", "wayland-protocols/client"]
 server = ["wayland-server", "wayland-protocols/server"]
-unstable_protocols = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wayland-protocols-misc/src/lib.rs
+++ b/wayland-protocols-misc/src/lib.rs
@@ -89,7 +89,6 @@ pub mod zwp_input_method_v2 {
     wayland_protocol!("./protocols/input-method-unstable-v2.xml", [wayland_protocols::wp::text_input::zv3]);
 }
 
-#[cfg(feature = "unstable_protocols")]
 pub mod zwp_virtual_keyboard_v1 {
     //! Virtual keyboard v1 unstable
     //!


### PR DESCRIPTION
I noticed there is no feature flag to enable use of zwp_virtual_keyboard_v1