### PR TITLE
Log requests on dead objects

### DIFF
--- a/wayland-backend/src/lib.rs
+++ b/wayland-backend/src/lib.rs
@@ -91,6 +91,7 @@ pub use sys::server;
 mod test;
 
 mod core_interfaces;
+mod debug;
 pub mod protocol;
 mod types;
 

--- a/wayland-backend/src/rs/mod.rs
+++ b/wayland-backend/src/rs/mod.rs
@@ -3,7 +3,6 @@
 mod client_impl;
 mod server_impl;
 
-mod debug;
 mod map;
 pub(crate) mod socket;
 mod wire;

--- a/wayland-backend/src/rs/server_impl/client.rs
+++ b/wayland-backend/src/rs/server_impl/client.rs
@@ -7,6 +7,7 @@ use std::{
 
 use crate::{
     core_interfaces::{WL_CALLBACK_INTERFACE, WL_DISPLAY_INTERFACE, WL_REGISTRY_INTERFACE},
+    debug,
     protocol::{
         check_for_signature, same_interface, same_interface_or_anonymous, AllowNull, Argument,
         ArgumentType, Interface, Message, ObjectInfo, ProtocolError, ANONYMOUS_INTERFACE,
@@ -135,11 +136,12 @@ impl<D> Client<D> {
         }
 
         if self.debug {
-            crate::rs::debug::print_send_message(
+            debug::print_send_message(
                 object.interface.name,
                 object_id.id.id,
                 message_desc.name,
                 &args,
+                false,
             );
         }
 
@@ -362,7 +364,7 @@ impl<D> Client<D> {
             let obj = self.map.find(msg.sender_id).unwrap();
 
             if self.debug {
-                super::super::debug::print_dispatched_message(
+                debug::print_dispatched_message(
                     obj.interface.name,
                     msg.sender_id,
                     obj.interface.requests.get(msg.opcode as usize).unwrap().name,

--- a/wayland-backend/src/rs/server_impl/mod.rs
+++ b/wayland-backend/src/rs/server_impl/mod.rs
@@ -10,6 +10,7 @@ mod common_poll;
 mod handle;
 mod registry;
 
+pub use crate::types::server::Credentials;
 pub use common_poll::InnerBackend;
 pub use handle::{InnerHandle, WeakInnerHandle};
 


### PR DESCRIPTION
To make it possible to understand that something got discarded, print a message saying so inside when `WAYLAND_DEBUG` is enabled.

This also changes how timestamps are computed for `WAYLAND_DEBUG` log so they align with `libwayland-client` to look into logs using both at the same time more accessible. The `[rs]` particle was added to the log to give a hint which library was used, which could be helpful when looking into random logs.