### PR TITLE
WIP backend/rs: Using `polling` instead of `kqueue`/`epoll`

### DIFF
--- a/wayland-backend/Cargo.toml
+++ b/wayland-backend/Cargo.toml
@@ -20,6 +20,7 @@ scoped-tls = { version = "1.0", optional = true }
 downcast-rs = "1.2"
 raw-window-handle = { version = "0.5.0", optional = true }
 rwh_06 = { package = "raw-window-handle", version = "0.6.0", optional = true }
+polling = "3.7.2"
 
 [dependencies.smallvec]
 version = "1.9"

--- a/wayland-backend/src/rs/server_impl/common_poll.rs
+++ b/wayland-backend/src/rs/server_impl/common_poll.rs
@@ -14,17 +14,6 @@ use crate::{
     types::server::InitError,
 };
 
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "redox"))]
-use rustix::event::{epoll, Timespec};
-
-#[cfg(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "macos"
-))]
-use rustix::event::kqueue::*;
 use smallvec::SmallVec;
 
 #[derive(Debug)]
@@ -34,21 +23,8 @@ pub struct InnerBackend<D: 'static> {
 
 impl<D> InnerBackend<D> {
     pub fn new() -> Result<Self, InitError> {
-        #[cfg(any(target_os = "linux", target_os = "android", target_os = "redox"))]
-        let poll_fd = epoll::create(epoll::CreateFlags::CLOEXEC)
-            .map_err(Into::into)
-            .map_err(InitError::Io)?;
-
-        #[cfg(any(
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "macos"
-        ))]
-        let poll_fd = kqueue().map_err(Into::into).map_err(InitError::Io)?;
-
-        Ok(Self { state: Arc::new(Mutex::new(State::new(poll_fd))) })
+        let state = State::new().map_err(Into::into).map_err(InitError::Io)?;
+        Ok(Self { state: Arc::new(Mutex::new(state)) })
     }
 
     pub fn flush(&self, client: Option<ClientId>) -> std::io::Result<()> {
@@ -60,7 +36,7 @@ impl<D> InnerBackend<D> {
     }
 
     pub fn poll_fd(&self) -> BorrowedFd<'_> {
-        let raw_fd = self.state.lock().unwrap().poll_fd.as_raw_fd();
+        let raw_fd = self.state.lock().unwrap().poller.as_raw_fd();
         // This allows the lifetime of the BorrowedFd to be tied to &self rather than the lock guard,
         // which is the real safety concern
         unsafe { BorrowedFd::borrow_raw(raw_fd) }
@@ -77,58 +53,18 @@ impl<D> InnerBackend<D> {
         ret
     }
 
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "redox"))]
     pub fn dispatch_all_clients(&self, data: &mut D) -> std::io::Result<usize> {
-        use std::os::unix::io::AsFd;
-
-        let poll_fd = self.poll_fd();
         let mut dispatched = 0;
-        let mut events = Vec::<epoll::Event>::with_capacity(32);
         loop {
-            let buffer = rustix::buffer::spare_capacity(&mut events);
-            epoll::wait(poll_fd.as_fd(), buffer, Some(&Timespec::default()))?;
+            let mut events = polling::Events::new(); // TODO with capacity?
+            self.state.lock().unwrap().poller.wait(&mut events, Some(std::time::Duration::ZERO))?;
 
             if events.is_empty() {
                 break;
             }
 
-            for event in events.drain(..) {
-                let id = InnerClientId::from_u64(event.data.u64());
-                // remove the cb while we call it, to gracefully handle reentrancy
-                if let Ok(count) = self.dispatch_events_for(data, id) {
-                    dispatched += count;
-                }
-            }
-            let cleanup = self.state.lock().unwrap().cleanup();
-            cleanup(&self.handle(), data);
-        }
-
-        Ok(dispatched)
-    }
-
-    #[cfg(any(
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "macos"
-    ))]
-    pub fn dispatch_all_clients(&self, data: &mut D) -> std::io::Result<usize> {
-        use std::time::Duration;
-
-        let poll_fd = self.poll_fd();
-        let mut dispatched = 0;
-        let mut events = Vec::<Event>::with_capacity(32);
-        loop {
-            let buffer = rustix::buffer::spare_capacity(&mut events);
-            let nevents = unsafe { kevent(&poll_fd, &[], buffer, Some(Duration::ZERO))? };
-
-            if nevents == 0 {
-                break;
-            }
-
-            for event in events.drain(..) {
-                let id = InnerClientId::from_u64(event.udata() as u64);
+            for event in events.iter() {
+                let id = InnerClientId::from_u64(event.key as u64);
                 // remove the cb while we call it, to gracefully handle reentrancy
                 if let Ok(count) = self.dispatch_events_for(data, id) {
                     dispatched += count;
@@ -163,37 +99,7 @@ impl<D> InnerBackend<D> {
                             }
                         }
                         Err(e) => {
-                            #[cfg(any(
-                                target_os = "linux",
-                                target_os = "android",
-                                target_os = "redox"
-                            ))]
-                            {
-                                epoll::delete(&state.poll_fd, client)?;
-                            }
-
-                            #[cfg(any(
-                                target_os = "dragonfly",
-                                target_os = "freebsd",
-                                target_os = "netbsd",
-                                target_os = "openbsd",
-                                target_os = "macos"
-                            ))]
-                            {
-                                use rustix::event::kqueue::*;
-                                use std::os::unix::io::{AsFd, AsRawFd};
-
-                                let evt = Event::new(
-                                    EventFilter::Read(client.as_fd().as_raw_fd()),
-                                    EventFlags::DELETE,
-                                    client_id.as_u64() as *mut _,
-                                );
-
-                                let events: &mut [Event] = &mut [];
-                                unsafe {
-                                    kevent(&state.poll_fd, &[evt], events, None).map(|_| ())?;
-                                }
-                            }
+                            let _ = state.poller.delete(client);
                             return Err(e);
                         }
                     };

