### PR TITLE
client: Implement `AsFd` for `Connection` and `EventQueue`

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### Additions
+
+- client: Add `Backend::poll_fd` to return fd for polling
+
 ## 0.3.0 -- 2023-09-02
 
 #### Breaking change

--- a/wayland-backend/src/client_api.rs
+++ b/wayland-backend/src/client_api.rs
@@ -181,6 +181,12 @@ impl Backend {
         self.backend.flush()
     }
 
+    /// Access the Wayland socket FD for polling
+    #[inline]
+    pub fn poll_fd(&self) -> BorrowedFd {
+        self.backend.poll_fd()
+    }
+
     /// Get the object ID for the `wl_display`
     #[inline]
     pub fn display_id(&self) -> ObjectId {

--- a/wayland-backend/src/rs/client_impl/mod.rs
+++ b/wayland-backend/src/rs/client_impl/mod.rs
@@ -191,6 +191,13 @@ impl InnerBackend {
         }
         Ok(())
     }
+
+    pub fn poll_fd(&self) -> BorrowedFd {
+        let raw_fd = self.state.lock_protocol().socket.as_raw_fd();
+        // This allows the lifetime of the BorrowedFd to be tied to &self rather than the lock guard,
+        // which is the real safety concern
+        unsafe { BorrowedFd::borrow_raw(raw_fd) }
+    }
 }
 
 #[derive(Debug)]

--- a/wayland-backend/src/sys/client_impl/mod.rs
+++ b/wayland-backend/src/sys/client_impl/mod.rs
@@ -293,6 +293,17 @@ impl InnerBackend {
         }
     }
 
+    pub fn poll_fd(&self) -> BorrowedFd {
+        let guard = self.lock_state();
+        unsafe {
+            BorrowedFd::borrow_raw(ffi_dispatch!(
+                wayland_client_handle(),
+                wl_display_get_fd,
+                guard.display
+            ))
+        }
+    }
+
     pub fn dispatch_inner_queue(&self) -> Result<usize, WaylandError> {
         self.inner.dispatch_lock.lock().unwrap().dispatch_pending(self.inner.clone())
     }

--- a/wayland-client/CHANGELOG.md
+++ b/wayland-client/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+#### Additions
+
+- Implement `AsFd` for `Connection` and `EventQueue` so they can easily be used in a
+  `calloop` source.
+
 ## 0.31.0 -- 2023-09-02
 
 #### Breaking changes

--- a/wayland-client/src/conn.rs
+++ b/wayland-client/src/conn.rs
@@ -3,7 +3,7 @@ use std::{
     io::ErrorKind,
     os::unix::io::OwnedFd,
     os::unix::net::UnixStream,
-    os::unix::prelude::{AsRawFd, FromRawFd},
+    os::unix::prelude::{AsFd, AsRawFd, BorrowedFd, FromRawFd},
     path::PathBuf,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -270,6 +270,13 @@ impl fmt::Display for ConnectError {
                 write!(f, "WAYLAND_SOCKET was set but contained garbage")
             }
         }
+    }
+}
+
+impl AsFd for Connection {
+    /// Provides fd from [`Backend::poll_fd`] for polling.
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.backend.poll_fd()
     }
 }
 

--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::collections::VecDeque;
 use std::convert::Infallible;
 use std::marker::PhantomData;
-use std::os::unix::io::OwnedFd;
+use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 use std::sync::{atomic::Ordering, Arc, Condvar, Mutex};
 use std::task;
 
@@ -346,6 +346,13 @@ impl<State> std::fmt::Debug for EventQueue<State> {
     #[cfg_attr(coverage, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EventQueue").field("handle", &self.handle).finish_non_exhaustive()
+    }
+}
+
+impl<State> AsFd for EventQueue<State> {
+    /// Provides fd from [`Backend::poll_fd`] for polling.
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.conn.as_fd()
     }
 }
 


### PR DESCRIPTION
This helps for using an `Generic<EventQueue>` with calloop 0.11.

https://github.com/Smithay/wayland-rs/pull/635 added this server-side for use in Smithay; the same thing seems useful for sctk.