### PR TITLE
Add CI job to publish on crates.io when a release is tagged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - master
+    tags:
+      - 'release-[0-9]+-[0-9]+-[0-9]+'
   pull_request:
 
 jobs:
@@ -429,3 +431,24 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc
           force_orphan: true
+
+  publish:
+    needs:
+      - format
+      - doc
+      - check-minimal
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Publish crates
+        uses: katyo/publish-crates@v1
+        with:
+          registry-token: ${{ secrets.CRATES_TOKEN }}
+          args: --no-verify
+          dry-run: ${{ !(github.repository == 'Smithay/wayland-rs' && startsWith(github.ref, 'refs/tags/release-')) }}
+          ignore-unpublished-changes: ${{ !(github.repository == 'Smithay/wayland-rs' && startsWith(github.ref, 'refs/tags/release-')) }}

--- a/wayland-backend/Cargo.toml
+++ b/wayland-backend/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 build = "build.rs"
 
 [dependencies]
-wayland-sys = { version = "0.31.0", path = "../wayland-sys", features = [] }
+wayland-sys = { version = "0.31.1", path = "../wayland-sys", features = [] }
 log = { version = "0.4", optional = true }
 scoped-tls = "1.0"
 downcast-rs = "1.2"

--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -13,8 +13,8 @@ description = "Bindings to the standard C implementation of the wayland protocol
 readme = "README.md"
 
 [dependencies]
