### PR TITLE
backend: Use `Message<_, BorrowedFd>` rather than `RawFd`

### DIFF
--- a/wayland-backend/src/client_api.rs
+++ b/wayland-backend/src/client_api.rs
@@ -2,7 +2,7 @@ use std::{
     any::Any,
     fmt,
     os::unix::{
-        io::{BorrowedFd, OwnedFd, RawFd},
+        io::{BorrowedFd, OwnedFd},
         net::UnixStream,
     },
     sync::Arc,
@@ -243,7 +243,7 @@ impl Backend {
     ///   is `wl_registry.bind`), the `child_spec` must be provided.
     pub fn send_request(
         &self,
-        msg: Message<ObjectId, RawFd>,
+        msg: Message<ObjectId, BorrowedFd>,
         data: Option<Arc<dyn ObjectData>>,
         child_spec: Option<(&'static Interface, u32)>,
     ) -> Result<ObjectId, InvalidId> {

--- a/wayland-backend/src/rs/client_impl/mod.rs
+++ b/wayland-backend/src/rs/client_impl/mod.rs
@@ -3,7 +3,7 @@
 use std::{
     fmt,
     os::unix::{
-        io::{AsRawFd, BorrowedFd, OwnedFd, RawFd},
+        io::{AsRawFd, BorrowedFd, OwnedFd},
         net::UnixStream,
     },
     sync::{Arc, Condvar, Mutex, MutexGuard, Weak},
@@ -317,7 +317,7 @@ impl InnerBackend {
 
     pub fn send_request(
         &self,
-        Message { sender_id: ObjectId { id }, opcode, args }: Message<ObjectId, RawFd>,
+        Message { sender_id: ObjectId { id }, opcode, args }: Message<ObjectId, BorrowedFd>,
         data: Option<Arc<dyn ObjectData>>,
         child_spec: Option<(&'static Interface, u32)>,
     ) -> Result<ObjectId, InvalidId> {

--- a/wayland-backend/src/rs/server_impl/client.rs
+++ b/wayland-backend/src/rs/server_impl/client.rs
@@ -1,7 +1,7 @@
 use std::{
     ffi::CString,
     os::unix::{
-        io::{AsFd, BorrowedFd, OwnedFd, RawFd},
+        io::{AsFd, BorrowedFd, OwnedFd},
         net::UnixStream,
     },
     sync::Arc,
@@ -120,7 +120,7 @@ impl<D> Client<D> {
 
     pub(crate) fn send_event(
         &mut self,
-        Message { sender_id: object_id, opcode, args }: Message<ObjectId, RawFd>,
+        Message { sender_id: object_id, opcode, args }: Message<ObjectId, BorrowedFd>,
         pending_destructors: Option<&mut Vec<super::handle::PendingDestructor<D>>>,
     ) -> Result<(), InvalidId> {
         if self.killed {

--- a/wayland-backend/src/rs/server_impl/handle.rs
+++ b/wayland-backend/src/rs/server_impl/handle.rs
@@ -1,10 +1,8 @@
 use std::{
     any::Any,
     ffi::CString,
-    os::unix::{
-        io::{OwnedFd, RawFd},
-        net::UnixStream,
-    },
+    os::unix::io::{BorrowedFd, OwnedFd},
+    os::unix::net::UnixStream,
     sync::{Arc, Mutex, Weak},
 };
 
@@ -199,7 +197,7 @@ impl InnerHandle {
         }
     }
 
-    pub fn send_event(&self, msg: Message<ObjectId, RawFd>) -> Result<(), InvalidId> {
+    pub fn send_event(&self, msg: Message<ObjectId, BorrowedFd>) -> Result<(), InvalidId> {
         self.state.lock().unwrap().send_event(msg)
     }
 
@@ -336,7 +334,7 @@ pub(crate) trait ErasedState: Any {
         &self,
         id: InnerObjectId,
     ) -> Result<Arc<dyn std::any::Any + Send + Sync>, InvalidId>;
-    fn send_event(&mut self, msg: Message<ObjectId, RawFd>) -> Result<(), InvalidId>;
+    fn send_event(&mut self, msg: Message<ObjectId, BorrowedFd>) -> Result<(), InvalidId>;
     fn post_error(&mut self, object_id: InnerObjectId, error_code: u32, message: CString);
     fn kill_client(&mut self, client_id: InnerClientId, reason: DisconnectReason);
     fn global_info(&self, id: InnerGlobalId) -> Result<GlobalInfo, InvalidId>;
@@ -462,7 +460,7 @@ impl<D> ErasedState for State<D> {
             .map(|arc| arc.into_any_arc())
     }
 
-    fn send_event(&mut self, msg: Message<ObjectId, RawFd>) -> Result<(), InvalidId> {
+    fn send_event(&mut self, msg: Message<ObjectId, BorrowedFd>) -> Result<(), InvalidId> {
         self.clients
             .get_client_mut(msg.sender_id.id.client_id.clone())?
             .send_event(msg, Some(&mut self.pending_destructors))

--- a/wayland-backend/src/rs/socket.rs
+++ b/wayland-backend/src/rs/socket.rs
@@ -208,7 +208,7 @@ impl BufferedSocket {
     //
     // if false is returned, it means there is not enough space
     // in the buffer
-    fn attempt_write_message(&mut self, msg: &Message<u32, RawFd>) -> IoResult<bool> {
+    fn attempt_write_message(&mut self, msg: &Message<u32, BorrowedFd>) -> IoResult<bool> {
         let fds_len = self.out_fds.len();
         loop {
             match write_to_buffers(msg, self.out_data.get_writable_storage(), &mut self.out_fds) {
@@ -236,7 +236,7 @@ impl BufferedSocket {
     ///
     /// If the message is too big to fit in the buffer, the error `Error::Sys(E2BIG)`
     /// will be returned.
-    pub fn write_message(&mut self, msg: &Message<u32, RawFd>) -> IoResult<()> {
+    pub fn write_message(&mut self, msg: &Message<u32, BorrowedFd>) -> IoResult<()> {
         if !self.attempt_write_message(msg)? {
             // the attempt failed, there is not enough space in the buffer
             // we need to flush it
@@ -398,7 +398,8 @@ mod tests {
     use crate::protocol::{AllowNull, Argument, ArgumentType, Message};
 
     use std::ffi::CString;
-    use std::os::unix::io::IntoRawFd;
+    use std::io;
+    use std::os::unix::io::BorrowedFd;
 
     use smallvec::smallvec;
 
@@ -412,18 +413,18 @@ mod tests {
     //
     // if arguments contain FDs, check that the fd point to
     // the same file, rather than are the same number.
-    fn assert_eq_msgs<Fd: AsRawFd + std::fmt::Debug>(
-        msg1: &Message<u32, Fd>,
-        msg2: &Message<u32, Fd>,
+    fn assert_eq_msgs<Fd1: AsFd + std::fmt::Debug, Fd2: AsFd + std::fmt::Debug>(
+        msg1: Message<u32, Fd1>,
+        msg2: Message<u32, Fd2>,
     ) {
+        let msg1 = msg1.map_fd(|fd| fd.as_fd().try_clone_to_owned().unwrap());
+        let msg2 = msg2.map_fd(|fd| fd.as_fd().try_clone_to_owned().unwrap());
         assert_eq!(msg1.sender_id, msg2.sender_id);
         assert_eq!(msg1.opcode, msg2.opcode);
         assert_eq!(msg1.args.len(), msg2.args.len());
         for (arg1, arg2) in msg1.args.iter().zip(msg2.args.iter()) {
             if let (Argument::Fd(fd1), Argument::Fd(fd2)) = (arg1, arg2) {
-                let fd1 = unsafe { BorrowedFd::borrow_raw(fd1.as_raw_fd()) };
-                let fd2 = unsafe { BorrowedFd::borrow_raw(fd2.as_raw_fd()) };
-                assert!(same_file(fd1, fd2));
+                assert!(same_file(fd1.as_fd(), fd2.as_fd()));
             } else {
                 assert_eq!(arg1, arg2);
             }
@@ -472,18 +473,17 @@ mod tests {
                 })
                 .unwrap();
 
-        assert_eq_msgs(&msg.map_fd(|fd| fd.as_raw_fd()), &ret_msg.map_fd(IntoRawFd::into_raw_fd));
+        assert_eq_msgs(msg, ret_msg);
     }
 
     #[test]
     fn write_read_cycle_fd() {
+        let stdin = io::stdin().lock();
+        let stdout = io::stdout().lock();
         let msg = Message {
             sender_id: 42,
             opcode: 7,
-            args: smallvec![
-                Argument::Fd(1), // stdin
-                Argument::Fd(0), // stdout
-            ],
+            args: smallvec![Argument::Fd(stdin.as_fd()), Argument::Fd(stdout.as_fd()),],
         };
 
         let (client, server) = ::std::os::unix::net::UnixStream::pair().unwrap();
@@ -503,11 +503,14 @@ mod tests {
                     if sender_id == 42 && opcode == 7 { Some(SIGNATURE) } else { None }
                 })
                 .unwrap();
-        assert_eq_msgs(&msg.map_fd(|fd| fd.as_raw_fd()), &ret_msg.map_fd(IntoRawFd::into_raw_fd));
+        assert_eq_msgs(msg, ret_msg);
     }
 
     #[test]
     fn write_read_cycle_multiple() {
+        let stdin = io::stderr().lock();
+        let stdout = io::stderr().lock();
+        let stderr = io::stderr().lock();
         let messages = vec![
             Message {
                 sender_id: 42,
@@ -520,18 +523,12 @@ mod tests {
             Message {
                 sender_id: 42,
                 opcode: 1,
-                args: smallvec![
-                    Argument::Fd(1), // stdin
-                    Argument::Fd(0), // stdout
-                ],
+                args: smallvec![Argument::Fd(stdin.as_fd()), Argument::Fd(stdout.as_fd()),],
             },
             Message {
                 sender_id: 42,
                 opcode: 2,
-                args: smallvec![
-                    Argument::Uint(3),
-                    Argument::Fd(2), // stderr
-                ],
+                args: smallvec![Argument::Uint(3), Argument::Fd(stderr.as_fd()),],
             },
         ];
 
@@ -560,7 +557,7 @@ mod tests {
         }
         assert_eq!(recv_msgs.len(), 3);
         for (msg1, msg2) in messages.into_iter().zip(recv_msgs) {
-            assert_eq_msgs(&msg1.map_fd(|fd| fd.as_raw_fd()), &msg2.map_fd(IntoRawFd::into_raw_fd));
+            assert_eq_msgs(msg1, msg2);
         }
     }
 
@@ -595,6 +592,6 @@ mod tests {
                 })
                 .unwrap();
 
-        assert_eq_msgs(&msg.map_fd(|fd| fd.as_raw_fd()), &ret_msg.map_fd(IntoRawFd::into_raw_fd));
+        assert_eq_msgs(msg, ret_msg);
     }
 }

--- a/wayland-backend/src/rs/wire.rs
+++ b/wayland-backend/src/rs/wire.rs
@@ -2,7 +2,7 @@
 
 use std::collections::VecDeque;
 use std::ffi::CStr;
-use std::os::unix::io::{BorrowedFd, OwnedFd, RawFd};
+use std::os::unix::io::{BorrowedFd, OwnedFd};
 
 use crate::protocol::{Argument, ArgumentType, Message};
 
@@ -68,7 +68,7 @@ impl std::fmt::Display for MessageParseError {
 ///
 /// Any serialized Fd will be `dup()`-ed in the process
 pub fn write_to_buffers(
-    msg: &Message<u32, RawFd>,
+    msg: &Message<u32, BorrowedFd>,
     payload: &mut [u8],
     fds: &mut Vec<OwnedFd>,
 ) -> Result<usize, MessageWriteError> {
@@ -123,9 +123,7 @@ pub fn write_to_buffers(
             Argument::NewId(n) => write_buf(n, payload)?,
             Argument::Array(ref a) => write_array_to_payload(a, payload)?,
             Argument::Fd(fd) => {
-                let dup_fd = unsafe { BorrowedFd::borrow_raw(fd) }
-                    .try_clone_to_owned()
-                    .map_err(MessageWriteError::DupFdFailed)?;
+                let dup_fd = fd.try_clone_to_owned().map_err(MessageWriteError::DupFdFailed)?;
                 fds.push(dup_fd);
                 payload
             }
@@ -252,7 +250,7 @@ mod tests {
     use super::*;
     use crate::protocol::AllowNull;
     use smallvec::smallvec;
-    use std::{ffi::CString, os::unix::io::IntoRawFd};
+    use std::ffi::CString;
 
     #[test]
     fn into_from_raw_cycle() {
@@ -290,6 +288,6 @@ mod tests {
             &mut fd_buffer,
         )
         .unwrap();
-        assert_eq!(rebuilt.map_fd(IntoRawFd::into_raw_fd), msg);
+        assert_eq!(rebuilt, msg.map_fd(|fd| fd.try_clone_to_owned().unwrap()));
     }
 }

--- a/wayland-backend/src/server_api.rs
+++ b/wayland-backend/src/server_api.rs
@@ -2,7 +2,7 @@ use std::{
     ffi::CString,
     fmt,
     os::unix::{
-        io::{BorrowedFd, OwnedFd, RawFd},
+        io::{BorrowedFd, OwnedFd},
         net::UnixStream,
     },
     sync::Arc,
@@ -386,7 +386,7 @@ impl Handle {
     /// - the message opcode must be valid for the sender interface
     /// - the argument list must match the prototype for the message associated with this opcode
     #[inline]
-    pub fn send_event(&self, msg: Message<ObjectId, RawFd>) -> Result<(), InvalidId> {
+    pub fn send_event(&self, msg: Message<ObjectId, BorrowedFd>) -> Result<(), InvalidId> {
         self.handle.send_event(msg)
     }
 

--- a/wayland-backend/src/sys/client_impl/mod.rs
+++ b/wayland-backend/src/sys/client_impl/mod.rs
@@ -5,7 +5,7 @@ use std::{
     ffi::CStr,
     os::raw::{c_int, c_void},
     os::unix::{
-        io::{BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd},
+        io::{AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd},
         net::UnixStream,
     },
     ptr::{self, NonNull},
@@ -554,7 +554,7 @@ impl InnerBackend {
 
     pub fn send_request(
         &self,
-        Message { sender_id: ObjectId { id }, opcode, args }: Message<ObjectId, RawFd>,
+        Message { sender_id: ObjectId { id }, opcode, args }: Message<ObjectId, BorrowedFd>,
         data: Option<Arc<dyn ObjectData>>,
         child_spec: Option<(&'static Interface, u32)>,
     ) -> Result<ObjectId, InvalidId> {
@@ -647,7 +647,7 @@ impl InnerBackend {
                 Argument::Uint(u) => argument_list.push(wl_argument { u }),
                 Argument::Int(i) => argument_list.push(wl_argument { i }),
                 Argument::Fixed(f) => argument_list.push(wl_argument { f }),
-                Argument::Fd(h) => argument_list.push(wl_argument { h }),
+                Argument::Fd(h) => argument_list.push(wl_argument { h: h.as_raw_fd() }),
                 Argument::Array(ref a) => {
                     let a = Box::new(wl_array {
                         size: a.len(),

--- a/wayland-backend/src/sys/server_impl/mod.rs
+++ b/wayland-backend/src/sys/server_impl/mod.rs
@@ -5,7 +5,7 @@ use std::{
     ffi::{CStr, CString},
     os::raw::{c_int, c_void},
     os::unix::{
-        io::{BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd},
+        io::{AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd},
         net::UnixStream,
     },
     ptr::NonNull,
@@ -591,7 +591,7 @@ impl InnerHandle {
         }
     }
 
-    pub fn send_event(&self, msg: Message<ObjectId, RawFd>) -> Result<(), InvalidId> {
+    pub fn send_event(&self, msg: Message<ObjectId, BorrowedFd>) -> Result<(), InvalidId> {
         self.state.lock().unwrap().send_event(msg)
     }
 
@@ -886,7 +886,7 @@ pub(crate) trait ErasedState: Any {
         &self,
         id: InnerObjectId,
     ) -> Result<Arc<dyn std::any::Any + Send + Sync>, InvalidId>;
-    fn send_event(&mut self, msg: Message<ObjectId, RawFd>) -> Result<(), InvalidId>;
+    fn send_event(&mut self, msg: Message<ObjectId, BorrowedFd>) -> Result<(), InvalidId>;
     fn post_error(&mut self, object_id: InnerObjectId, error_code: u32, message: CString);
     fn kill_client(&mut self, client_id: InnerClientId, reason: DisconnectReason);
     fn global_info(&self, id: InnerGlobalId) -> Result<GlobalInfo, InvalidId>;
@@ -1088,7 +1088,7 @@ impl<D: 'static> ErasedState for State<D> {
 
     fn send_event(
         &mut self,
-        Message { sender_id: ObjectId { id }, opcode, args }: Message<ObjectId, RawFd>,
+        Message { sender_id: ObjectId { id }, opcode, args }: Message<ObjectId, BorrowedFd>,
     ) -> Result<(), InvalidId> {
         if !id.alive.load(Ordering::Acquire) || id.ptr.is_null() {
             return Err(InvalidId);
@@ -1115,7 +1115,7 @@ impl<D: 'static> ErasedState for State<D> {
                 Argument::Uint(u) => argument_list.push(wl_argument { u }),
                 Argument::Int(i) => argument_list.push(wl_argument { i }),
                 Argument::Fixed(f) => argument_list.push(wl_argument { f }),
-                Argument::Fd(h) => argument_list.push(wl_argument { h }),
+                Argument::Fd(h) => argument_list.push(wl_argument { h: h.as_raw_fd() }),
                 Argument::Array(ref a) => {
                     let a = Box::new(wl_array {
                         size: a.len(),

--- a/wayland-backend/src/test/many_args.rs
+++ b/wayland-backend/src/test/many_args.rs
@@ -1,5 +1,7 @@
 use std::{
     ffi::{CStr, CString},
+    io,
+    os::unix::io::AsFd,
     sync::atomic::{AtomicBool, Ordering},
 };
 
@@ -65,6 +67,7 @@ macro_rules! serverdata_impls {
                 _: $server_backend::GlobalId,
                 object_id: $server_backend::ObjectId,
             ) -> Arc<dyn $server_backend::ObjectData<()>> {
+                let stdout = io::stdout().lock();
                 handle
                     .send_event(message!(
                         object_id,
@@ -77,7 +80,7 @@ macro_rules! serverdata_impls {
                             Argument::Str(Some(Box::new(
                                 CString::new("I want cake".as_bytes()).unwrap()
                             ))),
-                            Argument::Fd(1), // stdout
+                            Argument::Fd(stdout.as_fd()),
                         ],
                     ))
                     .unwrap();
@@ -183,6 +186,7 @@ expand_test!(many_args, {
     assert!(client_data.0.load(Ordering::SeqCst));
 
     // send the many_args request
+    let stdin = io::stdin().lock();
     client
         .send_request(
             message!(
@@ -196,7 +200,7 @@ expand_test!(many_args, {
                     Argument::Str(Some(Box::new(
                         CString::new("I like trains".as_bytes()).unwrap()
                     ))),
-                    Argument::Fd(0), // stdin
+                    Argument::Fd(stdin.as_fd()),
                 ],
             ),
             None,

--- a/wayland-client/src/conn.rs
+++ b/wayland-client/src/conn.rs
@@ -1,7 +1,7 @@
 use std::{
     env, fmt,
     io::ErrorKind,
-    os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd},
+    os::unix::io::{AsFd, BorrowedFd, FromRawFd, OwnedFd},
     os::unix::net::UnixStream,
     path::PathBuf,
     sync::{
@@ -198,7 +198,6 @@ impl Connection {
         data: Option<Arc<dyn ObjectData>>,
     ) -> Result<ObjectId, InvalidId> {
         let (msg, child_spec) = proxy.write_request(self, request)?;
-        let msg = msg.map_fd(|fd| fd.as_raw_fd());
         self.backend.send_request(msg, data, child_spec)
     }
 

--- a/wayland-server/src/display.rs
+++ b/wayland-server/src/display.rs
@@ -1,5 +1,5 @@
 use std::{
-    os::unix::io::{AsFd, AsRawFd, BorrowedFd},
+    os::unix::io::{AsFd, BorrowedFd},
     os::unix::net::UnixStream,
     sync::Arc,
 };
@@ -175,7 +175,6 @@ impl DisplayHandle {
         event: I::Event<'_>,
     ) -> Result<(), InvalidId> {
         let msg = resource.write_event(self, event)?;
-        let msg = msg.map_fd(|fd| fd.as_raw_fd());
         self.handle.send_event(msg)
     }
 


### PR DESCRIPTION
This is a breaking change to `wayland-backend`, but not to `wayland-client` or `wayland-server`. I believe that should be fine.

This avoids an unsafe conversion in the `rs` backend.

Based on https://github.com/Smithay/wayland-rs/pull/677.