### PR TITLE
Fix UB in rust_listener_create

### DIFF
--- a/wayland-sys/CHANGELOG.md
+++ b/wayland-sys/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## 0.30.0
 
+#### Bugfixes
+
+- Fix UB in `rust_listener_create`
+
 ## 0.30.0-beta.10
 
 #### Bugfixes

--- a/wayland-sys/src/server.rs
+++ b/wayland-sys/src/server.rs
@@ -202,7 +202,7 @@ pub mod signal {
 
     macro_rules! container_of(
         ($ptr: expr, $container: ident, $field: ident) => {
-            ($ptr as *mut u8).offset(-(memoffset::offset_of!($container, $field) as isize)) as *mut $container
+            ($ptr as *mut u8).sub(memoffset::offset_of!($container, $field)) as *mut $container
         }
     );
 

--- a/wayland-sys/src/server.rs
+++ b/wayland-sys/src/server.rs
@@ -283,6 +283,7 @@ pub mod signal {
             user_data: ptr::null_mut(),
         }));
 
+        // SAFETY: data is a valid pointer for `ListenerWithUserData`.
         unsafe { addr_of_mut!((*data).listener) }
     }
 

--- a/wayland-sys/src/server.rs
+++ b/wayland-sys/src/server.rs
@@ -284,7 +284,7 @@ pub mod signal {
         }));
 
         // SAFETY: data is a valid pointer for `ListenerWithUserData`.
-        unsafe { addr_of_mut!((*data).listener) }
+        unsafe { std::ptr::addr_of_mut!((*data).listener) }
     }
 
     pub unsafe fn rust_listener_get_user_data(listener: *mut wl_listener) -> *mut c_void {

--- a/wayland-sys/src/server.rs
+++ b/wayland-sys/src/server.rs
@@ -283,7 +283,7 @@ pub mod signal {
             user_data: ptr::null_mut(),
         }));
 
-        unsafe { &mut (*data).listener as *mut wl_listener }
+        unsafe { addr_of_mut!((*data).listener) }
     }
 
     pub unsafe fn rust_listener_get_user_data(listener: *mut wl_listener) -> *mut c_void {


### PR DESCRIPTION
`&mut (*data).listener` creates a reference only valid for the listener field according to stacked borrows. Later attempting to get access to the entire container is UB. Using `addr_of_mut!()` avoids the intermediate reference, avoiding UB.