### PR TITLE
wayland-backend: Add getter for global name

### DIFF
--- a/wayland-backend/src/rs/server_impl/handle.rs
+++ b/wayland-backend/src/rs/server_impl/handle.rs
@@ -14,7 +14,7 @@ use crate::{
 
 use super::{
     client::ClientStore, registry::Registry, ClientData, ClientId, Credentials, GlobalHandler,
-    InnerClientId, InnerGlobalId, InnerObjectId, ObjectData, ObjectId,
+    GlobalId, InnerClientId, InnerGlobalId, InnerObjectId, ObjectData, ObjectId,
 };
 
 pub(crate) type PendingDestructor<D> = (Arc<dyn ObjectData<D>>, InnerClientId, InnerObjectId);
@@ -252,6 +252,10 @@ impl InnerHandle {
         self.state.lock().unwrap().global_info(id)
     }
 
+    pub fn global_name(&self, global: InnerGlobalId, client: InnerClientId) -> Option<u32> {
+        self.state.lock().unwrap().global_name(global, client)
+    }
+
     pub fn get_global_handler<D: 'static>(
         &self,
         id: InnerGlobalId,
@@ -298,6 +302,7 @@ pub(crate) trait ErasedState: downcast_rs::Downcast {
     fn post_error(&mut self, object_id: InnerObjectId, error_code: u32, message: CString);
     fn kill_client(&mut self, client_id: InnerClientId, reason: DisconnectReason);
     fn global_info(&self, id: InnerGlobalId) -> Result<GlobalInfo, InvalidId>;
+    fn global_name(&self, global: InnerGlobalId, client: InnerClientId) -> Option<u32>;
     fn flush(&mut self, client: Option<ClientId>) -> std::io::Result<()>;
 }
 
@@ -438,6 +443,21 @@ impl<D> ErasedState for State<D> {
     }
     fn global_info(&self, id: InnerGlobalId) -> Result<GlobalInfo, InvalidId> {
         self.registry.get_info(id)
+    }
+
+    fn global_name(&self, global_id: InnerGlobalId, client_id: InnerClientId) -> Option<u32> {
+        let client = self.clients.get_client(client_id.clone()).ok()?;
+        let handler = self.registry.get_handler(global_id.clone()).ok()?;
+        let name = global_id.id;
+
+        let can_view =
+            handler.can_view(ClientId { id: client_id }, &client.data, GlobalId { id: global_id });
+
+        if can_view {
+            Some(name)
+        } else {
+            None
+        }
     }
 
     fn flush(&mut self, client: Option<ClientId>) -> std::io::Result<()> {

--- a/wayland-backend/src/server_api.rs
+++ b/wayland-backend/src/server_api.rs
@@ -481,6 +481,15 @@ impl Handle {
         self.handle.global_info(id.id)
     }
 
+    /// Get the name of the global.
+    ///
+    /// - `client` Client for which to look up the global.
+    #[doc(alias = "wl_global_get_name")]
+    #[inline]
+    pub fn global_name(&self, global: GlobalId, client: ClientId) -> Option<u32> {
+        self.handle.global_name(global.id, client.id)
+    }
+
     /// Returns the handler which manages the visibility and notifies when a client has bound the global.
     #[inline]
     pub fn get_global_handler<D: 'static>(

--- a/wayland-backend/src/sys/server_impl/mod.rs
+++ b/wayland-backend/src/sys/server_impl/mod.rs
@@ -791,6 +791,10 @@ impl InnerHandle {
         self.state.lock().unwrap().global_info(id)
     }
 
+    pub fn global_name(&self, global: InnerGlobalId, client: InnerClientId) -> Option<u32> {
+        self.state.lock().unwrap().global_name(global, client)
+    }
+
     /// Returns the handler which manages the visibility and notifies when a client has bound the global.
     pub fn get_global_handler<D: 'static>(
         &self,
@@ -852,6 +856,7 @@ pub(crate) trait ErasedState: downcast_rs::Downcast {
     fn post_error(&mut self, object_id: InnerObjectId, error_code: u32, message: CString);
     fn kill_client(&mut self, client_id: InnerClientId, reason: DisconnectReason);
     fn global_info(&self, id: InnerGlobalId) -> Result<GlobalInfo, InvalidId>;
+    fn global_name(&self, global: InnerGlobalId, client: InnerClientId) -> Option<u32>;
     fn is_known_global(&self, global_ptr: *const wl_global) -> bool;
     fn flush(&mut self, client: Option<ClientId>) -> std::io::Result<()>;
     fn display_ptr(&self) -> *mut wl_display;
@@ -1223,6 +1228,26 @@ impl<D: 'static> ErasedState for State<D> {
             version: udata.version,
             disabled: udata.disabled,
         })
+    }
+
+    fn global_name(&self, global: InnerGlobalId, client: InnerClientId) -> Option<u32> {
+        if !global.alive.load(Ordering::Acquire) {
+            return None;
+        }
+
+        if !client.alive.load(Ordering::Acquire) {
+            return None;
+        }
+
+        let name = unsafe {
+            ffi_dispatch!(wayland_server_handle(), wl_global_get_name, global.ptr, client.ptr)
+        };
+
+        if name == 0 {
+            None
+        } else {
+            Some(name)
+        }
     }
 
     fn is_known_global(&self, global_ptr: *const wl_global) -> bool {

--- a/wayland-sys/src/server.rs
+++ b/wayland-sys/src/server.rs
@@ -102,6 +102,7 @@ external_library!(WaylandServer, "wayland-server",
     // wl_global
         fn wl_global_remove(*mut wl_global) -> (),
         fn wl_global_destroy(*mut wl_global) -> (),
+        fn wl_global_get_name(*mut wl_global, *mut wl_client) -> u32,
         fn wl_global_get_user_data(*const wl_global) -> *mut c_void,
     // wl_resource
         fn wl_resource_post_event_array(*mut wl_resource, u32, *mut wl_argument) -> (),


### PR DESCRIPTION
This will be needed for events such as this one: https://wayland.app/protocols/ext-transient-seat-v1#ext_transient_seat_v1:event:ready