### PR TITLE
server: Verify that .lock fd matches on-disk file

### DIFF
--- a/wayland-server/CHANGELOG.md
+++ b/wayland-server/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed a lockfile race condition in `ListeningSocket`.
+
 ## 0.30.1 -- 30/05/2023
 
 - `New` objects inside `GlobalDispatch` can now have errors posted using `DataInit::post_error`.


### PR DESCRIPTION
Fixes a race condition that can happen if one thread unlinks the .lock between our open() and flock() calls.