### PR TITLE
Update downcast-rs to 2.0

### DIFF
--- a/wayland-backend/Cargo.toml
+++ b/wayland-backend/Cargo.toml
@@ -17,7 +17,7 @@ build = "build.rs"
 wayland-sys = { version = "0.31.5", path = "../wayland-sys", features = [] }
 log = { version = "0.4", optional = true }
 scoped-tls = { version = "1.0", optional = true }
-downcast-rs = "1.2"
+downcast-rs = "2.0"
 raw-window-handle = { version = "0.5.0", optional = true }
 rwh_06 = { package = "raw-window-handle", version = "0.6.0", optional = true }
 

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -17,7 +17,7 @@ wayland-backend = { version = "0.3.7", path = "../wayland-backend" }
 wayland-scanner = { version = "0.31.5", path = "../wayland-scanner" }
 bitflags = "2"
 log = { version = "0.4", optional = true }
-downcast-rs = "1.2"
+downcast-rs = "2.0"
 rustix = { version = "0.38.14", features = ["fs"] }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Simple housekeeping, no other particular reason.

This would deduplicate in the future what https://github.com/ruffle-rs/ruffle/pull/19205/files duplicates for us.