### PR TITLE
backend: Use Buffer<u8> instead of Buffer<u32>

### DIFF
--- a/wayland-backend/src/rs/socket.rs
+++ b/wayland-backend/src/rs/socket.rs
@@ -312,13 +312,7 @@ impl<T: Copy + Default> Buffer<T> {
     /// maximal write space availability
     fn move_to_front(&mut self) {
         if self.occupied > self.offset {
-            unsafe {
-                ::std::ptr::copy(
-                    &self.storage[self.offset] as *const T,
-                    &mut self.storage[0] as *mut T,
-                    self.occupied - self.offset,
-                );
-            }
+            self.storage.copy_within((self.offset)..(self.occupied), 0)
         }
         self.occupied -= self.offset;
         self.offset = 0;


### PR DESCRIPTION
I don't think `sendmsg`/`recvmsg` are necessarily guaranteed to read/write a multiple of 4 bytes, so for correctness we need to buffer bytes rather than words. This also avoids unsafe casts.

This is based on https://github.com/Smithay/wayland-rs/pull/666. Not sure if the helpers here for reading/writing words to the buffer could be improved. Perhaps as methods of `Buffer`, if that's only being used for this.

This doesn't seem particularly worse to handle than the previous way, since either version has to deal with lengths in bytes vs. words, and array padding.