### PR TITLE
backend: delete dead clients from epoll

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `Backend::manage_object` for handling foreign proxies with the sys backend
 
+#### Bugfixes
+
+- backend/rs: server: Fixed potential deadlock caused by dead clients
+
 ## 0.3.4 -- 2024-05-30
 
 #### Additions


### PR DESCRIPTION
I am not sure, if we need to do the same thing here for kqueue, I only observed this problem on an epoll system, but I figured it can't hurt.

This fixes a deadlock from killed clients blocking the loop in `dispatch_all_clients` for the rust-backend.