### PR TITLE
protocols-plasma: Update to `plasma-wayland-protocols` 1.16.0

### DIFF
--- a/wayland-protocols-plasma/CHANGELOG.md
+++ b/wayland-protocols-plasma/CHANGELOG.md
@@ -13,6 +13,9 @@
   * `keystate` version 5
   * `plasma-window-management` version 18
   * `zkde-screencast-unstable-v1` version 4
+- Add bindings that were missing
+  * `kde-lockscreen-overlay-v1`
+  * `kde-output-order-v1`
 
 ## 0.3.0 -- 2024-05-30
 

--- a/wayland-protocols-plasma/CHANGELOG.md
+++ b/wayland-protocols-plasma/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- Update plasma-wayland-protocols to 1.16.0
+  * New protocols:
+    - `kde-external-brightness-v1`
+    - `kde-screen-edge-v1`
+  * `appmenu` verison 2
+  * `fake-input` version 5
+  * `kde-output-device-v2` version 11
+  * `kde-output-management-v2` version 12
+  * `keystate` version 5
+  * `plasma-window-management` version 18
+  * `zkde-screencast-unstable-v1` version 4
+
 ## 0.3.0 -- 2024-05-30
 
 ### Breaking changes

--- a/wayland-protocols-plasma/src/lib.rs
+++ b/wayland-protocols-plasma/src/lib.rs
@@ -79,6 +79,15 @@ pub mod keystate {
     );
 }
 
+pub mod lockscreen_overlay {
+    pub mod v1 {
+        wayland_protocol!(
+            "./plasma-wayland-protocols/src/protocols/kde-lockscreen-overlay-v1.xml",
+            []
+        );
+    }
+}
+
 pub mod output_device {
     pub mod v1 {
         wayland_protocol!(
@@ -107,6 +116,15 @@ pub mod output_management {
         wayland_protocol!(
             "./plasma-wayland-protocols/src/protocols/kde-output-management-v2.xml",
             [crate::output_device::v2]
+        );
+    }
+}
+
+pub mod output_order {
+    pub mod v1 {
+        wayland_protocol!(
+            "./plasma-wayland-protocols/src/protocols/kde-output-order-v1.xml",
+            []
         );
     }
 }

--- a/wayland-protocols-plasma/src/lib.rs
+++ b/wayland-protocols-plasma/src/lib.rs
@@ -42,6 +42,15 @@ pub mod dpms {
     );
 }
 
+pub mod external_brightness {
+    pub mod v1 {
+        wayland_protocol!(
+            "./plasma-wayland-protocols/src/protocols/kde-external-brightness-v1.xml",
+            []
+        );
+    }
+}
+
 pub mod fake_input {
     wayland_protocol!(
         "./plasma-wayland-protocols/src/protocols/fake-input.xml",
@@ -121,7 +130,7 @@ pub mod plasma_shell {
 
 pub mod plasma_virtual_desktop {
     wayland_protocol!(
-        "./plasma-wayland-protocols/src/protocols/plasma-virtual-desktop.xml",
+        "./plasma-wayland-protocols/src/protocols/org-kde-plasma-virtual-desktop.xml",
         []
     );
 }
@@ -144,6 +153,15 @@ pub mod screencast {
     pub mod v1 {
         wayland_protocol!(
             "./plasma-wayland-protocols/src/protocols/zkde-screencast-unstable-v1.xml",
+            []
+        );
+    }
+}
+
+pub mod screen_edge {
+    pub mod v1 {
+        wayland_protocol!(
+            "./plasma-wayland-protocols/src/protocols/kde-screen-edge-v1.xml",
             []
         );
     }

--- a/wayland-protocols-plasma/src/lib.rs
+++ b/wayland-protocols-plasma/src/lib.rs
@@ -111,16 +111,6 @@ pub mod output_management {
     }
 }
 
-
-pub mod primary_output {
-    pub mod v1 {
-        wayland_protocol!(
-            "./plasma-wayland-protocols/src/protocols/kde-primary-output-v1.xml",
-            []
-        );
-    }
-}
-
 pub mod plasma_shell {
     wayland_protocol!(
         "./plasma-wayland-protocols/src/protocols/plasma-shell.xml",
@@ -140,6 +130,15 @@ pub mod plasma_window_management {
         "./plasma-wayland-protocols/src/protocols/plasma-window-management.xml",
         []
     );
+}
+
+pub mod primary_output {
+    pub mod v1 {
+        wayland_protocol!(
+            "./plasma-wayland-protocols/src/protocols/kde-primary-output-v1.xml",
+            []
+        );
+    }
 }
 
 pub mod remote_access {


### PR DESCRIPTION
Some protocols have [added a warning](https://invent.kde.org/libraries/plasma-wayland-protocols/-/merge_requests/80):

```
Warning! The protocol described in this file is a desktop environment
implementation detail. Regular clients must not use this protocol.
Backward incompatible changes may be added without bumping the major
version of the extension.
```

While protocols like `blur` presumably are considered safe to use.

Perhaps we should have a feature flag for those "implementation detail" protocols. But for now, this is just an update without breaking anything.