### PR TITLE
Replace io-lifetimes with std::os::fd

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The documentation for the releases can be found on [docs.rs](https://docs.rs/):
 
 ## Requirements
 
-Requires at least rust 1.59.0 to be used, and version 1.15 of the wayland system libraries if using the
+Requires at least rust 1.63.0 to be used, and version 1.15 of the wayland system libraries if using the
 system backend.
 
 ## Chat and support

--- a/wayland-backend/Cargo.toml
+++ b/wayland-backend/Cargo.toml
@@ -18,7 +18,7 @@ wayland-sys = { version = "0.31.0", path = "../wayland-sys", features = [] }
 log = { version = "0.4", optional = true }
 scoped-tls = "1.0"
 downcast-rs = "1.2"
-io-lifetimes = "1.0.0"
+io-lifetimes = "2"
 raw-window-handle = { version = "0.5.0", optional = true }
 
 [dependencies.smallvec]

--- a/wayland-backend/src/client_api.rs
+++ b/wayland-backend/src/client_api.rs
@@ -1,11 +1,10 @@
 use std::{
     any::Any,
     fmt,
+    os::fd::{BorrowedFd, OwnedFd},
     os::unix::{io::RawFd, net::UnixStream},
     sync::Arc,
 };
-
-use io_lifetimes::{BorrowedFd, OwnedFd};
 
 use crate::protocol::{Interface, Message, ObjectInfo};
 

--- a/wayland-backend/src/rs/client_impl/mod.rs
+++ b/wayland-backend/src/rs/client_impl/mod.rs
@@ -2,6 +2,7 @@
 
 use std::{
     fmt,
+    os::fd::{BorrowedFd, OwnedFd},
     os::unix::{
         io::{AsRawFd, RawFd},
         net::UnixStream,
@@ -17,7 +18,6 @@ use crate::{
         INLINE_ARGS,
     },
 };
-use io_lifetimes::{BorrowedFd, OwnedFd};
 use smallvec::SmallVec;
 
 use super::{

--- a/wayland-backend/src/rs/server_impl/client.rs
+++ b/wayland-backend/src/rs/server_impl/client.rs
@@ -1,5 +1,6 @@
 use std::{
     ffi::CString,
+    os::fd::OwnedFd,
     os::unix::{io::RawFd, net::UnixStream},
     sync::Arc,
 };
@@ -15,7 +16,6 @@ use crate::{
     types::server::{DisconnectReason, InvalidId},
 };
 
-use io_lifetimes::OwnedFd;
 use smallvec::SmallVec;
 
 use crate::rs::{

--- a/wayland-backend/src/rs/server_impl/common_poll.rs
+++ b/wayland-backend/src/rs/server_impl/common_poll.rs
@@ -1,4 +1,5 @@
 use std::{
+    os::fd::{BorrowedFd, OwnedFd},
     os::unix::io::{AsRawFd, FromRawFd},
     sync::{Arc, Mutex},
 };
@@ -14,7 +15,6 @@ use crate::{
     types::server::InitError,
 };
 
-use io_lifetimes::{BorrowedFd, OwnedFd};
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use nix::sys::epoll::*;
 

--- a/wayland-backend/src/rs/server_impl/handle.rs
+++ b/wayland-backend/src/rs/server_impl/handle.rs
@@ -1,13 +1,12 @@
 use std::{
     ffi::CString,
+    os::fd::OwnedFd,
     os::unix::{
         io::{AsRawFd, RawFd},
         net::UnixStream,
     },
     sync::{Arc, Mutex, Weak},
 };
-
-use io_lifetimes::OwnedFd;
 
 use crate::{
     protocol::{same_interface, Interface, Message, ObjectInfo, ANONYMOUS_INTERFACE},

--- a/wayland-backend/src/rs/server_impl/mod.rs
+++ b/wayland-backend/src/rs/server_impl/mod.rs
@@ -1,5 +1,6 @@
 //! Server-side rust implementation of a Wayland protocol backend
 
+use std::os::fd::OwnedFd;
 use std::{fmt, sync::Arc};
 
 use crate::protocol::{same_interface, Interface, Message};
@@ -12,7 +13,6 @@ mod registry;
 pub use crate::types::server::{Credentials, DisconnectReason, GlobalInfo, InitError, InvalidId};
 pub use common_poll::InnerBackend;
 pub use handle::{InnerHandle, WeakInnerHandle};
-use io_lifetimes::OwnedFd;
 
 use super::server::*;
 

--- a/wayland-backend/src/rs/socket.rs
+++ b/wayland-backend/src/rs/socket.rs
@@ -1,10 +1,10 @@
 //! Wayland socket manipulation
 
 use std::io::{ErrorKind, IoSlice, IoSliceMut, Result as IoResult};
+use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::os::unix::net::UnixStream;
 
-use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 use nix::sys::socket;
 
 use crate::protocol::{ArgumentType, Message};

--- a/wayland-backend/src/rs/wire.rs
+++ b/wayland-backend/src/rs/wire.rs
@@ -1,10 +1,9 @@
 //! Types and routines used to manipulate arguments from the wire format
 
+use std::os::fd::{BorrowedFd, OwnedFd};
 use std::os::unix::io::{FromRawFd, RawFd};
 use std::ptr;
 use std::{ffi::CStr, os::unix::prelude::AsRawFd};
-
-use io_lifetimes::{BorrowedFd, OwnedFd};
 
 use crate::protocol::{Argument, ArgumentType, Message};
 

--- a/wayland-backend/src/server_api.rs
+++ b/wayland-backend/src/server_api.rs
@@ -1,11 +1,10 @@
 use std::{
     ffi::CString,
     fmt,
+    os::fd::{BorrowedFd, OwnedFd},
     os::unix::{io::RawFd, net::UnixStream},
     sync::Arc,
 };
-
-use io_lifetimes::{BorrowedFd, OwnedFd};
 
 use crate::protocol::{Interface, Message, ObjectInfo};
 pub use crate::types::server::{Credentials, DisconnectReason, GlobalInfo, InitError, InvalidId};

--- a/wayland-backend/src/sys/client_impl/mod.rs
+++ b/wayland-backend/src/sys/client_impl/mod.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::HashSet,
     ffi::CStr,
+    os::fd::{BorrowedFd, OwnedFd},
     os::raw::{c_int, c_void},
     os::unix::{
         io::{FromRawFd, IntoRawFd, RawFd},
@@ -21,7 +22,6 @@ use crate::{
         ObjectInfo, ProtocolError, ANONYMOUS_INTERFACE,
     },
 };
-use io_lifetimes::{BorrowedFd, OwnedFd};
 use scoped_tls::scoped_thread_local;
 use smallvec::SmallVec;
 

--- a/wayland-backend/src/sys/server_impl/mod.rs
+++ b/wayland-backend/src/sys/server_impl/mod.rs
@@ -2,6 +2,7 @@
 
 use std::{
     ffi::{CStr, CString},
+    os::fd::{BorrowedFd, OwnedFd},
     os::raw::{c_int, c_void},
     os::unix::{
         io::{FromRawFd, IntoRawFd, RawFd},
@@ -17,7 +18,6 @@ use crate::protocol::{
     check_for_signature, same_interface, AllowNull, Argument, ArgumentType, Interface, Message,
     ObjectInfo, ANONYMOUS_INTERFACE,
 };
-use io_lifetimes::{BorrowedFd, OwnedFd};
 use scoped_tls::scoped_thread_local;
 use smallvec::SmallVec;
 

--- a/wayland-backend/src/test/mod.rs
+++ b/wayland-backend/src/test/mod.rs
@@ -1,8 +1,7 @@
 #![allow(dead_code, non_snake_case)]
 
+use std::os::fd::OwnedFd;
 use std::sync::Arc;
-
-use io_lifetimes::OwnedFd;
 
 use crate::protocol::{Argument, Message};
 

--- a/wayland-client/src/conn.rs
+++ b/wayland-client/src/conn.rs
@@ -1,6 +1,7 @@
 use std::{
     env, fmt,
     io::ErrorKind,
+    os::fd::OwnedFd,
     os::unix::net::UnixStream,
     os::unix::prelude::{AsRawFd, FromRawFd},
     path::PathBuf,
@@ -12,7 +13,6 @@ use std::{
 
 use wayland_backend::{
     client::{Backend, InvalidId, ObjectData, ObjectId, ReadEventsGuard, WaylandError},
-    io_lifetimes::OwnedFd,
     protocol::{ObjectInfo, ProtocolError},
 };
 

--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -2,13 +2,13 @@ use std::any::Any;
 use std::collections::VecDeque;
 use std::convert::Infallible;
 use std::marker::PhantomData;
+use std::os::fd::OwnedFd;
 use std::sync::{atomic::Ordering, Arc, Condvar, Mutex};
 use std::task;
 
 use nix::Error;
 use wayland_backend::{
     client::{Backend, ObjectData, ObjectId, ReadEventsGuard, WaylandError},
-    io_lifetimes::OwnedFd,
     protocol::{Argument, Message},
 };
 

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -55,6 +55,7 @@
 use std::{
     fmt,
     ops::RangeInclusive,
+    os::fd::OwnedFd,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,
@@ -63,7 +64,6 @@ use std::{
 
 use wayland_backend::{
     client::{Backend, InvalidId, ObjectData, ObjectId, WaylandError},
-    io_lifetimes::OwnedFd,
     protocol::Message,
 };
 

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -169,12 +169,12 @@
 use std::{
     fmt,
     hash::{Hash, Hasher},
+    os::fd::OwnedFd,
     os::unix::io::RawFd,
     sync::Arc,
 };
 use wayland_backend::{
     client::{InvalidId, ObjectData, ObjectId, WaylandError, WeakBackend},
-    io_lifetimes::OwnedFd,
     protocol::{Interface, Message},
 };
 

--- a/wayland-cursor/src/lib.rs
+++ b/wayland-cursor/src/lib.rs
@@ -49,6 +49,7 @@ use std::env;
 use std::fs::File;
 use std::io::{Error as IoError, Read, Result as IoResult, Seek, SeekFrom, Write};
 use std::ops::{Deref, Index};
+use std::os::fd::OwnedFd;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -60,7 +61,6 @@ use nix::unistd;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use {nix::sys::memfd, std::ffi::CStr};
 
-use wayland_client::backend::io_lifetimes::OwnedFd;
 use wayland_client::backend::{InvalidId, ObjectData, WeakBackend};
 use wayland_client::protocol::wl_buffer::WlBuffer;
 use wayland_client::protocol::wl_shm::{self, Format, WlShm};

--- a/wayland-scanner/src/client_gen.rs
+++ b/wayland-scanner/src/client_gen.rs
@@ -53,10 +53,11 @@ fn generate_objects_for(interface: &Interface) -> TokenStream {
         #mod_doc
         pub mod #mod_name {
             use std::sync::Arc;
+            use std::os::fd::OwnedFd;
 
             use super::wayland_client::{
                 backend::{
-                    Backend, WeakBackend, smallvec, ObjectData, ObjectId, InvalidId, io_lifetimes,
+                    Backend, WeakBackend, smallvec, ObjectData, ObjectId, InvalidId,
                     protocol::{WEnum, Argument, Message, Interface, same_interface}
                 },
                 QueueProxyData, Proxy, Connection, Dispatch, QueueHandle, DispatchError, Weak,
@@ -163,7 +164,7 @@ fn generate_objects_for(interface: &Interface) -> TokenStream {
                     #iface_name { id: ObjectId::null(), data: None, version: 0, backend }
                 }
 
-                fn parse_event(conn: &Connection, msg: Message<ObjectId, io_lifetimes::OwnedFd>) -> Result<(Self, Self::Event), DispatchError> {
+                fn parse_event(conn: &Connection, msg: Message<ObjectId, OwnedFd>) -> Result<(Self, Self::Event), DispatchError> {
                     #parse_body
                 }
 

--- a/wayland-scanner/src/common.rs
+++ b/wayland-scanner/src/common.rs
@@ -197,7 +197,7 @@ pub(crate) fn gen_message_enum(
                         Type::Array => quote! { Vec<u8> },
                         Type::Fd => {
                             if receiver {
-                                quote! { io_lifetimes::OwnedFd }
+                                quote! { OwnedFd }
                             } else {
                                 quote! { std::os::unix::io::RawFd }
                             }

--- a/wayland-scanner/src/server_gen.rs
+++ b/wayland-scanner/src/server_gen.rs
@@ -58,10 +58,11 @@ fn generate_objects_for(interface: &Interface) -> TokenStream {
         #mod_doc
         pub mod #mod_name {
             use std::sync::Arc;
+            use std::os::fd::OwnedFd;
 
             use super::wayland_server::{
                 backend::{
-                    smallvec, ObjectData, ObjectId, InvalidId, io_lifetimes, WeakHandle,
+                    smallvec, ObjectData, ObjectId, InvalidId, WeakHandle,
                     protocol::{WEnum, Argument, Message, Interface, same_interface}
                 },
                 Resource, Dispatch, DisplayHandle, DispatchError, ResourceData, New, Weak,
@@ -155,7 +156,7 @@ fn generate_objects_for(interface: &Interface) -> TokenStream {
                     handle.send_event(self, evt)
                 }
 
-                fn parse_request(conn: &DisplayHandle, msg: Message<ObjectId, io_lifetimes::OwnedFd>) -> Result<(Self, Self::Request), DispatchError> {
+                fn parse_request(conn: &DisplayHandle, msg: Message<ObjectId, OwnedFd>) -> Result<(Self, Self::Request), DispatchError> {
                     #parse_body
                 }
 

--- a/wayland-scanner/tests/scanner_assets/test-client-code.rs
+++ b/wayland-scanner/tests/scanner_assets/test-client-code.rs
@@ -2,13 +2,13 @@
 pub mod wl_display {
     use super::wayland_client::{
         backend::{
-            io_lifetimes,
             protocol::{same_interface, Argument, Interface, Message, WEnum},
             smallvec, Backend, InvalidId, ObjectData, ObjectId, WeakBackend,
         },
         Connection, Dispatch, DispatchError, Proxy, QueueHandle, QueueProxyData, Weak,
     };
     use std::sync::Arc;
+    use std::os::fd::OwnedFd;
     #[doc = "global error values\n\nThese errors are global and can be emitted in response to any\nserver request."]
     #[repr(u32)]
     #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -185,7 +185,7 @@ pub mod wl_display {
         }
         fn parse_event(
             conn: &Connection,
-            msg: Message<ObjectId, io_lifetimes::OwnedFd>,
+            msg: Message<ObjectId, OwnedFd>,
         ) -> Result<(Self, Self::Event), DispatchError> {
             let me = Self::from_id(conn, msg.sender_id.clone()).unwrap();
             let mut arg_iter = msg.args.into_iter();
@@ -309,13 +309,13 @@ pub mod wl_display {
 pub mod wl_registry {
     use super::wayland_client::{
         backend::{
-            io_lifetimes,
             protocol::{same_interface, Argument, Interface, Message, WEnum},
             smallvec, Backend, InvalidId, ObjectData, ObjectId, WeakBackend,
         },
         Connection, Dispatch, DispatchError, Proxy, QueueHandle, QueueProxyData, Weak,
     };
     use std::sync::Arc;
+    use std::os::fd::OwnedFd;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_BIND_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this request"]
@@ -459,7 +459,7 @@ pub mod wl_registry {
         }
         fn parse_event(
             conn: &Connection,
-            msg: Message<ObjectId, io_lifetimes::OwnedFd>,
+            msg: Message<ObjectId, OwnedFd>,
         ) -> Result<(Self, Self::Event), DispatchError> {
             let me = Self::from_id(conn, msg.sender_id.clone()).unwrap();
             let mut arg_iter = msg.args.into_iter();
@@ -556,13 +556,13 @@ pub mod wl_registry {
 pub mod wl_callback {
     use super::wayland_client::{
         backend::{
-            io_lifetimes,
             protocol::{same_interface, Argument, Interface, Message, WEnum},
             smallvec, Backend, InvalidId, ObjectData, ObjectId, WeakBackend,
         },
         Connection, Dispatch, DispatchError, Proxy, QueueHandle, QueueProxyData, Weak,
     };
     use std::sync::Arc;
+    use std::os::fd::OwnedFd;
     #[doc = r" The minimal object version supporting this event"]
     pub const EVT_DONE_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this event"]
@@ -678,7 +678,7 @@ pub mod wl_callback {
         }
         fn parse_event(
             conn: &Connection,
-            msg: Message<ObjectId, io_lifetimes::OwnedFd>,
+            msg: Message<ObjectId, OwnedFd>,
         ) -> Result<(Self, Self::Event), DispatchError> {
             let me = Self::from_id(conn, msg.sender_id.clone()).unwrap();
             let mut arg_iter = msg.args.into_iter();
@@ -717,13 +717,13 @@ pub mod wl_callback {
 pub mod test_global {
     use super::wayland_client::{
         backend::{
-            io_lifetimes,
             protocol::{same_interface, Argument, Interface, Message, WEnum},
             smallvec, Backend, InvalidId, ObjectData, ObjectId, WeakBackend,
         },
         Connection, Dispatch, DispatchError, Proxy, QueueHandle, QueueProxyData, Weak,
     };
     use std::sync::Arc;
+    use std::os::fd::OwnedFd;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_MANY_ARGS_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this request"]
@@ -828,7 +828,7 @@ pub mod test_global {
             #[doc = "some text"]
             some_text: String,
             #[doc = "a file descriptor"]
-            file_descriptor: io_lifetimes::OwnedFd,
+            file_descriptor: OwnedFd,
         },
         #[doc = "acking the creation of a secondary"]
         AckSecondary { sec: super::secondary::Secondary },
@@ -930,7 +930,7 @@ pub mod test_global {
         }
         fn parse_event(
             conn: &Connection,
-            msg: Message<ObjectId, io_lifetimes::OwnedFd>,
+            msg: Message<ObjectId, OwnedFd>,
         ) -> Result<(Self, Self::Event), DispatchError> {
             let me = Self::from_id(conn, msg.sender_id.clone()).unwrap();
             let mut arg_iter = msg.args.into_iter();
@@ -1293,13 +1293,13 @@ pub mod test_global {
 pub mod secondary {
     use super::wayland_client::{
         backend::{
-            io_lifetimes,
             protocol::{same_interface, Argument, Interface, Message, WEnum},
             smallvec, Backend, InvalidId, ObjectData, ObjectId, WeakBackend,
         },
         Connection, Dispatch, DispatchError, Proxy, QueueHandle, QueueProxyData, Weak,
     };
     use std::sync::Arc;
+    use std::os::fd::OwnedFd;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 2u32;
     #[doc = r" The wire opcode for this request"]
@@ -1412,7 +1412,7 @@ pub mod secondary {
         }
         fn parse_event(
             conn: &Connection,
-            msg: Message<ObjectId, io_lifetimes::OwnedFd>,
+            msg: Message<ObjectId, OwnedFd>,
         ) -> Result<(Self, Self::Event), DispatchError> {
             let me = Self::from_id(conn, msg.sender_id.clone()).unwrap();
             let mut arg_iter = msg.args.into_iter();
@@ -1456,13 +1456,13 @@ pub mod secondary {
 pub mod tertiary {
     use super::wayland_client::{
         backend::{
-            io_lifetimes,
             protocol::{same_interface, Argument, Interface, Message, WEnum},
             smallvec, Backend, InvalidId, ObjectData, ObjectId, WeakBackend,
         },
         Connection, Dispatch, DispatchError, Proxy, QueueHandle, QueueProxyData, Weak,
     };
     use std::sync::Arc;
+    use std::os::fd::OwnedFd;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 3u32;
     #[doc = r" The wire opcode for this request"]
@@ -1575,7 +1575,7 @@ pub mod tertiary {
         }
         fn parse_event(
             conn: &Connection,
-            msg: Message<ObjectId, io_lifetimes::OwnedFd>,
+            msg: Message<ObjectId, OwnedFd>,
         ) -> Result<(Self, Self::Event), DispatchError> {
             let me = Self::from_id(conn, msg.sender_id.clone()).unwrap();
             let mut arg_iter = msg.args.into_iter();
@@ -1619,13 +1619,13 @@ pub mod tertiary {
 pub mod quad {
     use super::wayland_client::{
         backend::{
-            io_lifetimes,
             protocol::{same_interface, Argument, Interface, Message, WEnum},
             smallvec, Backend, InvalidId, ObjectData, ObjectId, WeakBackend,
         },
         Connection, Dispatch, DispatchError, Proxy, QueueHandle, QueueProxyData, Weak,
     };
     use std::sync::Arc;
+    use std::os::fd::OwnedFd;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 3u32;
     #[doc = r" The wire opcode for this request"]
@@ -1738,7 +1738,7 @@ pub mod quad {
         }
         fn parse_event(
             conn: &Connection,
-            msg: Message<ObjectId, io_lifetimes::OwnedFd>,
+            msg: Message<ObjectId, OwnedFd>,
         ) -> Result<(Self, Self::Event), DispatchError> {
             let me = Self::from_id(conn, msg.sender_id.clone()).unwrap();
             let mut arg_iter = msg.args.into_iter();

--- a/wayland-scanner/tests/scanner_assets/test-server-code.rs
+++ b/wayland-scanner/tests/scanner_assets/test-server-code.rs
@@ -2,13 +2,13 @@
 pub mod wl_callback {
     use super::wayland_server::{
         backend::{
-            io_lifetimes,
             protocol::{same_interface, Argument, Interface, Message, WEnum},
             smallvec, InvalidId, ObjectData, ObjectId, WeakHandle,
         },
         Dispatch, DispatchError, DisplayHandle, New, Resource, ResourceData, Weak,
     };
     use std::sync::Arc;
+    use std::os::fd::OwnedFd;
     #[doc = r" The minimal object version supporting this event"]
     pub const EVT_DONE_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this event"]
@@ -112,7 +112,7 @@ pub mod wl_callback {
         }
         fn parse_request(
             conn: &DisplayHandle,
-            msg: Message<ObjectId, io_lifetimes::OwnedFd>,
+            msg: Message<ObjectId, OwnedFd>,
         ) -> Result<(Self, Self::Request), DispatchError> {
             let me = Self::from_id(conn, msg.sender_id.clone()).unwrap();
             let mut arg_iter = msg.args.into_iter();
@@ -159,13 +159,13 @@ pub mod wl_callback {
 pub mod test_global {
     use super::wayland_server::{
         backend::{
-            io_lifetimes,
             protocol::{same_interface, Argument, Interface, Message, WEnum},
             smallvec, InvalidId, ObjectData, ObjectId, WeakHandle,
         },
         Dispatch, DispatchError, DisplayHandle, New, Resource, ResourceData, Weak,
     };
     use std::sync::Arc;
+    use std::os::fd::OwnedFd;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_MANY_ARGS_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this request"]
@@ -222,7 +222,7 @@ pub mod test_global {
             #[doc = "some text"]
             some_text: String,
             #[doc = "a file descriptor"]
-            file_descriptor: io_lifetimes::OwnedFd,
+            file_descriptor: OwnedFd,
         },
         #[doc = "Only available since version 2 of the interface"]
         GetSecondary {
@@ -367,7 +367,7 @@ pub mod test_global {
         }
         fn parse_request(
             conn: &DisplayHandle,
-            msg: Message<ObjectId, io_lifetimes::OwnedFd>,
+            msg: Message<ObjectId, OwnedFd>,
         ) -> Result<(Self, Self::Request), DispatchError> {
             let me = Self::from_id(conn, msg.sender_id.clone()).unwrap();
             let mut arg_iter = msg.args.into_iter();
@@ -757,13 +757,13 @@ pub mod test_global {
 pub mod secondary {
     use super::wayland_server::{
         backend::{
-            io_lifetimes,
             protocol::{same_interface, Argument, Interface, Message, WEnum},
             smallvec, InvalidId, ObjectData, ObjectId, WeakHandle,
         },
         Dispatch, DispatchError, DisplayHandle, New, Resource, ResourceData, Weak,
     };
     use std::sync::Arc;
+    use std::os::fd::OwnedFd;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 2u32;
     #[doc = r" The wire opcode for this request"]
@@ -864,7 +864,7 @@ pub mod secondary {
         }
         fn parse_request(
             conn: &DisplayHandle,
-            msg: Message<ObjectId, io_lifetimes::OwnedFd>,
+            msg: Message<ObjectId, OwnedFd>,
         ) -> Result<(Self, Self::Request), DispatchError> {
             let me = Self::from_id(conn, msg.sender_id.clone()).unwrap();
             let mut arg_iter = msg.args.into_iter();
@@ -906,13 +906,13 @@ pub mod secondary {
 pub mod tertiary {
     use super::wayland_server::{
         backend::{
-            io_lifetimes,
             protocol::{same_interface, Argument, Interface, Message, WEnum},
             smallvec, InvalidId, ObjectData, ObjectId, WeakHandle,
         },
         Dispatch, DispatchError, DisplayHandle, New, Resource, ResourceData, Weak,
     };
     use std::sync::Arc;
+    use std::os::fd::OwnedFd;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 3u32;
     #[doc = r" The wire opcode for this request"]
@@ -1013,7 +1013,7 @@ pub mod tertiary {
         }
         fn parse_request(
             conn: &DisplayHandle,
-            msg: Message<ObjectId, io_lifetimes::OwnedFd>,
+            msg: Message<ObjectId, OwnedFd>,
         ) -> Result<(Self, Self::Request), DispatchError> {
             let me = Self::from_id(conn, msg.sender_id.clone()).unwrap();
             let mut arg_iter = msg.args.into_iter();
@@ -1055,13 +1055,13 @@ pub mod tertiary {
 pub mod quad {
     use super::wayland_server::{
         backend::{
-            io_lifetimes,
             protocol::{same_interface, Argument, Interface, Message, WEnum},
             smallvec, InvalidId, ObjectData, ObjectId, WeakHandle,
         },
         Dispatch, DispatchError, DisplayHandle, New, Resource, ResourceData, Weak,
     };
     use std::sync::Arc;
+    use std::os::fd::OwnedFd;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 3u32;
     #[doc = r" The wire opcode for this request"]
@@ -1162,7 +1162,7 @@ pub mod quad {
         }
         fn parse_request(
             conn: &DisplayHandle,
-            msg: Message<ObjectId, io_lifetimes::OwnedFd>,
+            msg: Message<ObjectId, OwnedFd>,
         ) -> Result<(Self, Self::Request), DispatchError> {
             let me = Self::from_id(conn, msg.sender_id.clone()).unwrap();
             let mut arg_iter = msg.args.into_iter();

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -19,7 +19,7 @@ bitflags = "2"
 log = { version = "0.4", optional = true }
 nix = { version = "0.26.0", default-features = false }
 downcast-rs = "1.2"
-io-lifetimes = "1.0.0"
+io-lifetimes = "2"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wayland-server/src/dispatch.rs
+++ b/wayland-server/src/dispatch.rs
@@ -1,7 +1,7 @@
+use std::os::fd::OwnedFd;
 use std::sync::Arc;
 
 use wayland_backend::{
-    io_lifetimes::OwnedFd,
     protocol::ProtocolError,
     server::{ClientId, DisconnectReason, ObjectData, ObjectId},
 };

--- a/wayland-server/src/display.rs
+++ b/wayland-server/src/display.rs
@@ -1,7 +1,10 @@
-use std::{os::unix::net::UnixStream, sync::Arc};
+use std::{
+    os::fd::{AsFd, BorrowedFd},
+    os::unix::net::UnixStream,
+    sync::Arc,
+};
 
 use wayland_backend::{
-    io_lifetimes::{AsFd, BorrowedFd},
     protocol::ObjectInfo,
     server::{Backend, ClientData, GlobalId, Handle, InitError, InvalidId, ObjectId},
 };

--- a/wayland-server/src/global.rs
+++ b/wayland-server/src/global.rs
@@ -1,3 +1,4 @@
+use std::os::fd::OwnedFd;
 use std::sync::Arc;
 
 use wayland_backend::server::{
@@ -72,7 +73,7 @@ impl<D> ObjectData<D> for ProtocolErrorData {
         _handle: &Handle,
         _data: &mut D,
         _client_id: ClientId,
-        _msg: wayland_backend::protocol::Message<ObjectId, io_lifetimes::OwnedFd>,
+        _msg: wayland_backend::protocol::Message<ObjectId, OwnedFd>,
     ) -> Option<Arc<dyn ObjectData<D>>> {
         None
     }

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -78,9 +78,9 @@
 use std::{
     fmt,
     hash::{Hash, Hasher},
+    os::fd::OwnedFd,
 };
 use wayland_backend::{
-    io_lifetimes::OwnedFd,
     protocol::{Interface, Message},
     server::{InvalidId, ObjectId, WeakHandle},
 };

--- a/wayland-server/src/socket.rs
+++ b/wayland-server/src/socket.rs
@@ -3,6 +3,7 @@ use std::{
     ffi::{OsStr, OsString},
     fs::{self, File},
     io,
+    os::fd::{AsFd, BorrowedFd},
     os::unix::{
         io::{AsRawFd, FromRawFd, RawFd},
         net::{UnixListener, UnixStream},
@@ -11,7 +12,6 @@ use std::{
     path::PathBuf,
 };
 
-use io_lifetimes::{AsFd, BorrowedFd};
 use nix::{
     fcntl::{flock, open, FlockArg, OFlag},
     sys::stat::{lstat, Mode},

--- a/wayland-tests/tests/attach_to_surface.rs
+++ b/wayland-tests/tests/attach_to_surface.rs
@@ -2,6 +2,7 @@ extern crate tempfile;
 
 use std::fs::File;
 use std::io::{Read, Seek, Write};
+use std::os::fd::OwnedFd;
 use std::os::unix::io::AsRawFd;
 
 #[macro_use]
@@ -11,7 +12,6 @@ use helpers::{globals, roundtrip, wayc, ways, TestServer};
 
 use wayc::protocol::wl_shm::Format;
 
-use wayland_backend::io_lifetimes::OwnedFd;
 use ways::protocol::wl_buffer::WlBuffer as ServerBuffer;
 
 #[test]

--- a/wayland-tests/tests/helpers/mod.rs
+++ b/wayland-tests/tests/helpers/mod.rs
@@ -6,12 +6,12 @@
 pub extern crate wayland_client as wayc;
 pub extern crate wayland_server as ways;
 
+use std::os::fd::OwnedFd;
 use std::os::unix::net::UnixStream;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use wayland_backend::client::ObjectData;
-use wayland_backend::io_lifetimes::OwnedFd;
 
 pub mod globals;
 


### PR DESCRIPTION
Since Rust 1.63, most of the features of io-lifetimes have been merged into std, including the only three we are using: `OwnedFd`, `BorrowedFd` and the `AsFd` trait.

This bumps our MSRV, but this is the MSRV of the newest io-lifetimes anyway.

I kept reexporting `io_lifetimes` as it was part of the public interface, but since it isn’t used any more it would be nice to remove it before the next minor version bump.  I can prepare a commit for that.

This partially conflicts with #640.