### PR TITLE
Update wlr-protocols submodule

### DIFF
--- a/wayland-protocols-wlr/CHANGELOG.md
+++ b/wayland-protocols-wlr/CHANGELOG.md
@@ -1,3 +1,8 @@
 # CHANGELOG: wayland-protocols-wlr
 
 ## Unreleased
+
+### Additions
+
+- Update wlr-protocols
+  - `wlr-output-management-unstable-v1` is now version 4, allowing to change the adaptive sync state


### PR DESCRIPTION
`cargo clippy --all --all-features --all-targets -- -D warnings` exited without errors/warnings and `cargo doc --all-features` build the docs with the new pages.