### PR TITLE
chore: fix cargo clippy for 1.69

### DIFF
--- a/wayland-backend/src/rs/server_impl/client.rs
+++ b/wayland-backend/src/rs/server_impl/client.rs
@@ -681,7 +681,7 @@ impl<D> ClientStore<D> {
 
     pub(crate) fn get_client(&self, id: InnerClientId) -> Result<&Client<D>, InvalidId> {
         match self.clients.get(id.id as usize) {
-            Some(&Some(ref client)) if client.id == id => Ok(client),
+            Some(Some(ref client)) if client.id == id => Ok(client),
             _ => Err(InvalidId),
         }
     }

--- a/wayland-scanner/src/util.rs
+++ b/wayland-scanner/src/util.rs
@@ -8,7 +8,7 @@ pub(crate) fn to_doc_attr(text: &str) -> TokenStream {
     quote!(#[doc = #text])
 }
 
-pub(crate) fn description_to_doc_attr(&(ref short, ref long): &(String, String)) -> TokenStream {
+pub(crate) fn description_to_doc_attr((short, long): &(String, String)) -> TokenStream {
     to_doc_attr(&format!("{}\n\n{}", short, long))
 }
 


### PR DESCRIPTION
There seems some clippy probrems