### PR TITLE
Fix `unused-imports` warning on recently `nightly`

### DIFF
--- a/wayland-backend/src/rs/server_impl/mod.rs
+++ b/wayland-backend/src/rs/server_impl/mod.rs
@@ -10,7 +10,6 @@ mod common_poll;
 mod handle;
 mod registry;
 
-pub use crate::types::server::{Credentials, DisconnectReason, GlobalInfo, InitError, InvalidId};
 pub use common_poll::InnerBackend;
 pub use handle::{InnerHandle, WeakInnerHandle};
 


### PR DESCRIPTION
This should fix the failing `check-minimal` CI test.