### PR TITLE
Fix CI

### DIFF
--- a/wayland-backend/src/lib.rs
+++ b/wayland-backend/src/lib.rs
@@ -47,8 +47,10 @@
 // Doc feature labels can be tested locally by running RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc -p <crate>
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-pub use io_lifetimes;
-pub use smallvec;
+/// Reexport of the `io_lifetimes` crate, which is part of `wayland-backend`'s public API.
+pub extern crate io_lifetimes;
+/// Reexport of the `smallvec` crate, which is part of `wayland-backend`'s public API.
+pub extern crate smallvec;
 
 /// Helper macro for quickly making a [`Message`](crate::protocol::Message)
 #[macro_export]

--- a/wayland-backend/src/lib.rs
+++ b/wayland-backend/src/lib.rs
@@ -47,10 +47,8 @@
 // Doc feature labels can be tested locally by running RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc -p <crate>
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-#[allow(missing_docs)]
-pub extern crate io_lifetimes;
-#[allow(missing_docs)]
-pub extern crate smallvec;
+pub use io_lifetimes;
+pub use smallvec;
 
 /// Helper macro for quickly making a [`Message`](crate::protocol::Message)
 #[macro_export]

--- a/wayland-tests/tests/client_proxies.rs
+++ b/wayland-tests/tests/client_proxies.rs
@@ -43,6 +43,7 @@ fn proxy_equals() {
         )
         .unwrap();
 
+    #[allow(clippy::redundant_clone)]
     let compositor3 = compositor1.clone();
 
     assert!(compositor1 == compositor3);
@@ -86,6 +87,7 @@ fn proxy_user_data() {
         )
         .unwrap();
 
+    #[allow(clippy::redundant_clone)]
     let compositor3 = compositor1.clone();
 
     assert!(compositor1.data::<usize>() == Some(&0xDEADBEEF));
@@ -122,6 +124,7 @@ fn dead_proxies() {
 
     roundtrip(&mut client, &mut server, &mut client_ddata, &mut server_ddata).unwrap();
 
+    #[allow(clippy::redundant_clone)]
     let output2 = output.clone();
 
     assert!(output == output2);


### PR DESCRIPTION
Apparently `pub extern crate` requires docs with the `missing_docs` lint and you can't use `#[allow(...)]` on it. So replacing it with `pub use` fixes this issue.

Also sprinkled some `#[allow(clippy::redundant_clone)]` until https://github.com/rust-lang/rust-clippy/pull/10873 reaches stable.