### PR TITLE
Add Zlib to cargo-deny license allow list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -23,6 +23,7 @@ allow = [
     "MIT",
     "ISC",
     "BSD-3-Clause",
+    "Zlib",
     # Used in unicode-ident, which is used by syn and proc-macro2.
     #
     # Do watch https://github.com/rust-lang/rust/issues/98116 for future progress on this


### PR DESCRIPTION
When I tried to introduce `calloop` as an optional dependency the CI failed at the cargo-deny action. One of calloops dependencies uses the Zlib license. This PR is adding it to the allow list of cargo-deny.