### PR TITLE
server: Implement `AsFd` for `ListeningSocket`

### DIFF
--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -19,3 +19,4 @@ thiserror = "1.0.2"
 log = { version = "0.4", optional = true }
 nix = { version = "0.25.0", default-features = false }
 downcast-rs = "1.2"
+io-lifetimes = "1.0.0"

--- a/wayland-server/src/socket.rs
+++ b/wayland-server/src/socket.rs
@@ -10,6 +10,7 @@ use std::{
     path::PathBuf,
 };
 
+use io_lifetimes::{AsFd, BorrowedFd};
 use nix::{
     fcntl::{flock, open, FlockArg, OFlag},
     sys::stat::{lstat, Mode},
@@ -144,6 +145,19 @@ impl AsRawFd for ListeningSocket {
     /// to get a stream to the new client.
     fn as_raw_fd(&self) -> RawFd {
         self.listener.as_raw_fd()
+    }
+}
+
+impl AsFd for ListeningSocket {
+    /// Returns a file descriptor that may be polled for readiness.
+    ///
+    /// This file descriptor may be polled using apis such as epoll and kqueue to be told when a client has
+    /// found the socket and is trying to connect.
+    ///
+    /// When the polling system reports the file descriptor is ready, you can use [`ListeningSocket::accept`]
+    /// to get a stream to the new client.
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.listener.as_fd()
     }
 }
 


### PR DESCRIPTION
It looks like the only other `AsRawFd` implementations here are in wayland-backend and already have corresponding `AsFd` implementations.