### PR TITLE
Include advertised version in `BindError::UnsupportVersion`

### DIFF
--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -168,7 +168,7 @@ impl GlobalList {
 
         // Test version requirements
         if version < version_start {
-            return Err(BindError::UnsupportedVersion);
+            return Err(BindError::UnsupportedVersion(version));
         }
 
         // To get the version to bind, take the lower of the version advertised by the server and the maximum
@@ -232,7 +232,7 @@ impl From<InvalidId> for GlobalError {
 #[derive(Debug)]
 pub enum BindError {
     /// The requested version of the global is not supported.
-    UnsupportedVersion,
+    UnsupportedVersion(u32),
 
     /// The requested global was not found in the registry.
     NotPresent,
@@ -243,8 +243,8 @@ impl std::error::Error for BindError {}
 impl fmt::Display for BindError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            BindError::UnsupportedVersion {} => {
-                write!(f, "the requested version of the global is not supported")
+            BindError::UnsupportedVersion(version) => {
+                write!(f, "the available version {version} of the global is lower than the requested version")
             }
             BindError::NotPresent {} => {
                 write!(f, "the requested global was not found in the registry")

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -156,12 +156,7 @@ impl GlobalList {
             .iter()
             // Find the with the correct interface
             .find_map(|Global { name, interface: interface_name, version }| {
-                // TODO: then_some
-                if interface.name == &interface_name[..] {
-                    Some((*name, *version))
-                } else {
-                    None
-                }
+                (interface.name == &interface_name[..]).then_some((*name, *version))
             })
             .ok_or(BindError::NotPresent)?;
 

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -155,7 +155,7 @@ impl GlobalList {
         let (name, version) = guard
             .iter()
             // Find the with the correct interface
-            .filter_map(|Global { name, interface: interface_name, version }| {
+            .find_map(|Global { name, interface: interface_name, version }| {
                 // TODO: then_some
                 if interface.name == &interface_name[..] {
                     Some((*name, *version))
@@ -163,7 +163,6 @@ impl GlobalList {
                     None
                 }
             })
-            .next()
             .ok_or(BindError::NotPresent)?;
 
         // Test version requirements


### PR DESCRIPTION
Reporting the advertised version is helpful because I can then report this to the user in case of an error.
This way I can get more information in a reported issue.

I also added two code clean up commits since the code was right next to each other.

The tests did not run successfully but they don't run through on master either.
Both branches fail at `client_receive_generic_error`:
```
---- client_receive_generic_error stdout ----
Protocol error 42 on object wl_compositor@3:
Protocol error 42 on object wl_compositor@3:
thread 'client_receive_generic_error' panicked at wayland-tests/tests/protocol_errors.rs:56:9:
assertion `left == right` failed
  left: ""
 right: "I don't like you!"
```
