### PR TITLE
Bump `bitflags` to v2

### DIFF
--- a/wayland-client/CHANGELOG.md
+++ b/wayland-client/CHANGELOG.md
@@ -1,8 +1,12 @@
 # CHANGELOG: wayland-client
 
-## 0.30.2 -- 30/05/2023
-
 ## Unreleased
+
+#### Breaking changes
+
+- Bump bitflags to 2.0
+
+## 0.30.2 -- 30/05/2023
 
 - Updated Wayland core protocol to 1.22
 

--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -15,10 +15,10 @@ readme = "README.md"
 [dependencies]
 wayland-backend = { version = "0.1.0", path = "../wayland-backend" }
 wayland-scanner = { version = "0.30.0", path = "../wayland-scanner" }
-bitflags = "1.2"
+bitflags = "2"
 nix = { version = "0.26.0", default-features = false }
 log = { version = "0.4", optional = true }
-calloop = { version = "0.10.5", optional = true }
+calloop = { version = "0.10.6", optional = true }
 
 [dev-dependencies]
 wayland-protocols = { path = "../wayland-protocols", features = ["client"] }

--- a/wayland-protocols-misc/CHANGELOG.md
+++ b/wayland-protocols-misc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- Bump bitflags to 2.0
+
 ## 0.1.0 -- 27/12/2022
 
 ## 0.1.0-beta.5

--- a/wayland-protocols-misc/Cargo.toml
+++ b/wayland-protocols-misc/Cargo.toml
@@ -20,7 +20,7 @@ wayland-backend = { version = "0.1.0", path = "../wayland-backend" }
 wayland-client = { version = "0.30.0", path = "../wayland-client", optional = true }
 wayland-server = { version = "0.30.0", path = "../wayland-server", optional = true }
 wayland-protocols = { version = "0.30.0", path = "../wayland-protocols", features=["unstable"] }
-bitflags = "1.0"
+bitflags = "2"
 
 [features]
 client = ["wayland-client", "wayland-protocols/client"]

--- a/wayland-protocols-plasma/CHANGELOG.md
+++ b/wayland-protocols-plasma/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- Bump bitflags to 2.0
+
 ### Additions
 
 - Introduce protocol `kde-plasma-window-management`.

--- a/wayland-protocols-plasma/Cargo.toml
+++ b/wayland-protocols-plasma/Cargo.toml
@@ -20,7 +20,7 @@ wayland-backend = { version = "0.1.0", path = "../wayland-backend" }
 wayland-client = { version = "0.30.0", path = "../wayland-client", optional = true }
 wayland-server = { version = "0.30.0", path = "../wayland-server", optional = true }
 wayland-protocols = { version = "0.30.0", path = "../wayland-protocols"}
-bitflags = "1.0"
+bitflags = "2"
 
 [features]
 client = ["wayland-client", "wayland-protocols/client"]

--- a/wayland-protocols-wlr/CHANGELOG.md
+++ b/wayland-protocols-wlr/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- Bump bitflags to 2.0
+
 ## 0.1.0 -- 27/12/2022
 
 ## 0.1.0-beta.14

--- a/wayland-protocols-wlr/Cargo.toml
+++ b/wayland-protocols-wlr/Cargo.toml
@@ -20,7 +20,7 @@ wayland-backend = { version = "0.1.0", path = "../wayland-backend" }
 wayland-client = { version = "0.30.0", path = "../wayland-client", optional = true }
 wayland-server = { version = "0.30.0", path = "../wayland-server", optional = true }
 wayland-protocols = { version = "0.30.0", path = "../wayland-protocols"}
-bitflags = "1.0"
+bitflags = "2"
 
 [features]
 client = ["wayland-client", "wayland-protocols/client"]

--- a/wayland-protocols/CHANGELOG.md
+++ b/wayland-protocols/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- Bump bitflags to 2.0
+
 ## 0.30.0 -- 27/12/2022
 
 ## 0.30.0-beta.15

--- a/wayland-protocols/Cargo.toml
+++ b/wayland-protocols/Cargo.toml
@@ -17,7 +17,7 @@ wayland-scanner = { version = "0.30.0", path = "../wayland-scanner" }
 wayland-backend = { version = "0.1.0", path = "../wayland-backend" }
 wayland-client = { version = "0.30.0", path = "../wayland-client", optional = true }
 wayland-server = { version = "0.30.0", path = "../wayland-server", optional = true }
-bitflags = "1.0"
+bitflags = "2"
 
 [features]
 client = ["wayland-client"]

--- a/wayland-scanner/CHANGELOG.md
+++ b/wayland-scanner/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Generated protocol object types now implement `Borrow<ObjectId>` and `Hash`
 
+#### Breaking changes
+
+- Bump bitflags to 2.0
+
 ## 0.30.0 -- 27/12/2022
 
 ## 0.30.0-beta.10

--- a/wayland-scanner/src/common.rs
+++ b/wayland-scanner/src/common.rs
@@ -40,6 +40,7 @@ impl ToTokens for Enum {
             enum_decl = quote! {
                 bitflags::bitflags! {
                     #doc_attr
+                    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
                     pub struct #ident: u32 {
                         #(#entries)*
                     }

--- a/wayland-server/CHANGELOG.md
+++ b/wayland-server/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### Breaking changes
+
+- Bump bitflags to 2.0
+
 ## 0.30.1 -- 30/05/2023
 
 - `New` objects inside `GlobalDispatch` can now have errors posted using `DataInit::post_error`.

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 [dependencies]
 wayland-backend = { version = "0.1.0", path = "../wayland-backend" }
 wayland-scanner = { version = "0.30.0", path = "../wayland-scanner" }
-bitflags = "1.2"
+bitflags = "2"
 log = { version = "0.4", optional = true }
 nix = { version = "0.26.0", default-features = false }
 downcast-rs = "1.2"


### PR DESCRIPTION
Changelog: https://github.com/bitflags/bitflags/blob/2.0.0/CHANGELOG.md#200.

This is a breaking change. The API that is implemented by the macro is now different.

We didn't really have to derive anything apart from `Debug` to make it work, but considering this is public I derived all other traits as well except `PartialOrd`, `Ord` and `Default`.

Fixes #622.