### PR TITLE
Enable doc_auto_cfg in crates with features

### DIFF
--- a/wayland-backend/src/lib.rs
+++ b/wayland-backend/src/lib.rs
@@ -37,7 +37,8 @@
 // The api modules are imported two times each, this is not accidental
 #![allow(clippy::duplicate_mod)]
 #![cfg_attr(coverage, feature(no_coverage))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+// Doc feature labels can be tested locally by running RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc -p <crate>
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub extern crate io_lifetimes;
 pub extern crate smallvec;
@@ -65,7 +66,6 @@ use std::{
 };
 
 #[cfg(any(test, feature = "client_system", feature = "server_system"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "client_system", feature = "server_system"))))]
 pub mod sys;
 
 pub mod rs;

--- a/wayland-backend/src/sys/mod.rs
+++ b/wayland-backend/src/sys/mod.rs
@@ -30,7 +30,6 @@ unsafe fn free_arrays(signature: &[ArgumentType], arglist: &[wl_argument]) {
 /// - [`Backend::from_foreign_display`](client::Backend::from_foreign_display) if you're interacting with an
 ///   already existing Wayland connection through FFI.
 #[cfg(any(test, feature = "client_system"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "client_system")))]
 #[path = "../client_api.rs"]
 pub mod client;
 
@@ -49,7 +48,6 @@ impl client::ObjectId {
     ///
     /// The provided pointer must be a valid pointer to a `wl_resource` and remain valid for as
     /// long as the retrieved `ObjectId` is used.
-    #[cfg_attr(docsrs, doc(cfg(feature = "client_system")))]
     pub unsafe fn from_ptr(
         interface: &'static crate::protocol::Interface,
         ptr: *mut wayland_sys::client::wl_proxy,
@@ -58,7 +56,6 @@ impl client::ObjectId {
     }
 
     /// Get the underlying libwayland pointer for this object
-    #[cfg_attr(docsrs, doc(cfg(feature = "client_system")))]
     pub fn as_ptr(&self) -> *mut wayland_sys::client::wl_proxy {
         self.id.as_ptr()
     }
@@ -81,7 +78,6 @@ impl client::Backend {
     ///
     /// You need to ensure the `*mut wl_display` remains live as long as the  [`Backend`](client::Backend)
     /// (or its clones) exist.
-    #[cfg_attr(docsrs, doc(cfg(feature = "client_system")))]
     pub unsafe fn from_foreign_display(display: *mut wayland_sys::client::wl_display) -> Self {
         Self { backend: unsafe { client_impl::InnerBackend::from_foreign_display(display) } }
     }
@@ -91,7 +87,6 @@ impl client::Backend {
     /// This pointer is needed to interface with EGL, Vulkan and other C libraries.
     ///
     /// This pointer is only valid for the lifetime of the backend.
-    #[cfg_attr(docsrs, doc(cfg(feature = "client_system")))]
     pub fn display_ptr(&self) -> *mut wayland_sys::client::wl_display {
         self.backend.display_ptr()
     }
@@ -101,7 +96,6 @@ impl client::Backend {
 ///
 /// The main entrypoint is the [`Backend::new`](server::Backend::new) method.
 #[cfg(any(test, feature = "server_system"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "server_system")))]
 #[path = "../server_api.rs"]
 pub mod server;
 
@@ -118,7 +112,6 @@ impl server::ObjectId {
     ///
     /// The provided pointer must be a valid pointer to a `wl_resource` and remain valid for as
     /// long as the retrieved `ObjectId` is used.
-    #[cfg_attr(docsrs, doc(cfg(feature = "server_system")))]
     pub unsafe fn from_ptr(
         interface: &'static crate::protocol::Interface,
         ptr: *mut wayland_sys::server::wl_resource,
@@ -129,7 +122,6 @@ impl server::ObjectId {
     /// Returns the pointer that represents this object.
     ///
     /// The pointer may be used to interoperate with libwayland.
-    #[cfg_attr(docsrs, doc(cfg(feature = "server_system")))]
     pub fn as_ptr(&self) -> *mut wayland_sys::server::wl_resource {
         self.id.as_ptr()
     }
@@ -138,7 +130,6 @@ impl server::ObjectId {
 #[cfg(any(test, feature = "server_system"))]
 impl server::Handle {
     /// Access the underlying `*mut wl_display` pointer
-    #[cfg_attr(docsrs, doc(cfg(feature = "server_system")))]
     pub fn display_ptr(&self) -> *mut wayland_sys::server::wl_display {
         self.handle.display_ptr()
     }

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -169,6 +169,8 @@
 #![warn(missing_docs, missing_debug_implementations)]
 #![forbid(improper_ctypes, unsafe_op_in_unsafe_fn)]
 #![cfg_attr(coverage, feature(no_coverage))]
+// Doc feature labels can be tested locally by running RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc -p <crate>
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use std::{
     hash::{Hash, Hasher},

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -72,6 +72,8 @@
 //! If you need to receive pointers from FFI, you can make [`ObjectId`]s from the `*mut wl_resource` pointers
 //! using `ObjectId::from_ptr()`, and then make the resources using [`Resource::from_id`].
 #![forbid(improper_ctypes, unsafe_op_in_unsafe_fn)]
+// Doc feature labels can be tested locally by running RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc -p <crate>
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use std::hash::{Hash, Hasher};
 use wayland_backend::{

--- a/wayland-sys/src/lib.rs
+++ b/wayland-sys/src/lib.rs
@@ -28,6 +28,8 @@
 //! if the feature `dlopen` is absent, as we link against the library directly in that case.
 #![allow(non_camel_case_types)]
 #![forbid(improper_ctypes, unsafe_op_in_unsafe_fn)]
+// Doc feature labels can be tested locally by running RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc -p <crate>
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 // If compiling with neither the `client` or `server` feature (non-sensical but
 // it's what happens when running `cargo test --all` from the workspace root),


### PR DESCRIPTION
The wayland-protocols crates already had these enabled.

Related to this is #587 which sets `--cfg=docsrs` in the crates where it has not been done yet for docs.rs