### PR TITLE
protocols: Mention breaking API change

### DIFF
--- a/wayland-protocols/CHANGELOG.md
+++ b/wayland-protocols/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG: wayland-protocols
 
 ## Unreleased
+
+### Breaking changes
+- `set_constraint_adjustment`/`SetConstraintAdjustment` now takes a `ConstraintAdjustment` instead of a u32.
+
+### Additions
+
 - Bump wayland-protocols to 1.36
   - `wp-tablet-v2` is now stable
   - New staging protocols:


### PR DESCRIPTION
Due to https://gitlab.freedesktop.org/wayland/wayland-protocols/-/commit/1c57b24ff867eabacb6ecc1e74b1e4d1ccafcf4b, the generated code here is now an enum instead of a `u32`.

It seems reasonable to make this a breaking change for `wayland-protocols-*`, but not release a semver bump of `wayland-client`/`wayland-server`.