### PR TITLE
Prefer sonames when loading dynamic libraries

### DIFF
--- a/wayland-sys/src/client.rs
+++ b/wayland-sys/src/client.rs
@@ -88,14 +88,7 @@ external_library!(WaylandClient, "wayland-client",
 #[cfg(all(feature = "client", feature = "dlopen"))]
 pub fn wayland_client_option() -> Option<&'static WaylandClient> {
     static WAYLAND_CLIENT_OPTION: Lazy<Option<WaylandClient>> = Lazy::new(||{
-        // This is a workaround for Ubuntu 17.04, which doesn't have a bare symlink
-        // for libwayland-client.so but does have it with the version numbers for
-        // whatever reason.
-        //
-        // We could do some trickery with str slices but that is more trouble
-        // than its worth
-        let versions = ["libwayland-client.so",
-                        "libwayland-client.so.0"];
+        let versions = ["libwayland-client.so.0", "libwayland-client.so"];
         for ver in &versions {
             match unsafe { WaylandClient::open(ver) } {
                 Ok(h) => return Some(h),

--- a/wayland-sys/src/cursor.rs
+++ b/wayland-sys/src/cursor.rs
@@ -43,13 +43,7 @@ external_library!(WaylandCursor, "wayland-cursor",
 #[cfg(feature = "dlopen")]
 pub fn wayland_cursor_option() -> Option<&'static WaylandCursor> {
     static WAYLAND_CURSOR_OPTION: Lazy<Option<WaylandCursor>> = Lazy::new(|| {
-        // This is a workaround for Ubuntu 17.04, which doesn't have a bare symlink
-        // for libwayland-client.so but does have it with the version numbers for
-        // whatever reason.
-        //
-        // We could do some trickery with str slices but that is more trouble
-        // than its worth
-        let versions = ["libwayland-cursor.so", "libwayland-cursor.so.0"];
+        let versions = ["libwayland-cursor.so.0", "libwayland-cursor.so"];
 
         for ver in &versions {
             match unsafe { WaylandCursor::open(ver) } {

--- a/wayland-sys/src/egl.rs
+++ b/wayland-sys/src/egl.rs
@@ -22,13 +22,7 @@ external_library!(WaylandEgl, "wayland-egl",
 #[cfg(feature = "dlopen")]
 pub fn wayland_egl_option() -> Option<&'static WaylandEgl> {
     static WAYLAND_EGL_OPTION: Lazy<Option<WaylandEgl>> = Lazy::new(|| {
-        // This is a workaround for Ubuntu 17.04, which doesn't have a bare symlink
-        // for libwayland-client.so but does have it with the version numbers for
-        // whatever reason.
-        //
-        // We could do some trickery with str slices but that is more trouble
-        // than its worth
-        let versions = ["libwayland-egl.so", "libwayland-egl.so.1"];
+        let versions = ["libwayland-egl.so.1", "libwayland-egl.so"];
 
         for ver in &versions {
             match unsafe { WaylandEgl::open(ver) } {

--- a/wayland-sys/src/server.rs
+++ b/wayland-sys/src/server.rs
@@ -156,14 +156,7 @@ external_library!(WaylandServer, "wayland-server",
 #[cfg(all(feature = "server", feature = "dlopen"))]
 pub fn wayland_server_option() -> Option<&'static WaylandServer> {
     static WAYLAND_SERVER_OPTION: Lazy<Option<WaylandServer>> = Lazy::new(||{
-        // This is a workaround for Ubuntu 17.04, which doesn't have a bare symlink
-        // for libwayland-server.so but does have it with the version numbers for
-        // whatever reason.
-        //
-        // We could do some trickery with str slices but that is more trouble
-        // than its worth
-        let versions = ["libwayland-server.so",
-                        "libwayland-server.so.0"];
+        let versions = ["libwayland-server.so.0", "libwayland-server.so"];
         for ver in &versions {
             match unsafe { WaylandServer::open(ver) } {
                 Ok(h) => return Some(h),


### PR DESCRIPTION
The standard practice for loading dynamic libraries is to use `sonames`, versioned `.so` files. That way you ensure that the `.so` file contains the expected API, and not another version with possibly breaking changes. Therefore, the soname version should be tried first, and only then as a backup the unversioned `.so` file.

Doing so is not a workaround for Ubuntu, like the comments suggest, virtually all Linux distributions use sonames, so those comments have also been removed.

For me this order caused problems when making a Snap package for Neovide, using the classic confinement. On Ubuntu and also in Snaps, the unversioned `.so` file is only installed if you install the developer packages, so the Snap does not include those. Therefore the `.so` file is not found and loaded from the host instead, despite the fact that the correct file is included in the Snap. Note that a similar change also had to be done for https://github.com/rust-windowing/xkbcommon-dl/pull/16.

It would be great if a patch release could be released with these changes, so that I can continue working on the Neovide Snap properly.