### PR TITLE
Build documentation with all features for docs.rs

### DIFF
--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -26,3 +26,7 @@ calloop = { version = "0.10.3", optional = true }
 wayland-protocols = { path = "../wayland-protocols", features = ["client"] }
 futures-util = "0.3"
 tempfile = "3.2"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/wayland-cursor/Cargo.toml
+++ b/wayland-cursor/Cargo.toml
@@ -15,3 +15,7 @@ readme = "README.md"
 wayland-client = { version = "=0.30.0-beta.14", path = "../wayland-client" }
 xcursor = "0.3.1"
 nix = { version = "0.25.0", default-features = false, features = ["mman"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/wayland-egl/Cargo.toml
+++ b/wayland-egl/Cargo.toml
@@ -15,3 +15,7 @@ readme = "README.md"
 wayland-backend = { version = "=0.1.0-beta.14", path = "../wayland-backend", features = ["client_system"] }
 wayland-sys = { version = "0.30.0", path="../wayland-sys", features = ["egl"] }
 thiserror = "1.0.30"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/wayland-scanner/Cargo.toml
+++ b/wayland-scanner/Cargo.toml
@@ -22,3 +22,7 @@ quick-xml = "0.23"
 
 [dev-dependencies]
 similar = "2"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -19,3 +19,7 @@ thiserror = "1.0.2"
 log = { version = "0.4", optional = true }
 nix = { version = "0.25.0", default-features = false }
 downcast-rs = "1.2"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/wayland-sys/Cargo.toml
+++ b/wayland-sys/Cargo.toml
@@ -29,3 +29,4 @@ server = ["libc", "memoffset"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Not all crates were build with all features enabled for docs.rs. So some of the hyperlinks broke.
This adds
```toml
[package.metadata.docs.rs]
all-features = true
rustdoc-args = ["--cfg", "docsrs"]
```
to the Cargo.toml of all wayland-rs crates except the `wayland-tests` crate.