-wayland-backend = { version = "0.3.1", path = "../wayland-backend" }
-wayland-scanner = { version = "0.31.0", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.3", path = "../wayland-backend" }
+wayland-scanner = { version = "0.31.1", path = "../wayland-scanner" }
 bitflags = "2"
 rustix = { version = "0.38.0", features = ["event"] }
 log = { version = "0.4", optional = true }

--- a/wayland-cursor/Cargo.toml
+++ b/wayland-cursor/Cargo.toml
@@ -13,7 +13,7 @@ description = "Bindings to libwayland-cursor."
 readme = "README.md"
 
 [dependencies]
-wayland-client = { version = "0.31.0", path = "../wayland-client" }
+wayland-client = { version = "0.31.2", path = "../wayland-client" }
 xcursor = "0.3.1"
 rustix = { version = "0.38.15", features = ["shm"] }
 

--- a/wayland-egl/Cargo.toml
+++ b/wayland-egl/Cargo.toml
@@ -13,8 +13,8 @@ description = "Bindings to libwayland-egl."
 readme = "README.md"
 
 [dependencies]
-wayland-backend = { version = "0.3.0", path = "../wayland-backend", features = ["client_system"] }
-wayland-sys = { version = "0.31.0", path="../wayland-sys", features = ["egl"] }
+wayland-backend = { version = "0.3.3", path = "../wayland-backend", features = ["client_system"] }
+wayland-sys = { version = "0.31.1", path="../wayland-sys", features = ["egl"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wayland-protocols-misc/Cargo.toml
+++ b/wayland-protocols-misc/Cargo.toml
@@ -15,11 +15,11 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wayland-scanner = { version = "0.31.0", path = "../wayland-scanner" }
-wayland-backend = { version = "0.3.0", path = "../wayland-backend" }
-wayland-client = { version = "0.31.0", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.0", path = "../wayland-server", optional = true }
-wayland-protocols = { version = "0.31.0", path = "../wayland-protocols", features=["unstable"] }
+wayland-scanner = { version = "0.31.1", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.3", path = "../wayland-backend" }
+wayland-client = { version = "0.31.2", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.1", path = "../wayland-server", optional = true }
+wayland-protocols = { version = "0.31.2", path = "../wayland-protocols", features=["unstable"] }
 bitflags = "2"
 
 [features]

--- a/wayland-protocols-plasma/Cargo.toml
+++ b/wayland-protocols-plasma/Cargo.toml
@@ -15,11 +15,11 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wayland-scanner = { version = "0.31.0", path = "../wayland-scanner" }
-wayland-backend = { version = "0.3.0", path = "../wayland-backend" }
-wayland-client = { version = "0.31.0", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.0", path = "../wayland-server", optional = true }
-wayland-protocols = { version = "0.31.0", path = "../wayland-protocols"}
+wayland-scanner = { version = "0.31.1", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.3", path = "../wayland-backend" }
+wayland-client = { version = "0.31.2", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.1", path = "../wayland-server", optional = true }
+wayland-protocols = { version = "0.31.2", path = "../wayland-protocols"}
 bitflags = "2"
 
 [features]

--- a/wayland-protocols-wlr/Cargo.toml
+++ b/wayland-protocols-wlr/Cargo.toml
@@ -15,11 +15,11 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wayland-scanner = { version = "0.31.0", path = "../wayland-scanner" }
-wayland-backend = { version = "0.3.0", path = "../wayland-backend" }
-wayland-client = { version = "0.31.0", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.0", path = "../wayland-server", optional = true }
-wayland-protocols = { version = "0.31.0", path = "../wayland-protocols"}
+wayland-scanner = { version = "0.31.1", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.3", path = "../wayland-backend" }
+wayland-client = { version = "0.31.2", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.1", path = "../wayland-server", optional = true }
+wayland-protocols = { version = "0.31.2", path = "../wayland-protocols"}
 bitflags = "2"
 
 [features]

--- a/wayland-protocols/Cargo.toml
+++ b/wayland-protocols/Cargo.toml
@@ -13,10 +13,10 @@ rust-version = "1.65"
 readme = "README.md"
 
 [dependencies]
-wayland-scanner = { version = "0.31.0", path = "../wayland-scanner" }
-wayland-backend = { version = "0.3.0", path = "../wayland-backend" }
-wayland-client = { version = "0.31.0", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.0", path = "../wayland-server", optional = true }
+wayland-scanner = { version = "0.31.1", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.3", path = "../wayland-backend" }
+wayland-client = { version = "0.31.2", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.1", path = "../wayland-server", optional = true }
 bitflags = "2"
 
 [features]

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -13,8 +13,8 @@ rust-version = "1.65"
 readme = "README.md"
 
 [dependencies]
-wayland-backend = { version = "0.3.0", path = "../wayland-backend" }
-wayland-scanner = { version = "0.31.0", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.3", path = "../wayland-backend" }
+wayland-scanner = { version = "0.31.1", path = "../wayland-scanner" }
 bitflags = "2"
 log = { version = "0.4", optional = true }
 downcast-rs = "1.2"


### PR DESCRIPTION
This uses `katyo/publish-crates@v1`, which checks which crates have had their versions bumped, and releases them on crates.io. While making sure to publish dependencies first before the crate that depends on them. This has apparently worked well in drm-rs.

Since subcrates are versioned differently, when we discussed this earlier date-based tags names seemed best. So as @elinorbgr suggested, this goes with `release-YYYY-MM-DD` as the tagging scheme. (The CI job checks for tags prefixed with `release-`). I can't really think of anything better than that.

So to release, we should be able to simply update the versions in `Cargo.toml` files, update the changelog files, and tag a release.

The `publish-crates` action requires that all subcrates depends on the latest version of any other crate in the repository. And it requires that all crates with changes have a bumped version so they can be released. This seems a bit annoying if we wanted to just release a change to `wayland-backend`, for instance, but should help avoid mistakes. Manually dealing with the releases for all the crates here, without any automated checks, is error-prone.

The action here does a `dry-run` for all CI runs (and uses `ignore-unpublished-changes` to not error if crates have changes without already having their versions bumped). But disables `dry-run` when a tag is pushed with the right format.

A `CRATES_TOKEN` secret will need to be added to the repository for this to work. I am not currently a member of smithay/publishers on crates.io, and `wayland-backend` and `wayland-protocols-*` don't currently have `smithay/publishers` as an owner, so @elinorbgr will have to add that. (And make sure `smithay/publishers` is an owner of all the crates is probably a good idea.)

