### PR TITLE
client/server: Eq and Hash for Weak helpers

### DIFF
--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -170,7 +170,10 @@
 #![forbid(improper_ctypes, unsafe_op_in_unsafe_fn)]
 #![cfg_attr(coverage, feature(no_coverage))]
 
-use std::sync::Arc;
+use std::{
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
 use wayland_backend::{
     client::{InvalidId, ObjectData, ObjectId, WaylandError, WeakBackend},
     protocol::{Interface, Message},
@@ -366,6 +369,14 @@ impl<I: Proxy> Weak<I> {
 impl<I> PartialEq for Weak<I> {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
+    }
+}
+
+impl<I> Eq for Weak<I> {}
+
+impl<I> Hash for Weak<I> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
     }
 }
 

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -73,6 +73,7 @@
 //! using `ObjectId::from_ptr()`, and then make the resources using [`Resource::from_id`].
 #![forbid(improper_ctypes, unsafe_op_in_unsafe_fn)]
 
+use std::hash::{Hash, Hasher};
 use wayland_backend::{
     protocol::{Interface, Message},
     server::{ClientId, InvalidId, ObjectId, WeakHandle},
@@ -277,6 +278,14 @@ impl<I: Resource> Weak<I> {
 impl<I> PartialEq for Weak<I> {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
+    }
+}
+
+impl<I> Eq for Weak<I> {}
+
+impl<I> Hash for Weak<I> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
     }
 }
 


### PR DESCRIPTION
Adds `Eq` and `Hash` impls for `Weak` so that it can be used as the key in a `HashMap`