### PR TITLE
Add Clone+Debug bounds to Proxy and Resource

### DIFF
--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -219,7 +219,7 @@ pub mod protocol {
 }
 
 /// Trait representing a Wayland interface
-pub trait Proxy: Sized {
+pub trait Proxy: Clone + std::fmt::Debug + Sized {
     /// The event enum for this interface
     type Event;
     /// The request enum for this interface

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -127,7 +127,7 @@ use std::{
 };
 
 /// Trait representing a Wayland interface
-pub trait Resource: Sized {
+pub trait Resource: Clone + std::fmt::Debug + Sized {
     /// The event enum for this interface
     type Event;
     /// The request enum for this interface


### PR DESCRIPTION
The code generated by the scanner already meets these bounds, adding
them to the trait simplifies generic code using them.

Fixes #533