### PR TITLE
backend/sys: associate imported proxy with correct event queue

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bugfixes
+
+- backend/sys: Fix importing external objects with `Backend::manage_object` by
+  associating the proxy with the correct event queue
+
 ## 0.3.6 -- 2024-07-16
 
 ### Bugfixes


### PR DESCRIPTION
fixes a regression introduced in e777e85f6846ee732ab33adce5755bfc57b08649 which moved all proxies to a separate event queue but left proxies imported with `Backend::manage_object` on the default queue.

cc @chrisduerr 