### PR TITLE
Update wayland-protocols to 1.29

### DIFF
--- a/wayland-protocols/CHANGELOG.md
+++ b/wayland-protocols/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Additions
+
+- Bump wayland-protocols to 1.29
+  - `xdg-shell` has some new error values, however the version was not bumped:
+    - `xdg_wm_base::Error::Unresponsive`
+    - `xdg_surface::Error::InvalidSize`
+    - `xdg_toplevel::Error::InvalidSize`
+    - `xdg_toplevel::Error::InvalidParent`
+  - A some new staging protocols:
+    - `ext-idle-notify`
+    - `wp-content-type`
+    - `xwayland_shell_v1`
+
 ## 0.30.0-beta.9
 
 ### Additions

--- a/wayland-protocols/src/ext.rs
+++ b/wayland-protocols/src/ext.rs
@@ -3,6 +3,19 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 #[cfg(feature = "staging")]
+pub mod idle_notify {
+    //! This protocol allows clients to monitor user idle status.
+
+    #[allow(missing_docs)]
+    pub mod v1 {
+        wayland_protocol!(
+            "./protocols/staging/ext-idle-notify/ext-idle-notify-v1.xml",
+            []
+        );
+    }
+}
+
+#[cfg(feature = "staging")]
 pub mod session_lock {
     //! This protocol allows for a privileged Wayland client to lock the session
     //! and display arbitrary graphics while the session is locked.

--- a/wayland-protocols/src/lib.rs
+++ b/wayland-protocols/src/lib.rs
@@ -9,11 +9,12 @@
 //!
 //! ## Protocol categories
 //!
-//! The protocols provided in this crate are grouped in 3 main categories:
+//! The protocols provided in this crate are grouped in 4 main categories:
 //!
 //! - The [`wp`] module contains general purpose wayland protocols
 //! - The [`xdg`] module contains protocols specifically related to window management
-//! - The [`ext`] module contains protocols that do not fit into the two previous categories.
+//! - The [`xwayland`] module contains protocols used by xwayland.
+//! - The [`ext`] module contains protocols that do not fit into the three previous categories.
 //!
 //! ## Staging protocols
 //!
@@ -52,3 +53,4 @@ mod protocol_macro;
 pub mod ext;
 pub mod wp;
 pub mod xdg;
+pub mod xwayland;

--- a/wayland-protocols/src/wp.rs
+++ b/wayland-protocols/src/wp.rs
@@ -3,6 +3,20 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 #[cfg(feature = "staging")]
+pub mod content_type {
+    //! This protocol allows a client to describe the kind of content a surface
+    //! will display, to allow the compositor to optimize its behavior for it.
+
+    #[allow(missing_docs)]
+    pub mod v1 {
+        wayland_protocol!(
+            "./protocols/staging/content-type/content-type-v1.xml",
+            []
+        );
+    }
+}
+
+#[cfg(feature = "staging")]
 pub mod drm_lease {
     //! This protocol is used by Wayland compositors which act as Direct
     //! Renderering Manager (DRM) masters to lease DRM resources to Wayland
@@ -364,44 +378,4 @@ pub mod viewporter {
     //! dimensions from the size of the buffer.
 
     wayland_protocol!("./protocols/stable/viewporter/viewporter.xml", []);
-}
-
-#[cfg(feature = "unstable")]
-pub mod xwayland_keyboard_grab {
-    //! Protocol for grabbing the keyboard from Xwayland
-    //!
-    //! This protocol is application-specific to meet the needs of the X11
-    //! protocol through Xwayland. It provides a way for Xwayland to request
-    //! all keyboard events to be forwarded to a surface even when the
-    //! surface does not have keyboard focus.
-    //!
-    //! In the X11 protocol, a client may request an "active grab" on the
-    //! keyboard. On success, all key events are reported only to the
-    //! grabbing X11 client. For details, see XGrabKeyboard(3).
-    //!
-    //! The core Wayland protocol does not have a notion of an active
-    //! keyboard grab. When running in Xwayland, X11 applications may
-    //! acquire an active grab inside Xwayland but that cannot be translated
-    //! to the Wayland compositor who may set the input focus to some other
-    //! surface. In doing so, it breaks the X11 client assumption that all
-    //! key events are reported to the grabbing client.
-    //!
-    //! This protocol specifies a way for Xwayland to request all keyboard
-    //! be directed to the given surface. The protocol does not guarantee
-    //! that the compositor will honor this request and it does not
-    //! prescribe user interfaces on how to handle the respond. For example,
-    //! a compositor may inform the user that all key events are now
-    //! forwarded to the given client surface, or it may ask the user for
-    //! permission to do so.
-    //!
-    //! Compositors are required to restrict access to this application
-    //! specific protocol to Xwayland alone.
-
-    /// Unstable version 1
-    pub mod zv1 {
-        wayland_protocol!(
-            "./protocols/unstable/xwayland-keyboard-grab/xwayland-keyboard-grab-unstable-v1.xml",
-            []
-        );
-    }
 }

--- a/wayland-protocols/src/xwayland.rs
+++ b/wayland-protocols/src/xwayland.rs
@@ -1,0 +1,79 @@
+//! XWayland related protocols
+
+#![cfg_attr(rustfmt, rustfmt_skip)]
+
+#[cfg(feature = "staging")]
+pub mod shell {
+    //! This protocol adds a xwayland_surface role which allows an Xwayland
+    //! server to associate an X11 window to a wl_surface.
+    //!
+    //! Before this protocol, this would be done via the Xwayland server
+    //! providing the wl_surface's resource id via the a client message with
+    //! the WL_SURFACE_ID atom on the X window.
+    //! This was problematic as a race could occur if the wl_surface
+    //! associated with a WL_SURFACE_ID for a window was destroyed before the
+    //! client message was processed by the compositor and another surface
+    //! (or other object) had taken its id due to recycling.
+    //!
+    //! This protocol solves the problem by moving the X11 window to wl_surface
+    //! association step to the Wayland side, which means that the association
+    //! cannot happen out-of-sync with the resource lifetime of the wl_surface.
+    //!
+    //! This protocol avoids duplicating the race on the other side by adding a
+    //! non-zero monotonic serial number which is entirely unique that is set on
+    //! both the wl_surface (via. xwayland_surface_v1's set_serial method) and
+    //! the X11 window (via. the `WL_SURFACE_SERIAL` client message) that can be
+    //! used to associate them, and synchronize the two timelines.
+    //!
+    //! The key words "must", "must not", "required", "shall", "shall not",
+    //! "should", "should not", "recommended",  "may", and "optional" in this
+    //! document are to be interpreted as described in IETF RFC 2119.
+
+    #[allow(missing_docs)]
+    pub mod v1 {
+        wayland_protocol!(
+            "./protocols/staging/xwayland-shell/xwayland-shell-v1.xml",
+            []
+        );
+    }
+}
+
+#[cfg(feature = "unstable")]
+pub mod keyboard_grab {
+    //! Protocol for grabbing the keyboard from Xwayland
+    //!
+    //! This protocol is application-specific to meet the needs of the X11
+    //! protocol through Xwayland. It provides a way for Xwayland to request
+    //! all keyboard events to be forwarded to a surface even when the
+    //! surface does not have keyboard focus.
+    //!
+    //! In the X11 protocol, a client may request an "active grab" on the
+    //! keyboard. On success, all key events are reported only to the
+    //! grabbing X11 client. For details, see XGrabKeyboard(3).
+    //!
+    //! The core Wayland protocol does not have a notion of an active
+    //! keyboard grab. When running in Xwayland, X11 applications may
+    //! acquire an active grab inside Xwayland but that cannot be translated
+    //! to the Wayland compositor who may set the input focus to some other
+    //! surface. In doing so, it breaks the X11 client assumption that all
+    //! key events are reported to the grabbing client.
+    //!
+    //! This protocol specifies a way for Xwayland to request all keyboard
+    //! be directed to the given surface. The protocol does not guarantee
+    //! that the compositor will honor this request and it does not
+    //! prescribe user interfaces on how to handle the respond. For example,
+    //! a compositor may inform the user that all key events are now
+    //! forwarded to the given client surface, or it may ask the user for
+    //! permission to do so.
+    //!
+    //! Compositors are required to restrict access to this application
+    //! specific protocol to Xwayland alone.
+
+    /// Unstable version 1
+    pub mod zv1 {
+        wayland_protocol!(
+            "./protocols/unstable/xwayland-keyboard-grab/xwayland-keyboard-grab-unstable-v1.xml",
+            []
+        );
+    }
+}


### PR DESCRIPTION
Since there are now two xwayland protocols, there is now an `xwayland` module for this protocols.

~~Pending on a new wayland-protocols release with https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/174~~