### PR TITLE
Generate aliases with "z" stripped for stable dmabuf protocol

### DIFF
--- a/wayland-protocols/src/wp.rs
+++ b/wayland-protocols/src/wp.rs
@@ -179,6 +179,24 @@ pub mod linux_dmabuf {
             []
         );
     }
+
+    /// Stable version 1 (Aliased to zv1, as zv1 became stable without name change)
+    pub mod v1 {
+        #[cfg(feature = "client")]
+        pub mod client {
+            //! Client-side API of this protocol
+            pub use super::super::zv1::client::__interfaces;
+            use super::super::zv1::client::*;
+            wayland_scanner::__generate_aliases!("./protocols/stable/linux-dmabuf/linux-dmabuf-v1.xml");
+        }
+        #[cfg(feature = "server")]
+        pub mod server {
+            //! Server-side API of this protocol
+            pub use super::super::zv1::server::__interfaces;
+            use super::super::zv1::server::*;
+            wayland_scanner::__generate_aliases!("./protocols/stable/linux-dmabuf/linux-dmabuf-v1.xml");
+        }
+    }
 }
 
 #[cfg(feature = "unstable")]

--- a/wayland-scanner/src/aliases_gen.rs
+++ b/wayland-scanner/src/aliases_gen.rs
@@ -1,0 +1,41 @@
+use proc_macro2::{Ident, Span, TokenStream};
+
+use quote::quote;
+
+use crate::{
+    protocol::{Interface, Protocol},
+    util::{description_to_doc_attr, snake_to_camel},
+};
+
+pub fn generate_aliases(protocol: &Protocol) -> TokenStream {
+    protocol.interfaces.iter().map(generate_aliases_for).collect()
+}
+
+fn generate_aliases_for(interface: &Interface) -> TokenStream {
+    let zname = &interface.name;
+    let name = interface.name.strip_prefix('z').unwrap_or(zname);
+
+    let zmod_name = Ident::new(zname, Span::call_site());
+    let zmod = quote!(super::#zmod_name);
+
+    let ziface_name = Ident::new(&snake_to_camel(zname), Span::call_site());
+    let iface_name = Ident::new(&snake_to_camel(name), Span::call_site());
+
+    let mod_name = Ident::new(name, Span::call_site());
+    let mod_doc = interface.description.as_ref().map(description_to_doc_attr);
+
+    let enums = crate::common::generate_enum_reexports_for(&zmod, interface);
+    let sinces =
+        crate::common::gen_msg_constant_reexports(&zmod, &interface.requests, &interface.events);
+
+    quote! {
+        #mod_doc
+        pub mod #mod_name {
+            #enums
+            #sinces
+            pub use #zmod::Event;
+            pub use #zmod::Request;
+            pub use #zmod::#ziface_name as #iface_name;
+        }
+    }
+}


### PR DESCRIPTION
As you may know, `zwp_linux_dmabuf_v1` became stable without striping of the `z` prefix.
This is just a random idea to do the striping ourselves, by aliasing all `v1` types to `zv1` ones. 

Eg.
- wp_linux_buffer_params_v1
  - WpLinuxBufferParamsV1 -> ZwpLinuxBufferParamsV1
  - Event -> Event
  - Request -> Request
  - ...
