### PR TITLE
Reflect MSRV in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The documentation for the releases can be found on [docs.rs](https://docs.rs/):
 
 ## Requirements
 
-Requires at least rust 1.53.0 to be used, and version 1.15 of the wayland system libraries if using the
+Requires at least rust 1.59.0 to be used, and version 1.15 of the wayland system libraries if using the
 system backend.
 
 ## Chat and support

--- a/wayland-backend/Cargo.toml
+++ b/wayland-backend/Cargo.toml
@@ -3,6 +3,7 @@ name = "wayland-backend"
 version = "0.1.0-beta.14"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
 edition = "2018"
+rust-version = "1.59"
 repository = "https://github.com/smithay/wayland-rs"
 documentation = "https://docs.rs/wayland-backend/"
 license = "MIT"
@@ -22,7 +23,7 @@ raw-window-handle = { version = "0.5.0", optional = true }
 
 [dependencies.smallvec]
 version = "1.9"
-# Some additional features can be enabled since wayland-rs requires at least Rust 1.53
+# Some additional features can be enabled since wayland-rs requires at least Rust 1.59
 features = [
     "union", # 1.49
     "const_generics", # 1.51

--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -6,6 +6,7 @@ repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
 license = "MIT"
 edition = "2018"
+rust-version = "1.59"
 categories = ["gui", "api-bindings"]
 keywords = ["wayland", "client"]
 description = "Bindings to the standard C implementation of the wayland protocol, client side."

--- a/wayland-cursor/Cargo.toml
+++ b/wayland-cursor/Cargo.toml
@@ -6,6 +6,7 @@ repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
 license = "MIT"
 edition = "2018"
+rust-version = "1.59"
 categories = ["gui", "api-bindings"]
 keywords = ["wayland", "client"]
 description = "Bindings to libwayland-cursor."

--- a/wayland-egl/Cargo.toml
+++ b/wayland-egl/Cargo.toml
@@ -6,6 +6,7 @@ repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
 license = "MIT"
 edition = "2018"
+rust-version = "1.59"
 categories = ["gui", "api-bindings"]
 keywords = ["wayland", "client"]
 description = "Bindings to libwayland-egl."

--- a/wayland-protocols-misc/Cargo.toml
+++ b/wayland-protocols-misc/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["wayland", "client", "server", "protocol", "extension"]
 description = "Generated API for misc and deprecated wayland protocol extensions"
 categories = ["gui", "api-bindings"]
 edition = "2018"
+rust-version = "1.59"
 readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/wayland-protocols-plasma/Cargo.toml
+++ b/wayland-protocols-plasma/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["wayland", "client", "server", "protocol", "extension"]
 description = "Generated API for the Plasma wayland protocol extensions"
 categories = ["gui", "api-bindings"]
 edition = "2018"
+rust-version = "1.59"
 readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/wayland-protocols-wlr/Cargo.toml
+++ b/wayland-protocols-wlr/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["wayland", "client", "server", "protocol", "extension"]
 description = "Generated API for the WLR wayland protocol extensions"
 categories = ["gui", "api-bindings"]
 edition = "2018"
+rust-version = "1.59"
 readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/wayland-protocols/Cargo.toml
+++ b/wayland-protocols/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["wayland", "client", "server", "protocol", "extension"]
 description = "Generated API for the officials wayland protocol extensions"
 categories = ["gui", "api-bindings"]
 edition = "2018"
+rust-version = "1.59"
 readme = "README.md"
 
 [dependencies]

--- a/wayland-scanner/Cargo.toml
+++ b/wayland-scanner/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 categories = ["gui", "api-bindings"]
 keywords = ["wayland", "codegen"]
 edition = "2018"
+rust-version = "1.59"
 readme = "README.md"
 
 [lib]

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -9,6 +9,7 @@ categories = ["gui", "api-bindings"]
 keywords = ["wayland", "server", "compositor"]
 description = "Bindings to the standard C implementation of the wayland protocol, server side."
 edition = "2018"
+rust-version = "1.59"
 readme = "README.md"
 
 [dependencies]

--- a/wayland-sys/Cargo.toml
+++ b/wayland-sys/Cargo.toml
@@ -8,6 +8,7 @@ description = "FFI bindings to the various libwayland-*.so libraries. You should
 license = "MIT"
 categories = ["external-ffi-bindings"]
 edition = "2018"
+rust-version = "1.59"
 readme = "README.md"
 
 [dependencies]

--- a/wayland-tests/Cargo.toml
+++ b/wayland-tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wayland-tests"
 version = "0.1.0"
 edition = "2018"
+rust-version = "1.59"
 publish = false
 autotests = false
 


### PR DESCRIPTION
Updates the MSRV in the Readme and also defines the `rust-version` in the crate manifests