### PR TITLE
backend/rs: delay client cleanup

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -33,4 +33,6 @@ allow = [
     # Google categorizes the license under "notice" which means it can be used (with some exceptions like
     # notices or advertising clauses): https://opensource.google/documentation/reference/thirdparty/licenses#notice
     "Unicode-DFS-2016",
+    # Unicode-DFS-2016 has been superseded by Unicode V3
+    "Unicode-3.0",
 ]

--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bugfixes
+
+- backend/rs: Prevent a potential deadlock during client cleanup
+
 ## 0.3.7 -- 2024-09-04
 
 ### Bugfixes

--- a/wayland-backend/src/debug.rs
+++ b/wayland-backend/src/debug.rs
@@ -58,7 +58,7 @@ pub fn print_send_message<Id: Display, Fd: AsRawFd>(
 
 pub(crate) struct DisplaySlice<'a, D>(pub &'a [D]);
 
-impl<'a, D: Display> Display for DisplaySlice<'a, D> {
+impl<D: Display> Display for DisplaySlice<'_, D> {
     #[cfg_attr(coverage, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut it = self.0.iter();

--- a/wayland-backend/src/rs/server_impl/client.rs
+++ b/wayland-backend/src/rs/server_impl/client.rs
@@ -720,7 +720,7 @@ impl<D> ClientStore<D> {
     pub(crate) fn cleanup(
         &mut self,
         pending_destructors: &mut Vec<PendingDestructor<D>>,
-    ) -> SmallVec<[ClientId; 1]> {
+    ) -> SmallVec<[Client<D>; 1]> {
         let mut cleaned = SmallVec::new();
         for place in &mut self.clients {
             if place.as_ref().map(|client| client.killed).unwrap_or(false) {
@@ -728,7 +728,7 @@ impl<D> ClientStore<D> {
                 let mut client = place.take().unwrap();
                 client.queue_all_destructors(pending_destructors);
                 let _ = client.flush();
-                cleaned.push(ClientId { id: client.id });
+                cleaned.push(client);
             }
         }
         cleaned

--- a/wayland-backend/src/rs/server_impl/handle.rs
+++ b/wayland-backend/src/rs/server_impl/handle.rs
@@ -53,6 +53,7 @@ impl<D> State<D> {
                     ObjectId { id: object_id },
                 );
             }
+            std::mem::drop(dead_clients);
         }
     }
 

--- a/wayland-backend/src/rs/server_impl/registry.rs
+++ b/wayland-backend/src/rs/server_impl/registry.rs
@@ -127,7 +127,7 @@ impl<D> Registry<D> {
         Some((target_global.interface, target_global.id.clone(), target_global.handler.clone()))
     }
 
-    pub(crate) fn cleanup(&mut self, dead_clients: &[ClientId]) {
+    pub(crate) fn cleanup(&mut self, dead_clients: &[Client<D>]) {
         self.known_registries
             .retain(|obj_id| !dead_clients.iter().any(|cid| cid.id == obj_id.client_id))
     }

--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -632,7 +632,7 @@ impl<State: 'static> QueueHandle<State> {
     }
 }
 
-impl<'a, State> Drop for QueueFreezeGuard<'a, State> {
+impl<State> Drop for QueueFreezeGuard<'_, State> {
     fn drop(&mut self) {
         let mut lock = self.qh.inner.lock().unwrap();
         lock.freeze_count -= 1;

--- a/wayland-server/src/dispatch.rs
+++ b/wayland-server/src/dispatch.rs
@@ -158,7 +158,7 @@ pub struct DataInit<'a, D: 'static> {
     pub(crate) error: &'a mut Option<(u32, String)>,
 }
 
-impl<'a, D> DataInit<'a, D> {
+impl<D> DataInit<'_, D> {
     /// Initialize an object by assigning it its user-data
     pub fn init<I: Resource + 'static, U: Send + Sync + 'static>(
         &mut self,

--- a/wayland-sys/src/server.rs
+++ b/wayland-sys/src/server.rs
@@ -251,6 +251,9 @@ pub mod signal {
         // Safety: the signal pointer is valid
         unsafe {
             list_for_each!(l, &mut (*signal).listener_list as *mut wl_list, wl_listener, link, {
+                // nightly only lint
+                #[allow(unknown_lints)]
+                #[allow(unpredictable_function_pointer_comparisons)]
                 if (*l).notify == notify {
                     return l;
                 }


### PR DESCRIPTION
delay client cleanup until the state lock is dropped to prevent potential deadlocks in drop impls of the client state.