### PR TITLE
Uncomment Plasma window management protocol

### DIFF
--- a/wayland-protocols-plasma/CHANGELOG.md
+++ b/wayland-protocols-plasma/CHANGELOG.md
@@ -2,4 +2,8 @@
 
 ## Unreleased
 
+### Additions
+
+- Introduce protocol `kde-plasma-window-management`.
+
 ## 0.1.0 -- 27/12/2022

--- a/wayland-protocols-plasma/src/lib.rs
+++ b/wayland-protocols-plasma/src/lib.rs
@@ -128,15 +128,12 @@ pub mod plasma_virtual_desktop {
     );
 }
 
-// This protocol is disabled for now as the XML file contains XML-escaped numerical expressions
-// which wayland-scanner cannot parse.
-//
-// pub mod plasma_window_management {
-//     wayland_protocol!(
-//         "./plasma-wayland-protocols/src/protocols/plasma-window-management.xml",
-//         []
-//     );
-// }
+pub mod plasma_window_management {
+    wayland_protocol!(
+        "./plasma-wayland-protocols/src/protocols/plasma-window-management.xml",
+        []
+    );
+}
 
 pub mod remote_access {
     wayland_protocol!(


### PR DESCRIPTION
The protocol was fixed by https://github.com/KDE/plasma-wayland-protocols/commit/b00501d7cdf7c4107af03ca29cb14fc0d21c5b3e which seems to be working alright with wayland-scanner locally.