### PR TITLE
Bump wayland-protocols to 1.37

### DIFF
--- a/wayland-protocols/CHANGELOG.md
+++ b/wayland-protocols/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Additions
+- Bump wayland-protocols to 1.37
+  - New staging protocols:
+    * `ext-image-capture-source-v1`
+    * `ext-image-copy-capture-v1`
+    * `xdg-toplevel-icon-v1`
+
 ## 0.3.0 -- 2024-05-30
 
 ### Breaking changes

--- a/wayland-protocols/src/ext.rs
+++ b/wayland-protocols/src/ext.rs
@@ -88,3 +88,37 @@ pub mod transient_seat {
     }
 
 }
+
+
+#[cfg(feature = "staging")]
+pub mod image_capture_source {
+    //! This protocol serves as an intermediary between capturing protocols and
+    //! potential image capture sources such as outputs and toplevels.
+    //!
+    //! This protocol may be extended to support more image capture sources in the
+    //! future, thereby adding those image capture sources to other protocols that
+    //! use the image capture source object without having to modify those
+    //! protocols.
+
+    #[allow(missing_docs)]
+    pub mod v1 {
+        wayland_protocol!(
+            "./protocols/staging/ext-image-capture-source/ext-image-capture-source-v1.xml",
+            [crate::ext::foreign_toplevel_list::v1, crate::xdg::shell]
+        );
+    }
+}
+
+#[cfg(feature = "staging")]
+pub mod image_copy_capture {
+    //! This protocol allows clients to ask the compositor to capture image sources
+    //! such as outputs and toplevels into user submitted buffers.
+
+    #[allow(missing_docs)]
+    pub mod v1 {
+        wayland_protocol!(
+            "./protocols/staging/ext-image-copy-capture/ext-image-copy-capture-v1.xml",
+            [crate::ext::image_capture_source::v1, crate::xdg::shell]
+        );
+    }
+}

--- a/wayland-protocols/src/xdg.rs
+++ b/wayland-protocols/src/xdg.rs
@@ -198,3 +198,22 @@ pub mod dialog {
         );
     }
 }
+
+#[cfg(feature = "staging")]
+pub mod toplevel_icon {
+    //! This protocol allows clients to set icons for their toplevel surfaces
+    //! either via the XDG icon stock (using an icon name), or from pixel data.
+    //!
+    //! A toplevel icon represents the individual toplevel (unlike the application
+    //! or launcher icon, which represents the application as a whole), and may be
+    //! shown in window switchers, window overviews and taskbars that list
+    //! individual windows.
+
+    /// Version 1
+    pub mod v1 {
+        wayland_protocol!(
+            "./protocols/staging/xdg-toplevel-icon/xdg-toplevel-icon-v1.xml",
+            [crate::xdg::shell]
+        );
+    }
+}


### PR DESCRIPTION
`xdg-toplevel-icon-v1`, `ext-image-capture-source-v1`, `ext-image-copy-capture-v1`.

Pending upstream tagged release.