### PR TITLE
Allow DOCTYPE in protocol definition

### DIFF
--- a/wayland-scanner/src/parse.rs
+++ b/wayland-scanner/src/parse.rs
@@ -54,9 +54,9 @@ fn parse_or_panic<T: FromStr>(txt: &[u8]) -> T {
 
 fn init_protocol<R: BufRead>(reader: &mut Reader<R>) -> Protocol {
     // Check two firsts lines for protocol tag
-    for _ in 0..2 {
+    for _ in 0..3 {
         match reader.read_event_into(&mut Vec::new()) {
-            Ok(Event::Decl(_)) => {
+            Ok(Event::Decl(_) | Event::DocType(_)) => {
                 continue;
             }
             Ok(Event::Start(bytes)) => {


### PR DESCRIPTION
Currently wayland-scanner only allows the `<?xml ... ?>` declaration and the protocol tag at the start of a xml protocol definition. This PR allows one to additionaly specify a `<!DOCTYPE ...>` like this:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE protocol SYSTEM "https://gitlab.freedesktop.org/wayland/wayland/-/raw/ee12e69b8fb8c55460126e4e527eb4f7fee5526e/protocol/wayland.dtd">
<protocol name="test_proto">
    <interface name="test_interface" version="1">
        <description summary="Testing"></description>
        <event name="ping"></event>
    </interface>
</protocol>
```
The specified file can be consumed by LSPs to enable assisting with autocompletion and syntax checking.