### PR TITLE
wayland-client: Add tokio feature for AsyncEventQueue

### DIFF
--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -12,13 +12,20 @@ keywords = ["wayland", "client"]
 description = "Bindings to the standard C implementation of the wayland protocol, client side."
 readme = "README.md"
 
+[[example]]
+name = "list_globals"
+
+[[example]]
+name = "simple_window_async"
+required-features = ["tokio"]
+
 [dependencies]
 wayland-backend = { version = "0.3.1", path = "../wayland-backend" }
 wayland-scanner = { version = "0.31.0", path = "../wayland-scanner" }
 bitflags = "2"
 rustix = { version = "0.38.0", features = ["event"] }
 log = { version = "0.4", optional = true }
-tokio = { version = "1", optional = true, default-features = false, features = ["net"] }
+tokio = { version = "1", optional = true, default-features = false, features = ["net", "rt"] }
 
 [dev-dependencies]
 wayland-protocols = { path = "../wayland-protocols", features = ["client"] }

--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -18,6 +18,7 @@ wayland-scanner = { version = "0.31.0", path = "../wayland-scanner" }
 bitflags = "2"
 rustix = { version = "0.38.0", features = ["event"] }
 log = { version = "0.4", optional = true }
+tokio = { version = "1", optional = true, default-features = false, features = ["net"] }
 
 [dev-dependencies]
 wayland-protocols = { path = "../wayland-protocols", features = ["client"] }
@@ -28,3 +29,7 @@ tempfile = "3.2"
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+default = []
+tokio = ["dep:tokio"]

