### PR TITLE
client: Implement `Eq` for `Connection`

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Additions
+- client: Implement `Eq` for `Backend`
+
 ## 0.3.2 -- 2023-09-25
 
 #### Bugfixes

--- a/wayland-backend/src/client_api.rs
+++ b/wayland-backend/src/client_api.rs
@@ -129,7 +129,7 @@ impl ObjectId {
 ///
 /// This type hosts all the interface for interacting with the wayland protocol. It can be
 /// cloned, all clones refer to the same underlying connection.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Backend {
     pub(crate) backend: client_impl::InnerBackend,
 }

--- a/wayland-backend/src/rs/client_impl/mod.rs
+++ b/wayland-backend/src/rs/client_impl/mod.rs
@@ -138,6 +138,14 @@ impl WeakInnerBackend {
     }
 }
 
+impl PartialEq for InnerBackend {
+    fn eq(&self, rhs: &Self) -> bool {
+        Arc::ptr_eq(&self.state, &rhs.state)
+    }
+}
+
+impl Eq for InnerBackend {}
+
 impl InnerBackend {
     pub fn downgrade(&self) -> WeakInnerBackend {
         WeakInnerBackend { state: Arc::downgrade(&self.state) }

--- a/wayland-backend/src/sys/client_impl/mod.rs
+++ b/wayland-backend/src/sys/client_impl/mod.rs
@@ -216,6 +216,14 @@ impl WeakInnerBackend {
     }
 }
 
+impl PartialEq for InnerBackend {
+    fn eq(&self, rhs: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &rhs.inner)
+    }
+}
+
+impl Eq for InnerBackend {}
+
 unsafe impl Send for InnerBackend {}
 unsafe impl Sync for InnerBackend {}
 

--- a/wayland-client/CHANGELOG.md
+++ b/wayland-client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+#### Additions
+- Implement `Eq` for `Connection`
+
 ## 0.31.1 -- 2023-09-19
 
 #### Additions

--- a/wayland-client/src/conn.rs
+++ b/wayland-client/src/conn.rs
@@ -37,7 +37,7 @@ use crate::{protocol::wl_display::WlDisplay, EventQueue, Proxy};
 /// In case you need to plug yourself into an external Wayland connection that you don't control, you'll
 /// likely get access to it as a [`Backend`], in which case you can create a [`Connection`] from it using
 /// the [`from_backend`](Connection::from_backend) method.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Connection {
     pub(crate) backend: Backend,
 }


### PR DESCRIPTION
This is useful in some cases, and there's no harm to providing it.