### PR TITLE
backend/rs: Retry send/recv on `EINTR`

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 #### Bugfixes
 - backend/sys: Fix error/segfault if object argument is no longer alive
+- backend/rs: Retry send/recv on `EINTR`
+  * Matches the behavior of libwayland
 
 ## 0.3.2 -- 2023-09-25
 


### PR DESCRIPTION
This could be considered a breaking API change, but probably no callers are actually handling it. And it seems libwayland does this, so making the rs backend consistent here can be considered a bug fix.