### PR TITLE
feat: let delegate_noop can handle constGeneric

### DIFF
--- a/wayland-client/CHANGELOG.md
+++ b/wayland-client/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Implement `AsFd` for `Connection` and `EventQueue` so they can easily be used in a
   `calloop` source.
+- Make `delegate_noop` usable for constGeneric type.
 
 ## 0.31.0 -- 2023-09-02
 

--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -786,8 +786,8 @@ impl ObjectData for TemporaryData {
 /// ```
 #[macro_export]
 macro_rules! delegate_dispatch {
-    ($(@< $( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? $dispatch_from:ty : [$interface: ty: $udata: ty] => $dispatch_to: ty) => {
-        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::Dispatch<$interface, $udata> for $dispatch_from {
+    ($(@< $( $($lt:ident )+ $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? $dispatch_from:ty : [$interface: ty: $udata: ty] => $dispatch_to: ty) => {
+        impl$(< $( $($lt )+ $( : $clt $(+ $dlt )* )? ),+ >)? $crate::Dispatch<$interface, $udata> for $dispatch_from {
             fn event(
                 state: &mut Self,
                 proxy: &$interface,
@@ -831,13 +831,28 @@ macro_rules! delegate_dispatch {
 ///
 /// // This interface should not emit events:
 /// delegate_noop!(ExampleApp: wl_subcompositor::WlSubcompositor);
+///
+/// // Also you can do it with generic type, for example
+/// struct ExampleAppGeneric<const X: usize>;
+/// delegate_noop!(@<const X: usize> ExampleAppGeneric<X>: ignore wl_data_offer::WlDataOffer);
+/// delegate_noop!(@<const X: usize> ExampleAppGeneric<X>: wl_subcompositor::WlSubcompositor);
+///
+/// // @ is to start with generic, and for base generic type looks like below.
+/// trait E {
+///    // add code here
+/// }
+/// struct ExampleAppGeneric2<T: E> {
+///     a: T
+/// }
+/// delegate_noop!(@<T: E> ExampleAppGeneric2<T>: wl_data_offer::WlDataOffer);
+/// delegate_noop!(@<T: E> ExampleAppGeneric2<T>: ignore wl_subcompositor::WlSubcompositor);
 /// ```
 ///
 /// This last example will execute `unreachable!()` if the interface emits any events.
 #[macro_export]
 macro_rules! delegate_noop {
-    ($(@< $( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? $dispatch_from: ty : $interface: ty) => {
-        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::Dispatch<$interface, ()> for $dispatch_from {
+    ($(@< $( $($lt:ident )+ $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? $dispatch_from: ty : $interface: ty) => {
+        impl$(< $( $($lt )+ $( : $clt $(+ $dlt )* )? ),+ >)? $crate::Dispatch<$interface, ()> for $dispatch_from {
             fn event(
                 _: &mut Self,
                 _: &$interface,
@@ -851,8 +866,9 @@ macro_rules! delegate_noop {
         }
     };
 
-    ($(@< $( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? $dispatch_from: ty : ignore $interface: ty) => {
-        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::Dispatch<$interface, ()> for $dispatch_from {
+
+    ($(@< $( $($lt:ident )+ $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? $dispatch_from: ty : ignore $interface: ty) => {
+        impl$(< $( $($lt )+ $( : $clt $(+ $dlt )* )? ),+ >)? $crate::Dispatch<$interface, ()> for $dispatch_from {
             fn event(
                 _: &mut Self,
                 _: &$interface,
@@ -864,4 +880,5 @@ macro_rules! delegate_noop {
             }
         }
     };
+
 }

--- a/wayland-server/CHANGELOG.md
+++ b/wayland-server/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Updated wayland-backend to 0.3
 - Use `BorrowedFd<'_>` arguments instead of `RawFd`
 - `Resource::destroyed` now passes the resource type instead of the `ObjectId`.
+- Make `delegate_dispatch` usable for constGeneric type.
 
 #### Additions
 

--- a/wayland-server/src/dispatch.rs
+++ b/wayland-server/src/dispatch.rs
@@ -347,10 +347,15 @@ impl<I: Resource + 'static, U: Send + Sync + 'static, D: Dispatch<I, U> + 'stati
 ///     }
 /// }
 /// ```
+/// This macro_rules also support to be used with generic type, it will be similiar with client one
+/// like
+/// ```ignore
+/// delegate_dispatch!(@<const X : usize> ExampleApp<X>: [wl_output::WlOutput: MyUserData] => DelegateToMe);
+/// ```
 #[macro_export]
 macro_rules! delegate_dispatch {
-    ($(@< $( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? $dispatch_from:ty : [$interface: ty: $udata: ty] => $dispatch_to: ty) => {
-        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::Dispatch<$interface, $udata> for $dispatch_from {
+    ($(@< $( $($lt:ident )+ $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? $dispatch_from:ty : [$interface: ty: $udata: ty] => $dispatch_to: ty) => {
+        impl$(< $( $($lt )+ $( : $clt $(+ $dlt )* )? ),+ >)? $crate::Dispatch<$interface, $udata> for $dispatch_from {
             fn request(
                 state: &mut Self,
                 client: &$crate::Client,


### PR DESCRIPTION
the macro of delegate_noop cannot handle like
`struct A<const X: unsize>`, such kind of struct, so I want to fix it