### PR TITLE
Simplify ClientData implementation

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -18,6 +18,7 @@
 - client: introduce `Backend::dispatch_inner_queue()` meant for ensuring a system backend in guest mode can
   still process events event it does not control reading the socket.
 - introduce the `log` cargo feature to control logging behavior
+- A dummy implementation of ClientData is now provided through `()` and all trait methods are optional
 
 ## 0.1.0-beta.7
 

--- a/wayland-backend/src/server_api.rs
+++ b/wayland-backend/src/server_api.rs
@@ -100,9 +100,9 @@ downcast_rs::impl_downcast!(sync GlobalHandler<D>);
 /// A trait representing your data associated to a client
 pub trait ClientData: downcast_rs::DowncastSync {
     /// Notification that the client was initialized
-    fn initialized(&self, client_id: ClientId) {}
+    fn initialized(&self, _client_id: ClientId) {}
     /// Notification that the client is disconnected
-    fn disconnected(&self, client_id: ClientId, reason: DisconnectReason) {}
+    fn disconnected(&self, _client_id: ClientId, _reason: DisconnectReason) {}
     /// Helper for forwarding a Debug implementation of your `ClientData` type
     ///
     /// By default will just print `GlobalHandler { ... }`

--- a/wayland-backend/src/server_api.rs
+++ b/wayland-backend/src/server_api.rs
@@ -100,9 +100,9 @@ downcast_rs::impl_downcast!(sync GlobalHandler<D>);
 /// A trait representing your data associated to a client
 pub trait ClientData: downcast_rs::DowncastSync {
     /// Notification that the client was initialized
-    fn initialized(&self, client_id: ClientId);
+    fn initialized(&self, client_id: ClientId) {}
     /// Notification that the client is disconnected
-    fn disconnected(&self, client_id: ClientId, reason: DisconnectReason);
+    fn disconnected(&self, client_id: ClientId, reason: DisconnectReason) {}
     /// Helper for forwarding a Debug implementation of your `ClientData` type
     ///
     /// By default will just print `GlobalHandler { ... }`
@@ -118,6 +118,8 @@ impl std::fmt::Debug for dyn ClientData {
         self.debug(f)
     }
 }
+
+impl ClientData for () {}
 
 downcast_rs::impl_downcast!(sync ClientData);
 

--- a/wayland-backend/src/test/destructors.rs
+++ b/wayland-backend/src/test/destructors.rs
@@ -76,7 +76,7 @@ impl_client_objectdata!(client_sys);
 expand_test!(destructor_request, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let server_data = Arc::new(ServerData(AtomicBool::new(false)));
@@ -137,7 +137,7 @@ expand_test!(destructor_request, {
 expand_test!(destructor_cleanup, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let server_data = Arc::new(ServerData(AtomicBool::new(false)));

--- a/wayland-backend/src/test/many_args.rs
+++ b/wayland-backend/src/test/many_args.rs
@@ -109,7 +109,7 @@ clientdata_impls!(client_sys);
 expand_test!(many_args, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let server_data = Arc::new(ServerData(AtomicBool::new(false)));

--- a/wayland-backend/src/test/mod.rs
+++ b/wayland-backend/src/test/mod.rs
@@ -100,18 +100,6 @@ fn send_sync_server_sys() {
  */
 struct DoNothingData;
 
-// Server Client Data
-
-impl server_rs::ClientData for DoNothingData {
-    fn initialized(&self, _: server_rs::ClientId) {}
-    fn disconnected(&self, _: server_rs::ClientId, _: server_rs::DisconnectReason) {}
-}
-
-impl server_sys::ClientData for DoNothingData {
-    fn initialized(&self, _: server_sys::ClientId) {}
-    fn disconnected(&self, _: server_sys::ClientId, _: server_rs::DisconnectReason) {}
-}
-
 // Server Global Handler
 
 impl<D> server_rs::GlobalHandler<D> for DoNothingData {

--- a/wayland-backend/src/test/object_args.rs
+++ b/wayland-backend/src/test/object_args.rs
@@ -122,7 +122,7 @@ impl_client_objectdata!(client_sys);
 expand_test!(create_objects, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let server_data = Arc::new(ServerData(AtomicBool::new(false)));
@@ -222,7 +222,7 @@ expand_test!(create_objects, {
 expand_test!(panic bad_interface, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let server = server_backend::Backend::<()>::new().unwrap();
-    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let server_data = Arc::new(ServerData(AtomicBool::new(false)));
@@ -282,7 +282,7 @@ expand_test!(panic bad_interface, {
 expand_test!(panic double_null, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let server = server_backend::Backend::<()>::new().unwrap();
-    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let server_data = Arc::new(ServerData(AtomicBool::new(false)));
@@ -339,7 +339,7 @@ expand_test!(panic double_null, {
 expand_test!(null_obj_followed_by_interface, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let server = server_backend::Backend::<()>::new().unwrap();
-    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let server_data = Arc::new(ServerData(AtomicBool::new(false)));
@@ -408,7 +408,7 @@ expand_test!(null_obj_followed_by_interface, {
 expand_test!(new_id_null_and_non_null, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::<()>::new().unwrap();
-    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let server_data = Arc::new(ServerData(AtomicBool::new(false)));

--- a/wayland-backend/src/test/protocol_error.rs
+++ b/wayland-backend/src/test/protocol_error.rs
@@ -41,7 +41,7 @@ impl server_sys::GlobalHandler<()> for ServerData<server_sys::ObjectId> {
 expand_test!(protocol_error, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let object_id = Arc::new(Mutex::new(None));
@@ -113,7 +113,7 @@ expand_test!(protocol_error, {
 expand_test!(client_wrong_id, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::<()>::new().unwrap();
-    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
 
     let mut socket = BufferedSocket::new(unsafe { Socket::from_raw_fd(tx.into_raw_fd()) });
 
@@ -139,7 +139,7 @@ expand_test!(client_wrong_id, {
 expand_test!(client_wrong_opcode, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::<()>::new().unwrap();
-    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
 
     let mut socket = BufferedSocket::new(unsafe { Socket::from_raw_fd(tx.into_raw_fd()) });
 
@@ -163,7 +163,7 @@ expand_test!(client_wrong_opcode, {
 expand_test!(client_wrong_sender, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::<()>::new().unwrap();
-    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
 
     let mut socket = BufferedSocket::new(unsafe { Socket::from_raw_fd(tx.into_raw_fd()) });
 
@@ -245,7 +245,7 @@ impl<D> server_sys::ObjectData<D> for ProtocolErrorServerData {
 expand_test!(protocol_error_in_request_without_object_init, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     // Prepare a global

--- a/wayland-backend/src/test/server_created_objects.rs
+++ b/wayland-backend/src/test/server_created_objects.rs
@@ -111,7 +111,7 @@ impl_client_objectdata!(client_sys);
 expand_test!(server_created_object, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     let client_data = Arc::new(ClientData(AtomicU32::new(0)));

--- a/wayland-backend/src/test/sync.rs
+++ b/wayland-backend/src/test/sync.rs
@@ -37,7 +37,7 @@ impl client_sys::ObjectData for SyncData {
 expand_test!(sync, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     // send the request
@@ -70,7 +70,7 @@ expand_test!(sync, {
 expand_test!(panic test_bad_placeholder, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     // send the request
@@ -103,7 +103,7 @@ expand_test!(panic test_bad_placeholder, {
 expand_test!(panic test_bad_signature, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
     let mut server = server_backend::Backend::new().unwrap();
-    let _client_id = server.handle().insert_client(rx, Arc::new(DoNothingData)).unwrap();
+    let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
     // send the request


### PR DESCRIPTION
For smithay compositors it is completely optional to implement the
ClientData trait, however due to the required functions on the trait it
is still quite verbose to just implement some dummy struct to use for
it.

Both Smallvill and Anvil have this implemented on a NOOP struct, which
indicates that the majority of compositors will likely not interested in
implementing this themselves.

To make things a little easier for people not interested in implementing
this, a default implementation for `()` is added in this patch. This
allows just passing `Arc::new(())` to `insert_client`.

For people interested in actually using this trait, all functions have
been mode optional. That way it's going to be much cleaner when
compositors just want to provide a partial implementation.