### PR TITLE
backend: Return `MissingData` instead of `Malformed` if `len > raw.len()`

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -1,8 +1,11 @@
 # CHANGELOG: wayland-backend
 
-## 0.1.0-beta.10
-
 ## Unreleased
+
+#### Bugfixes
+- In rust backend, retry read if message is incomplete, instead of `Malformed` error.
+
+## 0.1.0-beta.10
 
 #### Breaking changes
 

--- a/wayland-backend/src/rs/wire.rs
+++ b/wayland-backend/src/rs/wire.rs
@@ -198,8 +198,10 @@ pub fn parse_message<'a, 'b>(
     let opcode = (word_2 & 0x0000_FFFF) as u16;
     let len = (word_2 >> 16) as usize / 4;
 
-    if len < 2 || len > raw.len() {
+    if len < 2 {
         return Err(MessageParseError::Malformed);
+    } else if len > raw.len() {
+        return Err(MessageParseError::MissingData);
     }
 
     let (mut payload, rest) = raw.split_at(len);


### PR DESCRIPTION
This allows the higher level code to try reading again to get any remaining bytes of the message, instead of treating the message as malformed.

This matches the implementation of `queue_event()` in libwayland which returns `0` in this case (rather than `-1` for an error).