### PR TITLE
Configure new `check-cfg` lint that `coverage` is an allowed option

### DIFF
--- a/wayland-backend/build.rs
+++ b/wayland-backend/build.rs
@@ -1,4 +1,6 @@
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(coverage)");
+
     if std::env::var("CARGO_FEATURE_LOG").ok().is_some() {
         // build the client shim
         cc::Build::new().file("src/sys/client_impl/log_shim.c").compile("log_shim_client");

--- a/wayland-client/build.rs
+++ b/wayland-client/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(coverage)");
+}


### PR DESCRIPTION
The lastest Rust nightly [adds checking for cfgs] and their possible values.  This requires us to define via `build.rs` that `coverage` is a valid `cfg`, and that it is a "boolean" without any allowed values.

[adds checking for cfgs]: https://blog.rust-lang.org/2024/05/06/check-cfg.html
