### PR TITLE
chore: Release

### DIFF
--- a/wayland-client/CHANGELOG.md
+++ b/wayland-client/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.31.7 -- 2024-10-23
+
 - Updated Wayland core protocol to 1.23
 
 ## 0.31.2 -- 2024-01-29

--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-client"
-version = "0.31.6"
+version = "0.31.7"
 documentation = "https://docs.rs/wayland-client/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]

--- a/wayland-cursor/Cargo.toml
+++ b/wayland-cursor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-cursor"
-version = "0.31.6"
+version = "0.31.7"
 documentation = "https://docs.rs/wayland-cursor/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -13,7 +13,7 @@ description = "Bindings to libwayland-cursor."
 readme = "README.md"
 
 [dependencies]
-wayland-client = { version = "0.31.6", path = "../wayland-client" }
+wayland-client = { version = "0.31.7", path = "../wayland-client" }
 xcursor = "0.3.1"
 rustix = { version = "0.38.15", features = ["shm"] }
 

--- a/wayland-protocols-misc/Cargo.toml
+++ b/wayland-protocols-misc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-protocols-misc"
-version = "0.3.4"
+version = "0.3.5"
 documentation = "https://docs.rs/wayland-protocols-misc/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -17,9 +17,9 @@ readme = "README.md"
 [dependencies]
 wayland-scanner = { version = "0.31.5", path = "../wayland-scanner" }
 wayland-backend = { version = "0.3.7", path = "../wayland-backend" }
-wayland-client = { version = "0.31.6", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.5", path = "../wayland-server", optional = true }
-wayland-protocols = { version = "0.32.4", path = "../wayland-protocols", features=["unstable"] }
+wayland-client = { version = "0.31.7", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.6", path = "../wayland-server", optional = true }
+wayland-protocols = { version = "0.32.5", path = "../wayland-protocols", features=["unstable"] }
 bitflags = "2"
 
 [features]

--- a/wayland-protocols-plasma/Cargo.toml
+++ b/wayland-protocols-plasma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-protocols-plasma"
-version = "0.3.4"
+version = "0.3.5"
 documentation = "https://docs.rs/wayland-protocols-plasma/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -17,9 +17,9 @@ readme = "README.md"
 [dependencies]
 wayland-scanner = { version = "0.31.5", path = "../wayland-scanner" }
 wayland-backend = { version = "0.3.7", path = "../wayland-backend" }
-wayland-client = { version = "0.31.6", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.5", path = "../wayland-server", optional = true }
-wayland-protocols = { version = "0.32.4", path = "../wayland-protocols"}
+wayland-client = { version = "0.31.7", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.6", path = "../wayland-server", optional = true }
+wayland-protocols = { version = "0.32.5", path = "../wayland-protocols"}
 bitflags = "2"
 
 [features]

--- a/wayland-protocols-wlr/Cargo.toml
+++ b/wayland-protocols-wlr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-protocols-wlr"
-version = "0.3.4"
+version = "0.3.5"
 documentation = "https://docs.rs/wayland-protocols-wlr/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -17,9 +17,9 @@ readme = "README.md"
 [dependencies]
 wayland-scanner = { version = "0.31.5", path = "../wayland-scanner" }
 wayland-backend = { version = "0.3.7", path = "../wayland-backend" }
-wayland-client = { version = "0.31.6", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.5", path = "../wayland-server", optional = true }
-wayland-protocols = { version = "0.32.4", path = "../wayland-protocols"}
+wayland-client = { version = "0.31.7", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.6", path = "../wayland-server", optional = true }
+wayland-protocols = { version = "0.32.5", path = "../wayland-protocols"}
 bitflags = "2"
 
 [features]

--- a/wayland-protocols/CHANGELOG.md
+++ b/wayland-protocols/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.32.5 -- 2024-10-23
+
 - Bump wayland-protocols to 1.38
   - New staging protocols:
     * `fifo-v1`

--- a/wayland-protocols/Cargo.toml
+++ b/wayland-protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-protocols"
-version = "0.32.4"
+version = "0.32.5"
 documentation = "https://docs.rs/wayland-protocols/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -15,8 +15,8 @@ readme = "README.md"
 [dependencies]
 wayland-scanner = { version = "0.31.5", path = "../wayland-scanner" }
 wayland-backend = { version = "0.3.7", path = "../wayland-backend" }
-wayland-client = { version = "0.31.6", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.5", path = "../wayland-server", optional = true }
+wayland-client = { version = "0.31.7", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.6", path = "../wayland-server", optional = true }
 bitflags = "2"
 
 [features]

--- a/wayland-server/CHANGELOG.md
+++ b/wayland-server/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.31.6 -- 2024-10-23
+
 - Updated Wayland core protocol to 1.23
 
 ## 0.31.2 -- 2024-05-30

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-server"
-version = "0.31.5"
+version = "0.31.6"
 documentation = "https://docs.rs/wayland-server/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]

--- a/wayland-tests/Cargo.toml
+++ b/wayland-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-tests"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.65"
 publish = false


### PR DESCRIPTION
`cargo release --no-publish --no-tag --no-push --execute patch --prev-tag-name release-2024-09-04 --exclude wayland-sys --exclude wayland-backend --exclude wayland-scanner --exclude wayland-egl`

If on `master` with `prev-tag-name` specified, the unchanged crates produce warnings, but are not automatically excluded. Not sure if there's some way to do that.