### PR TITLE
scanner: implement Borrow<ObjectId>

### DIFF
--- a/wayland-scanner/CHANGELOG.md
+++ b/wayland-scanner/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Generated protocol object types now implement `Borrow<ObjectId>`
+
 ## 0.30.0 -- 27/12/2022
 
 ## 0.30.0-beta.10

--- a/wayland-scanner/src/client_gen.rs
+++ b/wayland-scanner/src/client_gen.rs
@@ -90,6 +90,12 @@ fn generate_objects_for(interface: &Interface) -> TokenStream {
                 }
             }
 
+            impl std::borrow::Borrow<ObjectId> for #iface_name {
+                fn borrow(&self) -> &ObjectId {
+                    &self.id
+                }
+            }
+
             impl super::wayland_client::Proxy for #iface_name {
                 type Request = Request;
                 type Event = Event;

--- a/wayland-scanner/src/server_gen.rs
+++ b/wayland-scanner/src/server_gen.rs
@@ -95,6 +95,11 @@ fn generate_objects_for(interface: &Interface) -> TokenStream {
                 }
             }
 
+            impl std::borrow::Borrow<ObjectId> for #iface_name {
+                fn borrow(&self) -> &ObjectId {
+                    &self.id
+                }
+            }
 
             impl super::wayland_server::Resource for #iface_name {
                 type Request = Request;

--- a/wayland-scanner/tests/scanner_assets/test-client-code.rs
+++ b/wayland-scanner/tests/scanner_assets/test-client-code.rs
@@ -119,6 +119,11 @@ pub mod wl_display {
             self.id == other.id()
         }
     }
+    impl std::borrow::Borrow<ObjectId> for WlDisplay {
+        fn borrow(&self) -> &ObjectId {
+            &self.id
+        }
+    }
     impl super::wayland_client::Proxy for WlDisplay {
         type Request = Request;
         type Event = Event;
@@ -389,6 +394,11 @@ pub mod wl_registry {
             self.id == other.id()
         }
     }
+    impl std::borrow::Borrow<ObjectId> for WlRegistry {
+        fn borrow(&self) -> &ObjectId {
+            &self.id
+        }
+    }
     impl super::wayland_client::Proxy for WlRegistry {
         type Request = Request;
         type Event = Event;
@@ -596,6 +606,11 @@ pub mod wl_callback {
     impl PartialEq<Weak<WlCallback>> for WlCallback {
         fn eq(&self, other: &Weak<WlCallback>) -> bool {
             self.id == other.id()
+        }
+    }
+    impl std::borrow::Borrow<ObjectId> for WlCallback {
+        fn borrow(&self) -> &ObjectId {
+            &self.id
         }
     }
     impl super::wayland_client::Proxy for WlCallback {
@@ -838,6 +853,11 @@ pub mod test_global {
     impl PartialEq<Weak<TestGlobal>> for TestGlobal {
         fn eq(&self, other: &Weak<TestGlobal>) -> bool {
             self.id == other.id()
+        }
+    }
+    impl std::borrow::Borrow<ObjectId> for TestGlobal {
+        fn borrow(&self) -> &ObjectId {
+            &self.id
         }
     }
     impl super::wayland_client::Proxy for TestGlobal {
@@ -1312,6 +1332,11 @@ pub mod secondary {
             self.id == other.id()
         }
     }
+    impl std::borrow::Borrow<ObjectId> for Secondary {
+        fn borrow(&self) -> &ObjectId {
+            &self.id
+        }
+    }
     impl super::wayland_client::Proxy for Secondary {
         type Request = Request;
         type Event = Event;
@@ -1465,6 +1490,11 @@ pub mod tertiary {
             self.id == other.id()
         }
     }
+    impl std::borrow::Borrow<ObjectId> for Tertiary {
+        fn borrow(&self) -> &ObjectId {
+            &self.id
+        }
+    }
     impl super::wayland_client::Proxy for Tertiary {
         type Request = Request;
         type Event = Event;
@@ -1616,6 +1646,11 @@ pub mod quad {
     impl PartialEq<Weak<Quad>> for Quad {
         fn eq(&self, other: &Weak<Quad>) -> bool {
             self.id == other.id()
+        }
+    }
+    impl std::borrow::Borrow<ObjectId> for Quad {
+        fn borrow(&self) -> &ObjectId {
+            &self.id
         }
     }
     impl super::wayland_client::Proxy for Quad {

--- a/wayland-scanner/tests/scanner_assets/test-server-code.rs
+++ b/wayland-scanner/tests/scanner_assets/test-server-code.rs
@@ -58,6 +58,11 @@ pub mod wl_callback {
             self.id == other.id()
         }
     }
+    impl std::borrow::Borrow<ObjectId> for WlCallback {
+        fn borrow(&self) -> &ObjectId {
+            &self.id
+        }
+    }
     impl super::wayland_server::Resource for WlCallback {
         type Request = Request;
         type Event = Event;
@@ -301,6 +306,11 @@ pub mod test_global {
     impl PartialEq<Weak<TestGlobal>> for TestGlobal {
         fn eq(&self, other: &Weak<TestGlobal>) -> bool {
             self.id == other.id()
+        }
+    }
+    impl std::borrow::Borrow<ObjectId> for TestGlobal {
+        fn borrow(&self) -> &ObjectId {
+            &self.id
         }
     }
     impl super::wayland_server::Resource for TestGlobal {
@@ -792,6 +802,11 @@ pub mod secondary {
             self.id == other.id()
         }
     }
+    impl std::borrow::Borrow<ObjectId> for Secondary {
+        fn borrow(&self) -> &ObjectId {
+            &self.id
+        }
+    }
     impl super::wayland_server::Resource for Secondary {
         type Request = Request;
         type Event = Event;
@@ -931,6 +946,11 @@ pub mod tertiary {
             self.id == other.id()
         }
     }
+    impl std::borrow::Borrow<ObjectId> for Tertiary {
+        fn borrow(&self) -> &ObjectId {
+            &self.id
+        }
+    }
     impl super::wayland_server::Resource for Tertiary {
         type Request = Request;
         type Event = Event;
@@ -1068,6 +1088,11 @@ pub mod quad {
     impl PartialEq<Weak<Quad>> for Quad {
         fn eq(&self, other: &Weak<Quad>) -> bool {
             self.id == other.id()
+        }
+    }
+    impl std::borrow::Borrow<ObjectId> for Quad {
+        fn borrow(&self) -> &ObjectId {
+            &self.id
         }
     }
     impl super::wayland_server::Resource for Quad {


### PR DESCRIPTION
Sometimes it may be nessecary to store a `HashMap<ObjectId, T>` or a `HashSet<ObjectId>`. HashMap::get(_mut) allows using a generic parameter which implements `Borrow<K>`. By implementing Borrow<ObjectId> on the types wayland-scanner generates, a HashMap lookup can directly use `HashMap::get` with the protocol object wrapper instead of needing to call `.id()` and then use the id for lookup.

Resolves #600