### PR TITLE
scanner: Use `std::convert::Infallible` in `__phantom_lifetime` variants

### DIFF
--- a/wayland-scanner/CHANGELOG.md
+++ b/wayland-scanner/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Include an `std::convert::Infallible` in hidden `__phantom_lifetime` enum variants,
+  so they're explicitly unconstructable.
+
 ## 0.31.0 -- 2023-09-02
 
 #### Breaking changes

--- a/wayland-scanner/src/common.rs
+++ b/wayland-scanner/src/common.rs
@@ -302,8 +302,8 @@ pub(crate) fn gen_message_enum(
     let (generic, phantom_variant, phantom_case) = if !receiver {
         (
             quote! { 'a },
-            quote! { #[doc(hidden)] __phantom_lifetime { phantom: std::marker::PhantomData<&'a ()> } },
-            quote! { #name::__phantom_lifetime { .. } => unreachable!() },
+            quote! { #[doc(hidden)] __phantom_lifetime { phantom: std::marker::PhantomData<&'a ()>, never: std::convert::Infallible } },
+            quote! { #name::__phantom_lifetime { never, .. } => match never {} },
         )
     } else {
         (quote! {}, quote! {}, quote! {})
@@ -625,7 +625,7 @@ pub(crate) fn gen_write_body(interface: &Interface, side: Side) -> TokenStream {
     quote! {
         match msg {
             #(#arms,)*
-            #msg_type::__phantom_lifetime { .. } => unreachable!()
+            #msg_type::__phantom_lifetime { never, .. } => match never {}
         }
     }
 }

--- a/wayland-scanner/tests/scanner_assets/test-client-code.rs
+++ b/wayland-scanner/tests/scanner_assets/test-client-code.rs
@@ -64,7 +64,10 @@ pub mod wl_display {
         #[doc = "get global registry object\n\nThis request creates a registry object that allows the client\nto list and bind the global objects available from the\ncompositor.\n\nIt should be noted that the server side resources consumed in\nresponse to a get_registry request can only be released when the\nclient disconnects, not when the client side proxy is destroyed.\nTherefore, clients should invoke get_registry as infrequently as\npossible to avoid wasting memory."]
         GetRegistry {},
         #[doc(hidden)]
-        __phantom_lifetime { phantom: std::marker::PhantomData<&'a ()> },
+        __phantom_lifetime {
+            phantom: std::marker::PhantomData<&'a ()>,
+            never: std::convert::Infallible,
+        },
     }
     impl<'a> Request<'a> {
         #[doc = "Get the opcode number of this message"]
@@ -72,7 +75,7 @@ pub mod wl_display {
             match *self {
                 Request::Sync { .. } => 0u16,
                 Request::GetRegistry { .. } => 1u16,
-                Request::__phantom_lifetime { .. } => unreachable!(),
+                Request::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }
@@ -270,7 +273,7 @@ pub mod wl_display {
                     };
                     Ok((Message { sender_id: self.id.clone(), opcode: 1u16, args }, child_spec))
                 }
-                Request::__phantom_lifetime { .. } => unreachable!(),
+                Request::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }
@@ -343,14 +346,17 @@ pub mod wl_registry {
             id: (&'static Interface, u32),
         },
         #[doc(hidden)]
-        __phantom_lifetime { phantom: std::marker::PhantomData<&'a ()> },
+        __phantom_lifetime {
+            phantom: std::marker::PhantomData<&'a ()>,
+            never: std::convert::Infallible,
+        },
     }
     impl<'a> Request<'a> {
         #[doc = "Get the opcode number of this message"]
         pub fn opcode(&self) -> u16 {
             match *self {
                 Request::Bind { .. } => 0u16,
-                Request::__phantom_lifetime { .. } => unreachable!(),
+                Request::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }
@@ -538,7 +544,7 @@ pub mod wl_registry {
                     };
                     Ok((Message { sender_id: self.id.clone(), opcode: 0u16, args }, child_spec))
                 }
-                Request::__phantom_lifetime { .. } => unreachable!(),
+                Request::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }
@@ -579,13 +585,16 @@ pub mod wl_callback {
     #[non_exhaustive]
     pub enum Request<'a> {
         #[doc(hidden)]
-        __phantom_lifetime { phantom: std::marker::PhantomData<&'a ()> },
+        __phantom_lifetime {
+            phantom: std::marker::PhantomData<&'a ()>,
+            never: std::convert::Infallible,
+        },
     }
     impl<'a> Request<'a> {
         #[doc = "Get the opcode number of this message"]
         pub fn opcode(&self) -> u16 {
             match *self {
-                Request::__phantom_lifetime { .. } => unreachable!(),
+                Request::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }
@@ -723,7 +732,7 @@ pub mod wl_callback {
             InvalidId,
         > {
             match msg {
-                Request::__phantom_lifetime { .. } => unreachable!(),
+                Request::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }
@@ -813,7 +822,10 @@ pub mod test_global {
             ter: super::tertiary::Tertiary,
         },
         #[doc(hidden)]
-        __phantom_lifetime { phantom: std::marker::PhantomData<&'a ()> },
+        __phantom_lifetime {
+            phantom: std::marker::PhantomData<&'a ()>,
+            never: std::convert::Infallible,
+        },
     }
     impl<'a> Request<'a> {
         #[doc = "Get the opcode number of this message"]
@@ -826,7 +838,7 @@ pub mod test_global {
                 Request::Destroy => 4u16,
                 Request::ReverseLink { .. } => 5u16,
                 Request::NewidAndAllowNull { .. } => 6u16,
-                Request::__phantom_lifetime { .. } => unreachable!(),
+                Request::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }
@@ -1179,7 +1191,7 @@ pub mod test_global {
                     };
                     Ok((Message { sender_id: self.id.clone(), opcode: 6u16, args }, child_spec))
                 }
-                Request::__phantom_lifetime { .. } => unreachable!(),
+                Request::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }
@@ -1329,14 +1341,17 @@ pub mod secondary {
         #[doc = "This is a destructor, once sent this object cannot be used any longer.\nOnly available since version 2 of the interface"]
         Destroy,
         #[doc(hidden)]
-        __phantom_lifetime { phantom: std::marker::PhantomData<&'a ()> },
+        __phantom_lifetime {
+            phantom: std::marker::PhantomData<&'a ()>,
+            never: std::convert::Infallible,
+        },
     }
     impl<'a> Request<'a> {
         #[doc = "Get the opcode number of this message"]
         pub fn opcode(&self) -> u16 {
             match *self {
                 Request::Destroy => 0u16,
-                Request::__phantom_lifetime { .. } => unreachable!(),
+                Request::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }
@@ -1460,7 +1475,7 @@ pub mod secondary {
                     let args = smallvec::SmallVec::new();
                     Ok((Message { sender_id: self.id.clone(), opcode: 0u16, args }, child_spec))
                 }
-                Request::__phantom_lifetime { .. } => unreachable!(),
+                Request::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }
@@ -1496,14 +1511,17 @@ pub mod tertiary {
         #[doc = "This is a destructor, once sent this object cannot be used any longer.\nOnly available since version 3 of the interface"]
         Destroy,
         #[doc(hidden)]
-        __phantom_lifetime { phantom: std::marker::PhantomData<&'a ()> },
+        __phantom_lifetime {
+            phantom: std::marker::PhantomData<&'a ()>,
+            never: std::convert::Infallible,
+        },
     }
     impl<'a> Request<'a> {
         #[doc = "Get the opcode number of this message"]
         pub fn opcode(&self) -> u16 {
             match *self {
                 Request::Destroy => 0u16,
-                Request::__phantom_lifetime { .. } => unreachable!(),
+                Request::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }
@@ -1627,7 +1645,7 @@ pub mod tertiary {
                     let args = smallvec::SmallVec::new();
                     Ok((Message { sender_id: self.id.clone(), opcode: 0u16, args }, child_spec))
                 }
-                Request::__phantom_lifetime { .. } => unreachable!(),
+                Request::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }
@@ -1663,14 +1681,17 @@ pub mod quad {
         #[doc = "This is a destructor, once sent this object cannot be used any longer.\nOnly available since version 3 of the interface"]
         Destroy,
         #[doc(hidden)]
-        __phantom_lifetime { phantom: std::marker::PhantomData<&'a ()> },
+        __phantom_lifetime {
+            phantom: std::marker::PhantomData<&'a ()>,
+            never: std::convert::Infallible,
+        },
     }
     impl<'a> Request<'a> {
         #[doc = "Get the opcode number of this message"]
         pub fn opcode(&self) -> u16 {
             match *self {
                 Request::Destroy => 0u16,
-                Request::__phantom_lifetime { .. } => unreachable!(),
+                Request::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }
@@ -1794,7 +1815,7 @@ pub mod quad {
                     let args = smallvec::SmallVec::new();
                     Ok((Message { sender_id: self.id.clone(), opcode: 0u16, args }, child_spec))
                 }
-                Request::__phantom_lifetime { .. } => unreachable!(),
+                Request::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }

--- a/wayland-scanner/tests/scanner_assets/test-server-code.rs
+++ b/wayland-scanner/tests/scanner_assets/test-server-code.rs
@@ -31,14 +31,17 @@ pub mod wl_callback {
             callback_data: u32,
         },
         #[doc(hidden)]
-        __phantom_lifetime { phantom: std::marker::PhantomData<&'a ()> },
+        __phantom_lifetime {
+            phantom: std::marker::PhantomData<&'a ()>,
+            never: std::convert::Infallible,
+        },
     }
     impl<'a> Event<'a> {
         #[doc = "Get the opcode number of this message"]
         pub fn opcode(&self) -> u16 {
             match *self {
                 Event::Done { .. } => 0u16,
-                Event::__phantom_lifetime { .. } => unreachable!(),
+                Event::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }
@@ -142,7 +145,7 @@ pub mod wl_callback {
                         vec
                     },
                 }),
-                Event::__phantom_lifetime { .. } => unreachable!(),
+                Event::__phantom_lifetime { never, .. } => match never {},
             }
         }
         fn __set_object_data(
@@ -288,7 +291,10 @@ pub mod test_global {
         #[doc = "create a new quad optionally replacing a previous one"]
         CycleQuad { new_quad: super::quad::Quad, old_quad: Option<super::quad::Quad> },
         #[doc(hidden)]
-        __phantom_lifetime { phantom: std::marker::PhantomData<&'a ()> },
+        __phantom_lifetime {
+            phantom: std::marker::PhantomData<&'a ()>,
+            never: std::convert::Infallible,
+        },
     }
     impl<'a> Event<'a> {
         #[doc = "Get the opcode number of this message"]
@@ -297,7 +303,7 @@ pub mod test_global {
                 Event::ManyArgsEvt { .. } => 0u16,
                 Event::AckSecondary { .. } => 1u16,
                 Event::CycleQuad { .. } => 2u16,
-                Event::__phantom_lifetime { .. } => unreachable!(),
+                Event::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }
@@ -712,7 +718,7 @@ pub mod test_global {
                         vec
                     },
                 }),
-                Event::__phantom_lifetime { .. } => unreachable!(),
+                Event::__phantom_lifetime { never, .. } => match never {},
             }
         }
         fn __set_object_data(
@@ -794,13 +800,16 @@ pub mod secondary {
     #[non_exhaustive]
     pub enum Event<'a> {
         #[doc(hidden)]
-        __phantom_lifetime { phantom: std::marker::PhantomData<&'a ()> },
+        __phantom_lifetime {
+            phantom: std::marker::PhantomData<&'a ()>,
+            never: std::convert::Infallible,
+        },
     }
     impl<'a> Event<'a> {
         #[doc = "Get the opcode number of this message"]
         pub fn opcode(&self) -> u16 {
             match *self {
-                Event::__phantom_lifetime { .. } => unreachable!(),
+                Event::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }
@@ -906,7 +915,7 @@ pub mod secondary {
             msg: Self::Event<'a>,
         ) -> Result<Message<ObjectId, std::os::unix::io::BorrowedFd<'a>>, InvalidId> {
             match msg {
-                Event::__phantom_lifetime { .. } => unreachable!(),
+                Event::__phantom_lifetime { never, .. } => match never {},
             }
         }
         fn __set_object_data(
@@ -950,13 +959,16 @@ pub mod tertiary {
     #[non_exhaustive]
     pub enum Event<'a> {
         #[doc(hidden)]
-        __phantom_lifetime { phantom: std::marker::PhantomData<&'a ()> },
+        __phantom_lifetime {
+            phantom: std::marker::PhantomData<&'a ()>,
+            never: std::convert::Infallible,
+        },
     }
     impl<'a> Event<'a> {
         #[doc = "Get the opcode number of this message"]
         pub fn opcode(&self) -> u16 {
             match *self {
-                Event::__phantom_lifetime { .. } => unreachable!(),
+                Event::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }
@@ -1062,7 +1074,7 @@ pub mod tertiary {
             msg: Self::Event<'a>,
         ) -> Result<Message<ObjectId, std::os::unix::io::BorrowedFd<'a>>, InvalidId> {
             match msg {
-                Event::__phantom_lifetime { .. } => unreachable!(),
+                Event::__phantom_lifetime { never, .. } => match never {},
             }
         }
         fn __set_object_data(
@@ -1106,13 +1118,16 @@ pub mod quad {
     #[non_exhaustive]
     pub enum Event<'a> {
         #[doc(hidden)]
-        __phantom_lifetime { phantom: std::marker::PhantomData<&'a ()> },
+        __phantom_lifetime {
+            phantom: std::marker::PhantomData<&'a ()>,
+            never: std::convert::Infallible,
+        },
     }
     impl<'a> Event<'a> {
         #[doc = "Get the opcode number of this message"]
         pub fn opcode(&self) -> u16 {
             match *self {
-                Event::__phantom_lifetime { .. } => unreachable!(),
+                Event::__phantom_lifetime { never, .. } => match never {},
             }
         }
     }
@@ -1218,7 +1233,7 @@ pub mod quad {
             msg: Self::Event<'a>,
         ) -> Result<Message<ObjectId, std::os::unix::io::BorrowedFd<'a>>, InvalidId> {
             match msg {
-                Event::__phantom_lifetime { .. } => unreachable!(),
+                Event::__phantom_lifetime { never, .. } => match never {},
             }
         }
         fn __set_object_data(


### PR DESCRIPTION
I thought there was an empty type in the standard library, but somehow couldn't find it when I implemented this.

This makes it a bit more explicit that the variant is never constructed, and should help a bit with optimization. It does not impact public API.