### PR TITLE
WIP client: Add a `DestroyOnDrop` wrapper that calls destructor on `Drop`

### DIFF
--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -321,6 +321,31 @@ pub trait Proxy: Clone + std::fmt::Debug + Sized {
     }
 }
 
+/// Trait for instances of [`Proxy`] that have destructors
+pub trait ProxyDestroy: Proxy {
+    /// Sends the destructor request to the proxy, which is usually called `.destroy()`
+    fn call_proxy_destructor(&self);
+}
+
+/// Wrap a [`ProxyDestroy`] instance to automatically call the destructor on
+/// drop.
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub struct DestroyOnDrop<T: ProxyDestroy>(T);
+
+impl<T: ProxyDestroy> Drop for DestroyOnDrop<T> {
+    fn drop(&mut self) {
+        self.0.call_proxy_destructor();
+    }
+}
+
+impl<T: ProxyDestroy> std::ops::Deref for DestroyOnDrop<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
 /// Wayland dispatching error
 #[derive(Debug)]
 pub enum DispatchError {


### PR DESCRIPTION
I've been thinking a helper like this could be handy, since I end up implementing `Drop` on types that contain proxies often. So this would save some code, and also allow destructuring of those wrapper types since they won't have their own `Drop` impls.

The same idea was also suggested in https://github.com/Smithay/wayland-rs/issues/596.

I need to test this in a few use cases, and check a few things (probably should test the object version; make sure wayland doesn't allow multiple destructors or destructors with arguments, or handle those somehow; compare the `_destroy` code generated in libwayland.)