### PR TITLE
backend: don't do blocking flushes

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### Bugfixes
+
+- The rust backend no longer ever does a blocking flush
+
 ## 0.1.0-beta.8
 
 #### Breaking changes


### PR DESCRIPTION
If writing a message fails because the buffer is full and cannot be
flushed, this means that the other end is unresponsive, and thus fatal
to the connection.

Fixes #522