--- a/wayland-backend/src/rs/server_impl/handle.rs
+++ b/wayland-backend/src/rs/server_impl/handle.rs
@@ -1,7 +1,7 @@
 use std::{
     ffi::CString,
     os::unix::{
-        io::{OwnedFd, RawFd},
+        io::{AsFd, RawFd},
         net::UnixStream,
     },
     sync::{Arc, Mutex, Weak},
@@ -25,21 +25,21 @@ pub struct State<D: 'static> {
     pub(crate) clients: ClientStore<D>,
     pub(crate) registry: Registry<D>,
     pub(crate) pending_destructors: Vec<PendingDestructor<D>>,
-    pub(crate) poll_fd: OwnedFd,
+    pub(crate) poller: polling::Poller,
     pub(crate) default_max_buffer_size: usize,
 }
 
 impl<D> State<D> {
-    pub(crate) fn new(poll_fd: OwnedFd) -> Self {
+    pub(crate) fn new() -> std::io::Result<Self> {
         let debug =
             matches!(std::env::var_os("WAYLAND_DEBUG"), Some(str) if str == "1" || str == "server");
-        Self {
+        Ok(Self {
             clients: ClientStore::new(debug),
             registry: Registry::new(),
             pending_destructors: Vec::new(),
-            poll_fd,
+            poller: polling::Poller::new()?,
             default_max_buffer_size: DEFAULT_MAX_BUFFER_SIZE,
-        }
+        })
     }
 
     pub(crate) fn cleanup<'a>(&mut self) -> impl FnOnce(&super::Handle, &mut D) + 'a {
@@ -357,37 +357,9 @@ impl<D> ErasedState for State<D> {
         let id = self.clients.create_client(stream, data, self.default_max_buffer_size);
         let client = self.clients.get_client(id.clone()).unwrap();
 
-        // register the client to the internal epoll
-        #[cfg(any(target_os = "linux", target_os = "android", target_os = "redox"))]
-        let ret = {
-            use rustix::event::epoll;
-            epoll::add(
-                &self.poll_fd,
-                client,
-                epoll::EventData::new_u64(id.as_u64()),
-                epoll::EventFlags::IN,
-            )
-        };
-
-        #[cfg(any(
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "macos"
-        ))]
-        let ret = {
-            use rustix::event::kqueue::*;
-            use std::os::unix::io::{AsFd, AsRawFd};
-
-            let evt = Event::new(
-                EventFilter::Read(client.as_fd().as_raw_fd()),
-                EventFlags::ADD | EventFlags::RECEIPT,
-                id.as_u64() as *mut _,
-            );
-
-            let events: &mut [Event] = &mut [];
-            unsafe { kevent(&self.poll_fd, &[evt], events, None).map(|_| ()) }
+        // XXX 32-bit usize
+        let ret = unsafe {
+            self.poller.add(&client.as_fd(), polling::Event::writable(id.as_u64() as usize))
         };
 
         match ret {


### PR DESCRIPTION
I've had this in my git stash for a while. I think it wasn't working properly, but I may as well put in in a PR as a proof of concept.

Wayland-rs is often used with `calloop`, so `polling` is a dependency anyway. It may as well be used here then.

This requires `Poller` to implement `AsFd`, so it won't work on platforms that only have `poll`. https://docs.rs/polling/3.7.3/polling/struct.Poller.html#impl-AsFd-for-Poller mentions that illumos/solaris implement it. But I don't know if it works properly to insert into another poller.

If we want to support platforms that only have something like `poll`, we'll need a different sort of API, that doesn't require a single `fd` for polling multiple clients. But `libwayland` has the same issue, and there may not be much serious use to wayland-rs on platforms that don't support `libwayland`.

Other than portability, this is a nice cleanup of a bit of platform-specific code, but it's not a huge difference.