### PR TITLE
Use `VecDeque<OwnedFd>` and `Vec<OwnedFd>` for `in_fds`/`out_fds`

### DIFF
--- a/wayland-backend/src/rs/wire.rs
+++ b/wayland-backend/src/rs/wire.rs
@@ -192,6 +192,11 @@ pub fn parse_message<'a>(
         return Err(MessageParseError::MissingData);
     }
 
+    let fd_len = signature.iter().filter(|x| matches!(x, ArgumentType::Fd)).count();
+    if fd_len > fds.len() {
+        return Err(MessageParseError::MissingFD);
+    }
+
     let (mut payload, rest) = raw.split_at(len);
     payload = &payload[2..];
 


### PR DESCRIPTION
This avoids some awkward and potentially error-prone code, and should perform no worse than how the `Buffer` type was used.