### PR TITLE
server: Add resource and display handle to Dispatch::destroyed

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+#### Breaking changes
+
+- server: `ObjectData::destroyed` function signature has changed to pass the `Handle` and `self` as `Arc<Self>`
+
+```diff
+fn destroyed(
+-    &self,
++    self: Arc<Self>,
++    _handle: &Handle,
+    _: &mut D,
+    _client_id: ClientId,
+    _object_id: ObjectId,
+) {
+}
+```
+
 ## 0.1.2 -- 19/04/2023
 
 #### Bugfixes

--- a/wayland-backend/src/rs/server_impl/common_poll.rs
+++ b/wayland-backend/src/rs/server_impl/common_poll.rs
@@ -73,7 +73,8 @@ impl<D> InnerBackend<D> {
         client_id: InnerClientId,
     ) -> std::io::Result<usize> {
         let ret = self.dispatch_events_for(data, client_id);
-        let cleanup = self.state.lock().unwrap().cleanup();
+        let handle = self.handle();
+        let cleanup = self.state.lock().unwrap().cleanup(&handle);
         cleanup(data);
         ret
     }
@@ -97,7 +98,8 @@ impl<D> InnerBackend<D> {
                     dispatched += count;
                 }
             }
-            let cleanup = self.state.lock().unwrap().cleanup();
+            let handle = self.handle();
+            let cleanup = self.state.lock().unwrap().cleanup(&handle);
             cleanup(data);
         }
 
