### PR TITLE
wayland-scanner: Support `deprecated-since`

### DIFF
--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -211,7 +211,7 @@ use std::{
 ///
 /// This module is automatically generated from the `wayland.xml` protocol specification,
 /// and contains the interface definitions for the core Wayland protocol.
-#[allow(missing_docs)]
+#[allow(missing_docs, deprecated)]
 pub mod protocol {
     use self::__interfaces::*;
     use crate as wayland_client;

--- a/wayland-protocols/src/protocol_macro.rs
+++ b/wayland-protocols/src/protocol_macro.rs
@@ -9,7 +9,7 @@ macro_rules! wayland_protocol(
         mod generated {
             #![allow(dead_code,non_camel_case_types,unused_unsafe,unused_variables)]
             #![allow(non_upper_case_globals,non_snake_case,unused_imports)]
-            #![allow(missing_docs, clippy::all)]
+            #![allow(missing_docs, clippy::all, deprecated)]
 
             #[cfg(feature = "client")]
             pub mod client {

--- a/wayland-scanner/src/client_gen.rs
+++ b/wayland-scanner/src/client_gen.rs
@@ -18,7 +18,7 @@ fn generate_objects_for(interface: &Interface) -> TokenStream {
     let iface_name = Ident::new(&snake_to_camel(&interface.name), Span::call_site());
     let iface_const_name = format_ident!("{}_INTERFACE", interface.name.to_ascii_uppercase());
 
-    let enums = crate::common::generate_enums_for(interface);
+    let enums = crate::common::generate_enums_for(interface, Side::Client);
     let sinces = crate::common::gen_msg_constants(&interface.requests, &interface.events);
 
     let requests = crate::common::gen_message_enum(

--- a/wayland-scanner/src/parse.rs
+++ b/wayland-scanner/src/parse.rs
@@ -198,6 +198,7 @@ fn parse_request<R: BufRead>(reader: &mut Reader<R>, attrs: Attributes) -> Messa
             b"name" => request.name = decode_utf8_or_panic(attr.value.into_owned()),
             b"type" => request.typ = Some(parse_type(&attr.value)),
             b"since" => request.since = parse_or_panic(&attr.value),
+            b"deprecated-since" => request.deprecated_since = Some(parse_or_panic(&attr.value)),
             _ => {}
         }
     }
@@ -258,6 +259,7 @@ fn parse_event<R: BufRead>(reader: &mut Reader<R>, attrs: Attributes) -> Message
             b"name" => event.name = decode_utf8_or_panic(attr.value.into_owned()),
             b"type" => event.typ = Some(parse_type(&attr.value)),
             b"since" => event.since = parse_or_panic(&attr.value),
+            b"deprecated-since" => event.deprecated_since = Some(parse_or_panic(&attr.value)),
             _ => {}
         }
     }
@@ -355,6 +357,7 @@ fn parse_entry<R: BufRead>(reader: &mut Reader<R>, attrs: Attributes) -> Entry {
                 };
             }
             b"since" => entry.since = parse_or_panic(&attr.value),
+            b"deprecated-since" => entry.deprecated_since = Some(parse_or_panic(&attr.value)),
             b"summary" => {
                 entry.summary = Some(
                     String::from_utf8_lossy(&attr.value)

--- a/wayland-scanner/src/protocol.rs
+++ b/wayland-scanner/src/protocol.rs
@@ -43,13 +43,21 @@ pub struct Message {
     pub name: String,
     pub typ: Option<Type>,
     pub since: u32,
+    pub deprecated_since: Option<u32>,
     pub description: Option<(String, String)>,
     pub args: Vec<Arg>,
 }
 
 impl Message {
     pub fn new() -> Message {
-        Message { name: String::new(), typ: None, since: 1, description: None, args: Vec::new() }
+        Message {
+            name: String::new(),
+            typ: None,
+            since: 1,
+            deprecated_since: None,
+            description: None,
+            args: Vec::new(),
+        }
     }
 
     pub fn all_null(&self) -> bool {
@@ -110,13 +118,21 @@ pub struct Entry {
     pub name: String,
     pub value: u32,
     pub since: u16,
+    pub deprecated_since: Option<u16>,
     pub description: Option<(String, String)>,
     pub summary: Option<String>,
 }
 
 impl Entry {
     pub fn new() -> Entry {
-        Entry { name: String::new(), value: 0, since: 1, description: None, summary: None }
+        Entry {
+            name: String::new(),
+            value: 0,
+            since: 1,
+            deprecated_since: None,
+            description: None,
+            summary: None,
+        }
     }
 }
 

--- a/wayland-scanner/src/server_gen.rs
+++ b/wayland-scanner/src/server_gen.rs
@@ -23,7 +23,7 @@ fn generate_objects_for(interface: &Interface) -> TokenStream {
     let iface_name = Ident::new(&snake_to_camel(&interface.name), Span::call_site());
     let iface_const_name = format_ident!("{}_INTERFACE", interface.name.to_ascii_uppercase());
 
-    let enums = crate::common::generate_enums_for(interface);
+    let enums = crate::common::generate_enums_for(interface, Side::Server);
     let msg_constants = crate::common::gen_msg_constants(&interface.requests, &interface.events);
 
     let requests = crate::common::gen_message_enum(


### PR DESCRIPTION
Parses `deprecated-since` attributes in requests/events/entries, and generates `#[deprecated]`s. Note that this only happens for the client side, since servers are expected to support protocols indefinitely (P.S. should this be added to the description, if so only on the server side?)

The deprecations themselves also generate warnings for the `wayland-protocols*` crates, I'm not totally sure where the `#[allow(deprecated)]` should be and it feels silly to add them to every interface so I currently only put it for the core protocol (which iirc is the only place they are used so far), from what I see this is also a problem for `missing_docs`.

This needs some more testing, I only really tested [AxisDiscrete](https://docs.rs/wayland-client/latest/wayland_client/protocol/wl_pointer/enum.Event.html#variant.AxisDiscrete).