### PR TITLE
In debug logging, print 'fixed' values as floats

### DIFF
--- a/wayland-backend/src/protocol.rs
+++ b/wayland-backend/src/protocol.rs
@@ -126,7 +126,7 @@ impl<Id: std::fmt::Display, Fd: AsRawFd> std::fmt::Display for Argument<Id, Fd> 
         match self {
             Self::Int(value) => write!(f, "{}", value),
             Self::Uint(value) => write!(f, "{}", value),
-            Self::Fixed(value) => write!(f, "{}", value),
+            Self::Fixed(value) => write!(f, "{:.4}", *value as f64 / 256.0),
             Self::Str(value) => write!(f, "{:?}", value),
             Self::Object(value) => write!(f, "{}", value),
             Self::NewId(value) => write!(f, "{}", value),


### PR DESCRIPTION
I got a bit confused by the following:

```
2024-04-17T19:51:21.930954Z DEBUG session{session_id=365288}: mmserver::compositor: wheel delta: 0.0 -48.0
[ 768472.301][rs] -> wl_pointer@15.axis_source(2)
[ 768472.333][rs] -> wl_pointer@15.axis(13025, 0, -12288)
```