### PR TITLE
Remove FreeBSD 12.1 CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,9 +8,6 @@ env:
 task:
   only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR != ''
   matrix:
-    - name: FreeBSD 12.1
-      freebsd_instance:
-        image_family: freebsd-12-1-snap
     - name: FreeBSD 13.0
       freebsd_instance:
         image_family: freebsd-13-0-snap


### PR DESCRIPTION
FreeBSD 12 is EOL, and the package archives don't seem to be available anymore.