### PR TITLE
backend: fix prepare_read behavior

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - MSRV bumped to 1.65
 - `io-lifetimes` is no longer a (public) dependency
+- The `Backend::prepare_read()` method now returns `None` if the inner queue of the backend
+  needs to be dispatched using `Backend::dispatch_inner_queue()`, instead of trying to dispatch
+  it by itself. This can only happen when using the `sys` backend, and allows the crate to
+  behave properly when multiple threads try to read the socket using the libwayland API.
 
 #### Additions
 

--- a/wayland-backend/src/rs/client_impl/mod.rs
+++ b/wayland-backend/src/rs/client_impl/mod.rs
@@ -204,9 +204,9 @@ impl InnerReadEventsGuard {
     ///
     /// This call will not block, but event callbacks may be invoked in the process
     /// of preparing the guard.
-    pub fn try_new(backend: InnerBackend) -> Result<Self, WaylandError> {
+    pub fn try_new(backend: InnerBackend) -> Option<Self> {
         backend.state.lock_read().prepared_reads += 1;
-        Ok(Self { state: backend.state, done: false })
+        Some(Self { state: backend.state, done: false })
     }
 
     /// Access the Wayland socket FD for polling

--- a/wayland-client/CHANGELOG.md
+++ b/wayland-client/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 - Bump bitflags to 2.0
 - Updated wayland-backend to 0.2
-- Calloop integration is now removed, to avoid tying wayland-client to it
+- Calloop integration is now removed, to avoid tying wayland-client to it you can use the
+  `calloop-wayland-source` crate instead
 
 ## 0.30.2 -- 30/05/2023
 

--- a/wayland-tests/tests/helpers/mod.rs
+++ b/wayland-tests/tests/helpers/mod.rs
@@ -98,7 +98,7 @@ pub fn roundtrip<CD: 'static, SD: 'static>(
         ::std::thread::sleep(::std::time::Duration::from_millis(100));
         // dispatch all client-side
         client.event_queue.dispatch_pending(client_ddata).unwrap();
-        let e = client.conn.prepare_read().and_then(|guard| guard.read());
+        let e = client.conn.prepare_read().map(|guard| guard.read()).unwrap_or(Ok(0));
         // even if read_events returns an error, some messages may need dispatching
         client.event_queue.dispatch_pending(client_ddata).unwrap();
         e?;


### PR DESCRIPTION
This should fix the multithreading issues that have been encountered.

cc @kchibisov 