--- a/wayland-client/examples/simple_window_async.rs
+++ b/wayland-client/examples/simple_window_async.rs
@@ -1,0 +1,254 @@
+use std::{
+    error::Error,
+    fs::File,
+    os::unix::prelude::AsFd,
+    process,
+};
+
+use wayland_client::{
+    delegate_noop,
+    protocol::{
+        wl_buffer, wl_compositor, wl_keyboard, wl_registry, wl_seat, wl_shm, wl_shm_pool,
+        wl_surface,
+    },
+    Connection, Dispatch, QueueHandle, WEnum,
+    ConnectionExtAsync,
+};
+
+use wayland_protocols::xdg::shell::client::{xdg_surface, xdg_toplevel, xdg_wm_base};
+
+async fn real_main() -> Result<(), Box<dyn Error + 'static>> {
+    let conn = Connection::connect_to_env()?;
+
+    let mut event_queue = conn.new_async_event_queue()?;
+    let qhandle = event_queue.queue.handle();
+
+    let display = conn.display();
+    display.get_registry(&qhandle, ());
+
+    let mut state = State {
+        running: true,
+        base_surface: None,
+        buffer: None,
+        wm_base: None,
+        xdg_surface: None,
+        configured: false,
+    };
+
+    println!("Starting the example window app, press <ESC> to quit.");
+
+    while state.running {
+        event_queue.dispatch_single(&mut state).await?;
+    }
+
+    Ok(())
+}
+
+fn main() {
+    use tokio::runtime::Builder;
+    // Create the runtime here so that we don't force tokio/macros feature on downstream users
+    let rt = Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .expect("Failed to create tokio runtime");
+    rt.block_on(async move {
+        if let Err(e) = real_main().await {
+            panic!("{}", &e);
+        }
+    });
+}
+
+struct State {
+    running: bool,
+    base_surface: Option<wl_surface::WlSurface>,
+    buffer: Option<wl_buffer::WlBuffer>,
+    wm_base: Option<xdg_wm_base::XdgWmBase>,
+    xdg_surface: Option<(xdg_surface::XdgSurface, xdg_toplevel::XdgToplevel)>,
+    configured: bool,
+}
+
+impl Dispatch<wl_registry::WlRegistry, ()> for State {
+    fn event(
+        state: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let wl_registry::Event::Global { name, interface, .. } = event {
+            match &interface[..] {
+                "wl_compositor" => {
+                    let compositor =
+                        registry.bind::<wl_compositor::WlCompositor, _, _>(name, 1, qh, ());
+                    let surface = compositor.create_surface(qh, ());
+                    state.base_surface = Some(surface);
+
+                    if state.wm_base.is_some() && state.xdg_surface.is_none() {
+                        state.init_xdg_surface(qh);
+                    }
+                }
+                "wl_shm" => {
+                    let shm = registry.bind::<wl_shm::WlShm, _, _>(name, 1, qh, ());
+
+                    let (init_w, init_h) = (320, 240);
+
+                    let mut file = tempfile::tempfile().unwrap();
+                    draw(&mut file, (init_w, init_h));
+                    let pool = shm.create_pool(file.as_fd(), (init_w * init_h * 4) as i32, qh, ());
+                    let buffer = pool.create_buffer(
+                        0,
+                        init_w as i32,
+                        init_h as i32,
+                        (init_w * 4) as i32,
+                        wl_shm::Format::Argb8888,
+                        qh,
+                        (),
+                    );
+                    state.buffer = Some(buffer.clone());
+
+                    if state.configured {
+                        let surface = state.base_surface.as_ref().unwrap();
+                        surface.attach(Some(&buffer), 0, 0);
+                        surface.commit();
+                    }
+                }
+                "wl_seat" => {
+                    registry.bind::<wl_seat::WlSeat, _, _>(name, 1, qh, ());
+                }
+                "xdg_wm_base" => {
+                    let wm_base = registry.bind::<xdg_wm_base::XdgWmBase, _, _>(name, 1, qh, ());
+                    state.wm_base = Some(wm_base);
+
+                    if state.base_surface.is_some() && state.xdg_surface.is_none() {
+                        state.init_xdg_surface(qh);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+// Ignore events from these object types in this example.
+delegate_noop!(State: ignore wl_compositor::WlCompositor);
+delegate_noop!(State: ignore wl_surface::WlSurface);
+delegate_noop!(State: ignore wl_shm::WlShm);
+delegate_noop!(State: ignore wl_shm_pool::WlShmPool);
+delegate_noop!(State: ignore wl_buffer::WlBuffer);
+
+fn draw(tmp: &mut File, (buf_x, buf_y): (u32, u32)) {
+    use std::{cmp::min, io::Write};
+    let mut buf = std::io::BufWriter::new(tmp);
+    for y in 0..buf_y {
+        for x in 0..buf_x {
+            let a = 0xFF;
+            let r = min(((buf_x - x) * 0xFF) / buf_x, ((buf_y - y) * 0xFF) / buf_y);
+            let g = min((x * 0xFF) / buf_x, ((buf_y - y) * 0xFF) / buf_y);
+            let b = min(((buf_x - x) * 0xFF) / buf_x, (y * 0xFF) / buf_y);
+            buf.write_all(&[b as u8, g as u8, r as u8, a as u8]).unwrap();
+        }
+    }
+    buf.flush().unwrap();
+}
+
+impl State {
+    fn init_xdg_surface(&mut self, qh: &QueueHandle<State>) {
+        let wm_base = self.wm_base.as_ref().unwrap();
+        let base_surface = self.base_surface.as_ref().unwrap();
+
+        let xdg_surface = wm_base.get_xdg_surface(base_surface, qh, ());
+        let toplevel = xdg_surface.get_toplevel(qh, ());
+        toplevel.set_title("A fantastic window!".into());
+
+        base_surface.commit();
+
+        self.xdg_surface = Some((xdg_surface, toplevel));
+    }
+}
+
+impl Dispatch<xdg_wm_base::XdgWmBase, ()> for State {
+    fn event(
+        _: &mut Self,
+        wm_base: &xdg_wm_base::XdgWmBase,
+        event: xdg_wm_base::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let xdg_wm_base::Event::Ping { serial } = event {
+            wm_base.pong(serial);
+        }
+    }
+}
+
+impl Dispatch<xdg_surface::XdgSurface, ()> for State {
+    fn event(
+        state: &mut Self,
+        xdg_surface: &xdg_surface::XdgSurface,
+        event: xdg_surface::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let xdg_surface::Event::Configure { serial, .. } = event {
+            xdg_surface.ack_configure(serial);
+            state.configured = true;
+            let surface = state.base_surface.as_ref().unwrap();
+            if let Some(ref buffer) = state.buffer {
+                surface.attach(Some(buffer), 0, 0);
+                surface.commit();
+            }
+        }
+    }
+}
+
+impl Dispatch<xdg_toplevel::XdgToplevel, ()> for State {
+    fn event(
+        state: &mut Self,
+        _: &xdg_toplevel::XdgToplevel,
+        event: xdg_toplevel::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let xdg_toplevel::Event::Close {} = event {
+            state.running = false;
+        }
+    }
+}
+
+impl Dispatch<wl_seat::WlSeat, ()> for State {
+    fn event(
+        _: &mut Self,
+        seat: &wl_seat::WlSeat,
+        event: wl_seat::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let wl_seat::Event::Capabilities { capabilities: WEnum::Value(capabilities) } = event {
+            if capabilities.contains(wl_seat::Capability::Keyboard) {
+                seat.get_keyboard(qh, ());
+            }
+        }
+    }
+}
+
+impl Dispatch<wl_keyboard::WlKeyboard, ()> for State {
+    fn event(
+        state: &mut Self,
+        _: &wl_keyboard::WlKeyboard,
+        event: wl_keyboard::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let wl_keyboard::Event::Key { key, .. } = event {
+            if key == 1 {
+                // ESC key
+                state.running = false;
+            }
+        }
+    }
+}

--- a/wayland-client/examples/simple_window_async.rs
+++ b/wayland-client/examples/simple_window_async.rs
@@ -1,9 +1,4 @@
-use std::{
-    error::Error,
-    fs::File,
-    os::unix::prelude::AsFd,
-    process,
-};
+use std::{error::Error, fs::File, os::unix::prelude::AsFd, process};
 
 use wayland_client::{
     delegate_noop,
@@ -11,8 +6,7 @@ use wayland_client::{
         wl_buffer, wl_compositor, wl_keyboard, wl_registry, wl_seat, wl_shm, wl_shm_pool,
         wl_surface,
     },
-    Connection, Dispatch, QueueHandle, WEnum,
-    ConnectionExtAsync,
+    Connection, ConnectionExtAsync, Dispatch, QueueHandle, WEnum,
 };
 
 use wayland_protocols::xdg::shell::client::{xdg_surface, xdg_toplevel, xdg_wm_base};
@@ -47,10 +41,8 @@ async fn real_main() -> Result<(), Box<dyn Error + 'static>> {
 fn main() {
     use tokio::runtime::Builder;
     // Create the runtime here so that we don't force tokio/macros feature on downstream users
-    let rt = Builder::new_current_thread()
-        .enable_io()
-        .build()
-        .expect("Failed to create tokio runtime");
+    let rt =
+        Builder::new_current_thread().enable_io().build().expect("Failed to create tokio runtime");
     rt.block_on(async move {
         if let Err(e) = real_main().await {
             panic!("{}", &e);

--- a/wayland-client/src/async_event_queue.rs
+++ b/wayland-client/src/async_event_queue.rs
@@ -1,0 +1,183 @@
+use std::{
+    io,
+    num::NonZeroUsize,
+    sync::{
+        Arc,
+        atomic::Ordering,
+    },
+    os::fd::{
+        AsFd,
+        BorrowedFd,
+    },
+};
+use crate::{
+    conn::SyncData,
+    Connection,
+    EventQueue,
+    DispatchError,
+    WaylandError,
+    protocol::{
+        wl_display,
+    },
+};
+use tokio::io::{
+    unix::AsyncFd,
+    Ready,
+};
+
+/// Asynchronous version of [`EventQueue`], taking borrowed references to an [`EventQueue`],
+/// allowing for non-blocking polled asynchronous operations against the Queue using
+/// [`AsyncFd`] from the tokio runtime to poll against the wayland socket
+#[derive(Debug)]
+pub struct AsyncEventQueue<'a, State> {
+    /// Inner reference to synchronous version of this event queue
+    pub queue: EventQueue<State>,
+    conn: &'a Connection,
+    afd: AsyncFd<BorrowedFd<'a>>,
+}
+
+impl<'a, State> AsyncEventQueue<'a, State> {
+    /// Creates a new [`AsyncEventQueue`] from a reference to a given [`Connection`] and
+    /// *synchronous* [`EventQueue`]
+    #[inline]
+    pub fn new(
+        conn: &'a Connection,
+        event_queue: EventQueue<State>,
+    ) -> io::Result<Self> {
+        Ok(AsyncEventQueue {
+            queue: event_queue,
+            conn: conn,
+            afd: AsyncFd::new(conn.as_fd())?,
+        })
+    }
+
+    #[inline(always)]
+    fn dispatch_pending(&mut self, data: &mut State) -> Result<Option<NonZeroUsize>, DispatchError> {
+        self.queue.dispatch_pending(data)
+            .map(NonZeroUsize::new)
+    }
+
+    /// Asynchronous version of [`EventQueue::blocking_dispatch`] that uses tokio's fd-based
+    /// polling system to avoid blocking.
+    ///
+    /// This function completes once any number of events have been dispatched *on this thread*.
+    ///
+    /// In the success case, returns the # of events that were dispatched.
+    pub async fn dispatch_single(&mut self, data: &mut State) -> Result<usize, DispatchError> {
+        self.queue.flush_d()?;
+        if let Some(v) = self.dispatch_pending(data)? {
+            return Ok(v.get());
+        }
+        loop {
+            let mut guard = self.afd.readable_mut().await
+                .map_err(|e| DispatchError::Backend(WaylandError::from(e)))?;
+            let lock = if let Some(v) = self.queue.prepare_read() {
+                v
+            } else {
+                if let Some(v) = self.dispatch_pending(data)? {
+                    return Ok(v.get());
+                } else {
+                    continue;
+                }
+            };
+            let ret = match lock.read() {
+                Ok(..) => Some(self.queue.dispatch_pending(data)),
+                Err(ref e) if e.would_block() => {
+                    guard.clear_ready_matching(Ready::READABLE);
+                    None
+                },
+                Err(e) => Some(Err(DispatchError::from(e))),
+            };
+            if let Some(ret) = ret {
+                return ret;
+            }
+        }
+    }
+
+    /// Asynchronous version of [`EventQueue::roundtrip`]
+    ///
+    /// Instead of blocking, this [`Future`](std::future::Future) will complete once the roundtrip
+    /// has completed
+    ///
+    /// This function may be useful during initial setup of your app. This function may also be useful
+    /// where you need to guarantee all requests prior to calling this function are completed.
+    pub async fn roundtrip(&mut self, data: &mut State) -> Result<usize, DispatchError> {
+        let done = Arc::new(SyncData::default());
+        let display = self.conn.display();
+        self.conn.send_request(
+            &display,
+            wl_display::Request::Sync {},
+            Some(done.clone()),
+        ).map_err(|_| {
+            WaylandError::Io(rustix::io::Errno::PIPE.into())
+        })?;
+        let mut n = 0usize;
+        while !done.done.load(Ordering::Relaxed) {
+            n = n + self.dispatch_single(data).await?;
+        }
+        Ok(n)
+    }
+
+    /// Converts this AsyncEventQueue back into it's synchronous variant
+    #[inline(always)]
+    pub fn unwrap(self) -> EventQueue<State> {
+        self.into()
+    }
+}
+
+impl<'a, State> Into<EventQueue<State>> for AsyncEventQueue<'a, State> {
+    #[inline(always)]
+    fn into(self) -> EventQueue<State> {
+        self.queue
+    }
+}
+
+trait EventQueueExt<State> {
+    fn flush_d(&self) -> Result<(), DispatchError>;
+}
+
+impl<State> EventQueueExt<State> for EventQueue<State> {
+    #[inline(always)]
+    fn flush_d(&self) -> Result<(), DispatchError> {
+        self.flush()
+            .map_err(DispatchError::Backend)
+    }
+}
+
+/// Represents types of errors that might indicate that the error was that the operation would have
+/// blocked
+trait MaybeBlockingError {
+    /// Returns `true` if self indicates an error meaning that an operation would have blocked
+	fn would_block(&self) -> bool;
+}
+
+impl MaybeBlockingError for io::Error {
+	#[inline(always)]
+	fn would_block(&self) -> bool {
+		use io::ErrorKind;
+		self.kind() == ErrorKind::WouldBlock
+	}
+}
+
+impl MaybeBlockingError for WaylandError {
+	#[inline]
+	fn would_block(&self) -> bool {
+		match self {
+			WaylandError::Io(e) => e.would_block(),
+			_ => false
+		}
+	}
+}
+
+/// Additional methods available on [`Connection`] when an async runtime is available
+pub trait ConnectionExtAsync {
+    /// Creates a new *asynchronous* event queue, containing the downstream [`EventQueue`]
+    fn new_async_event_queue<'a, State>(&'a self) -> io::Result<AsyncEventQueue<'a, State>>;
+}
+
+impl ConnectionExtAsync for Connection {
+    #[inline]
+    fn new_async_event_queue<'a, State>(&'a self) -> io::Result<AsyncEventQueue<'a, State>> {
+        AsyncEventQueue::new(self, self.new_event_queue())
+    }
+}

--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -12,6 +12,8 @@ use wayland_backend::{
 };
 
 use crate::{conn::SyncData, Connection, DispatchError, Proxy};
+#[cfg(all(target_family = "unix", feature = "tokio"))]
+use crate::AsyncEventQueue;
 
 /// A trait for handlers of proxies' events delivered to an [`EventQueue`].
 ///
@@ -354,6 +356,14 @@ impl<State> AsFd for EventQueue<State> {
     /// Provides fd from [`Backend::poll_fd`] for polling.
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.conn.as_fd()
+    }
+}
+
+#[cfg(all(target_family = "unix", feature = "tokio"))]
+impl<'a, State> From<AsyncEventQueue<'a, State>> for EventQueue<State> {
+    #[inline(always)]
+    fn from(async_queue: AsyncEventQueue<'a, State>) -> Self {
+        async_queue.queue
     }
 }
 

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -195,12 +195,10 @@ pub mod backend {
 
 pub use wayland_backend::protocol::WEnum;
 
+#[cfg(all(target_family = "unix", feature = "tokio"))]
+pub use async_event_queue::{AsyncEventQueue, ConnectionExtAsync};
 pub use conn::{ConnectError, Connection};
 pub use event_queue::{Dispatch, EventQueue, QueueFreezeGuard, QueueHandle, QueueProxyData};
-#[cfg(all(target_family = "unix", feature = "tokio"))]
-pub use async_event_queue::{
-    AsyncEventQueue, ConnectionExtAsync
-};
 
 // internal imports for dispatching logging depending on the `log` feature
 #[cfg(feature = "log")]

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -177,6 +177,8 @@ use wayland_backend::{
     protocol::{Interface, Message},
 };
 
+#[cfg(all(target_family = "unix", feature = "tokio"))]
+mod async_event_queue;
 mod conn;
 mod event_queue;
 pub mod globals;
@@ -195,6 +197,10 @@ pub use wayland_backend::protocol::WEnum;
 
 pub use conn::{ConnectError, Connection};
 pub use event_queue::{Dispatch, EventQueue, QueueFreezeGuard, QueueHandle, QueueProxyData};
+#[cfg(all(target_family = "unix", feature = "tokio"))]
+pub use async_event_queue::{
+    AsyncEventQueue, ConnectionExtAsync
+};
 
 // internal imports for dispatching logging depending on the `log` feature
 #[cfg(feature = "log")]


### PR DESCRIPTION
This would add a `tokio` feature to the `wayland-client` crate, providing asynchronous versions of the following functions for an `EventQueue`.

I came across a desire for this integration while writing a single-threaded client, and needed to integrate events coming from other `tokio` sources.

I cannot find it now, but I swear I also once saw an issue asking how to integrate the `_poll` `EventQueue` API into [`tokio`](https://tokio.rs).

# Known Blocking Problems

- [ ] Documentation comments are lacking at best, and in some cases actually incorrect due to changes I've made to the API

# Known Lesser Issues

- [ ] `AsyncEventQueue` retains a reference to `Connection` specifically to appease lifetime req's of `AsyncFd` so that the `AsyncFd` can be long-lived. This *should* be avoidable.
- [ ] `simple_window_async` example only currently uses one `tokio` event source, making it somewhat meaningless
- [ ] There's too much code duplication between `simple_window` and `simple_window_async` examples, but using `include!(..)` macros to de-duplicate caused issues with the `wayland-scanner` proc macros
- [ ] ~~`dispatch_single` implementation could use review to ensure that `EventQueue::flush` calls are necessary and well-placed~~ `dispatch_single` implementation is broken due to expectations of `prepare_read()` being that it's called before the fd is readable

# Discussion Points

1. Does this belong in `wayland-client` with a `feature` flag as it is in this implementation, or would another crate make more sense? I personally think the former, but could see both.
2. Does the `dispatch_single` API on `AsyncEventQueue` make sense as a low-enough level API or does this feel more like a reference implementation that deserves lower level APIs?
3. I'd argue that with the popularity of `tokio` that offering a feature flag isn't *too* opinionated of a thing to do, given the # of folks who may like to have an API like this w/o thinking through the `AsyncFd` usage themselves

Sorry for the messy writeup, but I keep saying I'd break this out of the project I originally made it for, and submit it for upstream, and finally decided to do it even if it requires some discussion and a few edits (particularly around documentation) prior to being mergeable.