### PR TITLE
Fix deadlock in blocking_dispatch

### DIFF
--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -472,9 +472,8 @@ impl<State> EventQueue<State> {
         //
         // We purposefully ignore the possible error, as that would make us early return in a way that might
         // lose events, and the potential socket error will be caught in other places anyway.
-        let _ = backend.backend.dispatch_inner_queue();
+        let mut dispatched = backend.backend.dispatch_inner_queue().unwrap_or_default();
 
-        let mut dispatched = 0;
         while let Some(QueueEvent(cb, msg, odata)) = Self::try_next(&qhandle.inner) {
             cb(backend, msg, data, odata, qhandle)?;
             dispatched += 1;


### PR DESCRIPTION
If dispatch_inner_queue dispatches some events, blocking_dispatch will still wait for some events to come in, rather than turning the loop again and checking its done variable. This is causing Alacritty 0.13 to hang on startup.