### PR TITLE
backend: implement HasRawDisplayHandle for Backend in sys

### DIFF
--- a/wayland-backend/Cargo.toml
+++ b/wayland-backend/Cargo.toml
@@ -18,6 +18,7 @@ log = { version = "0.4", optional = true }
 scoped-tls = "1.0"
 downcast-rs = "1.2"
 io-lifetimes = "1.0.0"
+raw-window-handle = { version = "0.5.0", optional = true }
 
 [dependencies.smallvec]
 version = "1.9"

--- a/wayland-backend/src/lib.rs
+++ b/wayland-backend/src/lib.rs
@@ -30,6 +30,13 @@
 //! This crate can generate some runtime error message (notably when a protocol error occurs). By default
 //! those messages are printed to stderr. If you activate the `log` cargo feature, they will instead be
 //! piped through the `log` crate.
+//!
+//! ## raw-window-handle integration
+//!
+//! This crate can implement [`HasRawWindowHandle`](raw_window_handle::HasRawWindowHandle) for the client
+//! module [`Backend`](client::Backend) type if you activate the `raw-window-handle` feature.
+//!
+//! Note that the `client_system` feature must also be enabled for the implementation to be activated.
 
 #![forbid(improper_ctypes)]
 #![deny(unsafe_op_in_unsafe_fn)]

--- a/wayland-backend/src/sys/mod.rs
+++ b/wayland-backend/src/sys/mod.rs
@@ -97,6 +97,19 @@ impl client::Backend {
     }
 }
 
+// SAFETY:
+// - The display_ptr will not change for the lifetime of the backend.
+// - The display_ptr will be valid, either because we have created the pointer or the caller which created the
+//   backend has ensured the pointer is valid when `Backend::from_foreign_display` was called.
+#[cfg(feature = "raw-window-handle")]
+unsafe impl raw_window_handle::HasRawDisplayHandle for client::Backend {
+    fn raw_display_handle(&self) -> raw_window_handle::RawDisplayHandle {
+        let mut handle = raw_window_handle::WaylandDisplayHandle::empty();
+        handle.display = self.display_ptr().cast();
+        raw_window_handle::RawDisplayHandle::Wayland(handle)
+    }
+}
+
 /// Server-side implementation of a Wayland protocol backend using `libwayland`
 ///
 /// The main entrypoint is the [`Backend::new`](server::Backend::new) method.


### PR DESCRIPTION
This makes using wayland-backend within the raw-window-handle ecosystem easier. A new `raw-window-handle` feature has been added to enable this trait implementation