### PR TITLE
Bump versions and update changelogs

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.3.4 -- 2024-05-30
+
 ### Additions
 
 - Add `rwh_06` feature for `raw-window-handle` 0.6

--- a/wayland-backend/Cargo.toml
+++ b/wayland-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-backend"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
 edition = "2021"
 rust-version = "1.65"
@@ -14,7 +14,7 @@ readme = "README.md"
 build = "build.rs"
 
 [dependencies]
-wayland-sys = { version = "0.31.1", path = "../wayland-sys", features = [] }
+wayland-sys = { version = "0.31.2", path = "../wayland-sys", features = [] }
 log = { version = "0.4", optional = true }
 scoped-tls = "1.0"
 downcast-rs = "1.2"

--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-client"
-version = "0.31.2"
+version = "0.31.3"
 documentation = "https://docs.rs/wayland-client/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -13,8 +13,8 @@ description = "Bindings to the standard C implementation of the wayland protocol
 readme = "README.md"
 
 [dependencies]
-wayland-backend = { version = "0.3.3", path = "../wayland-backend" }
-wayland-scanner = { version = "0.31.1", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.4", path = "../wayland-backend" }
+wayland-scanner = { version = "0.31.2", path = "../wayland-scanner" }
 bitflags = "2"
 rustix = { version = "0.38.0", features = ["event"] }
 log = { version = "0.4", optional = true }

--- a/wayland-cursor/Cargo.toml
+++ b/wayland-cursor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-cursor"
-version = "0.31.1"
+version = "0.31.2"
 documentation = "https://docs.rs/wayland-cursor/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -13,7 +13,7 @@ description = "Bindings to libwayland-cursor."
 readme = "README.md"
 
 [dependencies]
-wayland-client = { version = "0.31.2", path = "../wayland-client" }
+wayland-client = { version = "0.31.3", path = "../wayland-client" }
 xcursor = "0.3.1"
 rustix = { version = "0.38.15", features = ["shm"] }
 

--- a/wayland-egl/Cargo.toml
+++ b/wayland-egl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-egl"
-version = "0.32.0"
+version = "0.32.1"
 documentation = "https://docs.rs/wayland-egl/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -13,8 +13,8 @@ description = "Bindings to libwayland-egl."
 readme = "README.md"
 
 [dependencies]
-wayland-backend = { version = "0.3.3", path = "../wayland-backend", features = ["client_system"] }
-wayland-sys = { version = "0.31.1", path="../wayland-sys", features = ["egl"] }
+wayland-backend = { version = "0.3.4", path = "../wayland-backend", features = ["client_system"] }
+wayland-sys = { version = "0.31.2", path="../wayland-sys", features = ["egl"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wayland-protocols-misc/CHANGELOG.md
+++ b/wayland-protocols-misc/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.3.0 -- 2024-05-30
+
+### Breaking changes
+- Updated wayland-protocols to 0.3
+
 ## 0.2.0 -- 2023-09-02
 
 ### Breaking changes

--- a/wayland-protocols-misc/Cargo.toml
+++ b/wayland-protocols-misc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-protocols-misc"
-version = "0.2.0"
+version = "0.3.0"
 documentation = "https://docs.rs/wayland-protocols-misc/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -15,11 +15,11 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wayland-scanner = { version = "0.31.1", path = "../wayland-scanner" }
-wayland-backend = { version = "0.3.3", path = "../wayland-backend" }
-wayland-client = { version = "0.31.2", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.1", path = "../wayland-server", optional = true }
-wayland-protocols = { version = "0.31.2", path = "../wayland-protocols", features=["unstable"] }
+wayland-scanner = { version = "0.31.2", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.4", path = "../wayland-backend" }
+wayland-client = { version = "0.31.3", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.2", path = "../wayland-server", optional = true }
+wayland-protocols = { version = "0.32.0", path = "../wayland-protocols", features=["unstable"] }
 bitflags = "2"
 
 [features]

--- a/wayland-protocols-plasma/CHANGELOG.md
+++ b/wayland-protocols-plasma/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.3.0 -- 2024-05-30
+
+### Breaking changes
+- Updated wayland-protocols to 0.3
+
+### Additions
 - Make available protocols that based on headerless xml files.
 
 ## 0.2.0 -- 2023-09-02

--- a/wayland-protocols-plasma/Cargo.toml
+++ b/wayland-protocols-plasma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-protocols-plasma"
-version = "0.2.0"
+version = "0.3.0"
 documentation = "https://docs.rs/wayland-protocols-plasma/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -15,11 +15,11 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wayland-scanner = { version = "0.31.1", path = "../wayland-scanner" }
-wayland-backend = { version = "0.3.3", path = "../wayland-backend" }
-wayland-client = { version = "0.31.2", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.1", path = "../wayland-server", optional = true }
-wayland-protocols = { version = "0.31.2", path = "../wayland-protocols"}
+wayland-scanner = { version = "0.31.2", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.4", path = "../wayland-backend" }
+wayland-client = { version = "0.31.3", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.2", path = "../wayland-server", optional = true }
+wayland-protocols = { version = "0.32.0", path = "../wayland-protocols"}
 bitflags = "2"
 
 [features]

--- a/wayland-protocols-wlr/CHANGELOG.md
+++ b/wayland-protocols-wlr/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.3.0 -- 2024-05-30
+
+### Breaking changes
+- Updated wayland-protocols to 0.3
+
 ## 0.2.0 -- 2023-09-02
 
 ### Breaking changes

--- a/wayland-protocols-wlr/Cargo.toml
+++ b/wayland-protocols-wlr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-protocols-wlr"
-version = "0.2.0"
+version = "0.3.0"
 documentation = "https://docs.rs/wayland-protocols-wlr/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -15,11 +15,11 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wayland-scanner = { version = "0.31.1", path = "../wayland-scanner" }
-wayland-backend = { version = "0.3.3", path = "../wayland-backend" }
-wayland-client = { version = "0.31.2", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.1", path = "../wayland-server", optional = true }
-wayland-protocols = { version = "0.31.2", path = "../wayland-protocols"}
+wayland-scanner = { version = "0.31.2", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.4", path = "../wayland-backend" }
+wayland-client = { version = "0.31.3", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.2", path = "../wayland-server", optional = true }
+wayland-protocols = { version = "0.32.0", path = "../wayland-protocols"}
 bitflags = "2"
 
 [features]

--- a/wayland-protocols/CHANGELOG.md
+++ b/wayland-protocols/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.3.0 -- 2024-05-30
+
 ### Breaking changes
 - `set_constraint_adjustment`/`SetConstraintAdjustment` now takes a `ConstraintAdjustment` instead of a u32.
 

--- a/wayland-protocols/Cargo.toml
+++ b/wayland-protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-protocols"
-version = "0.31.2"
+version = "0.32.0"
 documentation = "https://docs.rs/wayland-protocols/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -13,10 +13,10 @@ rust-version = "1.65"
 readme = "README.md"
 
 [dependencies]
-wayland-scanner = { version = "0.31.1", path = "../wayland-scanner" }
-wayland-backend = { version = "0.3.3", path = "../wayland-backend" }
-wayland-client = { version = "0.31.2", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.1", path = "../wayland-server", optional = true }
+wayland-scanner = { version = "0.31.2", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.4", path = "../wayland-backend" }
+wayland-client = { version = "0.31.3", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.2", path = "../wayland-server", optional = true }
 bitflags = "2"
 
 [features]

--- a/wayland-scanner/CHANGELOG.md
+++ b/wayland-scanner/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.31.2 -- 2024-05-30
+
 - Use wrapper type implementing `Sync` instead of `static mut`s.
 - Add headerless xml file parsing possibility for `parse` function.
 

--- a/wayland-scanner/Cargo.toml
+++ b/wayland-scanner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-scanner"
-version = "0.31.1"
+version = "0.31.2"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
 repository = "https://github.com/smithay/wayland-rs"
 documentation = "https://docs.rs/wayland-scanner/"

--- a/wayland-server/CHANGELOG.md
+++ b/wayland-server/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.31.2 -- 2024-05-30
+
 #### Additions
 
 - Add `Weak::is_alive` allowing to check if a resource is still alive.

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-server"
-version = "0.31.1"
+version = "0.31.2"
 documentation = "https://docs.rs/wayland-server/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -13,8 +13,8 @@ rust-version = "1.65"
 readme = "README.md"
 
 [dependencies]
-wayland-backend = { version = "0.3.3", path = "../wayland-backend" }
-wayland-scanner = { version = "0.31.1", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.4", path = "../wayland-backend" }
+wayland-scanner = { version = "0.31.2", path = "../wayland-scanner" }
 bitflags = "2"
 log = { version = "0.4", optional = true }
 downcast-rs = "1.2"

--- a/wayland-sys/Cargo.toml
+++ b/wayland-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-sys"
-version = "0.31.1"
+version = "0.31.2"
 repository = "https://github.com/smithay/wayland-rs"
 documentation = "https://docs.rs/wayland-sys/"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]


### PR DESCRIPTION
`cargo release --no-publish --no-tag --no-push --execute patch`

`wayland-protocols` needed a breaking version bump, so it was manually changed. The `CHANGELOG.md` files also had to be updated manually.

If CI is happy, hopefully tagging a release will automatically release everything fine.