@@ -230,7 +232,8 @@ impl<D> InnerBackend<D> {
                         },
                     );
                     if is_destructor {
-                        object.data.user_data.destroyed(
+                        object.data.user_data.clone().destroyed(
+                            &handle.clone(),
                             data,
                             ClientId { id: client_id.clone() },
                             ObjectId { id: object_id.clone() },

--- a/wayland-backend/src/rs/server_impl/mod.rs
+++ b/wayland-backend/src/rs/server_impl/mod.rs
@@ -127,7 +127,7 @@ impl<D> ObjectData<D> for UninitObjectData {
     }
 
     #[cfg_attr(coverage, no_coverage)]
-    fn destroyed(&self, _: &mut D, _: ClientId, _: ObjectId) {}
+    fn destroyed(self: Arc<Self>, _: &Handle, _: &mut D, _: ClientId, _: ObjectId) {}
 
     #[cfg_attr(coverage, no_coverage)]
     fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/wayland-backend/src/server_api.rs
+++ b/wayland-backend/src/server_api.rs
@@ -32,7 +32,13 @@ pub trait ObjectData<D>: downcast_rs::DowncastSync {
         msg: Message<ObjectId, OwnedFd>,
     ) -> Option<Arc<dyn ObjectData<D>>>;
     /// Notification that the object has been destroyed and is no longer active
-    fn destroyed(&self, data: &mut D, client_id: ClientId, object_id: ObjectId);
+    fn destroyed(
+        self: Arc<Self>,
+        handle: &Handle,
+        data: &mut D,
+        client_id: ClientId,
+        object_id: ObjectId,
+    );
     /// Helper for forwarding a Debug implementation of your `ObjectData` type
     ///
     /// By default will just print `ObjectData { ... }`
@@ -579,5 +585,12 @@ impl<D> ObjectData<D> for DumbObjectData {
     }
 
     #[cfg_attr(coverage, no_coverage)]
-    fn destroyed(&self, _: &mut D, _client_id: ClientId, _object_id: ObjectId) {}
+    fn destroyed(
+        self: Arc<Self>,
+        _handle: &Handle,
+        _: &mut D,
+        _client_id: ClientId,
+        _object_id: ObjectId,
+    ) {
+    }
 }

--- a/wayland-backend/src/sys/server_impl/mod.rs
+++ b/wayland-backend/src/sys/server_impl/mod.rs
@@ -438,7 +438,8 @@ impl<D> InnerBackend<D> {
         let pending_destructors =
             std::mem::take(&mut self.state.lock().unwrap().pending_destructors);
         for (object, client_id, object_id) in pending_destructors {
-            object.destroyed(data, client_id, object_id);
+            let handle = self.handle();
+            object.clone().destroyed(&handle, data, client_id, object_id);
         }
 
         if ret < 0 {
@@ -1590,10 +1591,15 @@ unsafe extern "C" fn resource_destructor<D: 'static>(resource: *mut wl_resource)
     let object_id =
         InnerObjectId { interface: udata.interface, ptr: resource, alive: udata.alive.clone(), id };
     if HANDLE.is_set() {
-        HANDLE.with(|&(_, data_ptr)| {
+        HANDLE.with(|&(ref state_arc, data_ptr)| {
             // Safety: the data pointer have been set by outside code and are valid
             let data = unsafe { &mut *(data_ptr as *mut D) };
-            udata.data.destroyed(data, ClientId { id: client_id }, ObjectId { id: object_id });
+            udata.data.destroyed(
+                &Handle { handle: InnerHandle { state: state_arc.clone() } },
+                data,
+                ClientId { id: client_id },
+                ObjectId { id: object_id },
+            );
         });
     } else {
         PENDING_DESTRUCTORS.with(|&pending_ptr| {
@@ -1628,7 +1634,7 @@ impl<D> ObjectData<D> for UninitObjectData {
     }
 
     #[cfg_attr(coverage, no_coverage)]
-    fn destroyed(&self, _: &mut D, _: ClientId, _: ObjectId) {}
+    fn destroyed(self: Arc<Self>, _: &Handle, _: &mut D, _: ClientId, _: ObjectId) {}
 
     #[cfg_attr(coverage, no_coverage)]
     fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/wayland-backend/src/test/destructors.rs
+++ b/wayland-backend/src/test/destructors.rs
@@ -24,7 +24,8 @@ macro_rules! impl_server_objectdata {
             }
 
             fn destroyed(
-                &self,
+                self: Arc<Self>,
+                _: &$server_backend::Handle,
                 _: &mut (),
                 _: $server_backend::ClientId,
                 _: $server_backend::ObjectId,

--- a/wayland-backend/src/test/many_args.rs
+++ b/wayland-backend/src/test/many_args.rs
@@ -43,7 +43,14 @@ macro_rules! serverdata_impls {
                 None
             }
 
-            fn destroyed(&self, _: &mut (), _: $server_backend::ClientId, _: $server_backend::ObjectId) {}
+            fn destroyed(
+                self: Arc<Self>,
+                _: &$server_backend::Handle,
+                _: &mut (),
+                _: $server_backend::ClientId,
+                _: $server_backend::ObjectId
+            ) {
+            }
         }
 
         impl $server_backend::GlobalHandler<()> for ServerData {

--- a/wayland-backend/src/test/mod.rs
+++ b/wayland-backend/src/test/mod.rs
@@ -143,7 +143,14 @@ impl<D> server_rs::ObjectData<D> for DoNothingData {
         None
     }
 
-    fn destroyed(&self, _: &mut D, _: server_rs::ClientId, _: server_rs::ObjectId) {}
+    fn destroyed(
+        self: Arc<Self>,
+        _handle: &server_rs::Handle,
+        _: &mut D,
+        _: server_rs::ClientId,
+        _: server_rs::ObjectId,
+    ) {
+    }
 }
 
 impl<D> server_sys::ObjectData<D> for DoNothingData {
@@ -157,7 +164,14 @@ impl<D> server_sys::ObjectData<D> for DoNothingData {
         None
     }
 
-    fn destroyed(&self, _: &mut D, _: server_sys::ClientId, _: server_sys::ObjectId) {}
+    fn destroyed(
+        self: Arc<Self>,
+        _handle: &server_sys::Handle,
+        _: &mut D,
+        _: server_sys::ClientId,
+        _: server_sys::ObjectId,
+    ) {
+    }
 }
 
 // Client Object Data

--- a/wayland-backend/src/test/object_args.rs
+++ b/wayland-backend/src/test/object_args.rs
@@ -68,7 +68,14 @@ macro_rules! impl_server_objectdata {
                 None
             }
 
-            fn destroyed(&self, _: &mut (), _: $server_backend::ClientId, _: $server_backend::ObjectId) {}
+            fn destroyed(
+                self: Arc<Self>,
+                _: &$server_backend::Handle,
+                _: &mut (),
+                _: $server_backend::ClientId,
+                _: $server_backend::ObjectId
+            ) {
+            }
         }
 
         impl $server_backend::GlobalHandler<()> for ServerData {

--- a/wayland-backend/src/test/protocol_error.rs
+++ b/wayland-backend/src/test/protocol_error.rs
@@ -223,7 +223,14 @@ impl<D> server_rs::ObjectData<D> for ProtocolErrorServerData {
         None
     }
 
-    fn destroyed(&self, _: &mut D, _: server_rs::ClientId, _: server_rs::ObjectId) {}
+    fn destroyed(
+        self: Arc<Self>,
+        _handle: &server_rs::Handle,
+        _: &mut D,
+        _: server_rs::ClientId,
+        _: server_rs::ObjectId,
+    ) {
+    }
 }
 
 impl<D> server_sys::ObjectData<D> for ProtocolErrorServerData {
@@ -238,7 +245,14 @@ impl<D> server_sys::ObjectData<D> for ProtocolErrorServerData {
         None
     }
 
-    fn destroyed(&self, _: &mut D, _: server_sys::ClientId, _: server_sys::ObjectId) {}
+    fn destroyed(
+        self: Arc<Self>,
+        _handle: &server_sys::Handle,
+        _: &mut D,
+        _: server_sys::ClientId,
+        _: server_sys::ObjectId,
+    ) {
+    }
 }
 
 expand_test!(protocol_error_in_request_without_object_init, {

--- a/wayland-server/CHANGELOG.md
+++ b/wayland-server/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+#### Breaking changes
+
+- `Resource::destroyed` now passes the resource type instead of the `ObjectId`.
+
+#### Additions
+
 - `New` objects inside `GlobalDispatch` can now have errors posted using `DataInit::post_error`.
 - Updated Wayland core protocol to 1.22
 

--- a/wayland-server/src/global.rs
+++ b/wayland-server/src/global.rs
@@ -77,7 +77,14 @@ impl<D> ObjectData<D> for ProtocolErrorData {
         None
     }
 
-    fn destroyed(&self, _data: &mut D, _client_id: ClientId, _object_id: ObjectId) {}
+    fn destroyed(
+        self: Arc<Self>,
+        _handle: &Handle,
+        _data: &mut D,
+        _client_id: ClientId,
+        _object_id: ObjectId,
+    ) {
+    }
 }
 
 /// A trait which provides an implementation for handling advertisement of a global to clients with some type

--- a/wayland-tests/tests/destructors.rs
+++ b/wayland-tests/tests/destructors.rs
@@ -163,8 +163,8 @@ impl ways::Dispatch<ways::protocol::wl_output::WlOutput, ServerUData> for Server
 
     fn destroyed(
         _: &mut Self,
-        _client: wayland_backend::server::ClientId,
-        _resource: wayland_backend::server::ObjectId,
+        _: ways::backend::ClientId,
+        _resource: &ways::protocol::wl_output::WlOutput,
         data: &ServerUData,
     ) {
         data.0.store(true, Ordering::Release);


### PR DESCRIPTION
This allows libraries (such as smithay) which may dispatch events to users when a protocol object is to destroyed to eliminate lists of known objects to destroy.

This is an example of some of the code in Smithay that can be removed with these changes

`src/wayland/shell/xdg/handlers/surface/toplevel.rs`

```diff
-    fn destroyed(state: &mut D, _client_id: ClientId, object_id: ObjectId, data: &XdgShellSurfaceUserData) {
+    fn destroyed(state: &mut D, _client_id: ClientId, toplevel: &XdgToplevel, data: &XdgShellSurfaceUserData) {
        data.alive_tracker.destroy_notify();
        data.decoration.lock().unwrap().take();

-        let mut shell_data = data.shell_data.lock().unwrap();
-        if let Some(index) = shell_data
-            .known_toplevels
-            .iter()
-            .position(|top| top.shell_surface.id() == object_id)
-        {
-            let toplevel = shell_data.known_toplevels.remove(index);
-            drop(shell_data);
-            let surface = toplevel.wl_surface().clone();
            XdgShellHandler::toplevel_destroyed(state, toplevel);
            compositor::with_states(&surface, |states| {
                *states
                    .data_map
                    .get::<XdgToplevelSurfaceData>()
                    .unwrap()
                    .lock()
                    .unwrap() = Default::default();
                *states.cached_state.pending::<SurfaceCachedState>() = Default::default();
                *states.cached_state.current::<SurfaceCachedState>() = Default::default();
            })
-        }
    }
```