### PR TITLE
wayland-backend: raw-window-handle 0.6

### DIFF
--- a/wayland-backend/Cargo.toml
+++ b/wayland-backend/Cargo.toml
@@ -19,6 +19,7 @@ log = { version = "0.4", optional = true }
 scoped-tls = "1.0"
 downcast-rs = "1.2"
 raw-window-handle = { version = "0.5.0", optional = true }
+rwh_06 = { package = "raw-window-handle", version = "0.6.0", optional = true }
 
 [dependencies.smallvec]
 version = "1.9"

--- a/wayland-backend/src/lib.rs
+++ b/wayland-backend/src/lib.rs
@@ -33,8 +33,12 @@
 //!
 //! ## raw-window-handle integration
 //!
-//! This crate can implement [`HasRawWindowHandle`](raw_window_handle::HasRawWindowHandle) for the client
-//! module [`Backend`](client::Backend) type if you activate the `raw-window-handle` feature.
+//! The `rwh_06` feature activates the [`HasDisplayHandle`](raw_window_handle::HasDisplayHandle) implementation
+//! for the client module [`Backend`](client::Backend).
+//!
+//! ### Deprecated raw-window-handle versions
+//! 
+//! While raw-window-handle 0.5 is supported via the `raw-window-handle` feature, it is deprecated and will be removed in the future.
 //!
 //! Note that the `client_system` feature must also be enabled for the implementation to be activated.
 


### PR DESCRIPTION
Unfortuntely we used the `raw-window-handle` feature name for 0.5, which would be a breaking change. To handle this for the future, replicate what winit does and make a new feature for 0.6. The 0.5 version feature is deprecated and will be removed in a later version.