### PR TITLE
server: Add `flush` to `DisplayHandle`, and implement `AsFd` for `Display`, for use in smithay

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `flush` method to server `Handle`.
+
 ## 0.2.0 -- 2023-07-13
 
 #### Breaking changes

--- a/wayland-backend/src/rs/server_impl/handle.rs
+++ b/wayland-backend/src/rs/server_impl/handle.rs
@@ -259,6 +259,10 @@ impl InnerHandle {
             .expect("Wrong type parameter passed to Handle::get_global_handler().");
         state.registry.get_handler(id)
     }
+
+    pub fn flush(&mut self, client: Option<ClientId>) -> std::io::Result<()> {
+        self.state.lock().unwrap().flush(client)
+    }
 }
 
 pub(crate) trait ErasedState: downcast_rs::Downcast {
@@ -291,6 +295,7 @@ pub(crate) trait ErasedState: downcast_rs::Downcast {
     fn post_error(&mut self, object_id: InnerObjectId, error_code: u32, message: CString);
     fn kill_client(&mut self, client_id: InnerClientId, reason: DisconnectReason);
     fn global_info(&self, id: InnerGlobalId) -> Result<GlobalInfo, InvalidId>;
+    fn flush(&mut self, client: Option<ClientId>) -> std::io::Result<()>;
 }
 
 downcast_rs::impl_downcast!(ErasedState);
@@ -425,5 +430,9 @@ impl<D> ErasedState for State<D> {
     }
     fn global_info(&self, id: InnerGlobalId) -> Result<GlobalInfo, InvalidId> {
         self.registry.get_info(id)
+    }
+
+    fn flush(&mut self, client: Option<ClientId>) -> std::io::Result<()> {
+        self.flush(client)
     }
 }

--- a/wayland-backend/src/server_api.rs
+++ b/wayland-backend/src/server_api.rs
@@ -480,6 +480,13 @@ impl Handle {
     ) -> Result<Arc<dyn GlobalHandler<D>>, InvalidId> {
         self.handle.get_global_handler(id.id)
     }
+
+    /// Flushes pending events destined for a client.
+    ///
+    /// If no client is specified, all pending events are flushed to all clients.
+    pub fn flush(&mut self, client: Option<ClientId>) -> std::io::Result<()> {
+        self.handle.flush(client)
+    }
 }
 
 /// A backend object that represents the state of a wayland server.

--- a/wayland-server/CHANGELOG.md
+++ b/wayland-server/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `flush_clients` method to server `DisplayHandle`.
+- Implement `AsFd` for `Display` so it can easily be used in a `calloop` source.
 
 #### Breaking changes
 

--- a/wayland-server/CHANGELOG.md
+++ b/wayland-server/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `flush_clients` method to server `DisplayHandle`.
+
 #### Breaking changes
 
 - Bump bitflags to 2.0

--- a/wayland-server/src/display.rs
+++ b/wayland-server/src/display.rs
@@ -1,6 +1,7 @@
 use std::{os::unix::net::UnixStream, sync::Arc};
 
 use wayland_backend::{
+    io_lifetimes::{AsFd, BorrowedFd},
     protocol::ObjectInfo,
     server::{Backend, ClientData, GlobalId, Handle, InitError, InvalidId, ObjectId},
 };
@@ -63,6 +64,13 @@ impl<State: 'static> Display<State> {
     /// Access the underlying [`Backend`] of this [`Display`]
     pub fn backend(&mut self) -> &mut Backend<State> {
         &mut self.backend
+    }
+}
+
+impl<State> AsFd for Display<State> {
+    /// Provides fd from [`Backend::poll_fd`] for polling.
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.backend.poll_fd()
     }
 }
 

--- a/wayland-server/src/display.rs
+++ b/wayland-server/src/display.rs
@@ -184,6 +184,11 @@ impl DisplayHandle {
     ) -> Result<Arc<dyn std::any::Any + Send + Sync + 'static>, InvalidId> {
         self.handle.get_object_data_any(id)
     }
+
+    /// Flush outgoing buffers into their respective sockets.
+    pub fn flush_clients(&mut self) -> std::io::Result<()> {
+        self.handle.flush(None)
+    }
 }
 
 impl From<Handle> for DisplayHandle {


### PR DESCRIPTION
This makes it easy to use `wayland_server::Display` with `calloop` 0.11 without hacking around IO safety.

If these solutions don't seem ideal for any reason, there may be alternatives. But some change is needed.