### PR TITLE
BREAKING: use `Cow<'static, CStr>` for string argument

### DIFF
--- a/wayland-backend/src/protocol.rs
+++ b/wayland-backend/src/protocol.rs
@@ -1,6 +1,6 @@
 //! Types and utilities for manipulating the Wayland protocol
 
-use std::{ffi::CString, os::unix::io::AsRawFd};
+use std::{borrow::Cow, ffi::CStr, os::unix::io::AsRawFd};
 
 pub use wayland_sys::common::{wl_argument, wl_interface, wl_message};
 
@@ -22,7 +22,7 @@ pub enum ArgumentType {
     Uint,
     /// A signed fixed point number with 1/256 precision
     Fixed,
-    /// A string. This is represented as a [`CString`] in a message.
+    /// A string. This is represented as a [`Cow<'static, CStr>`] in a message.
     Str(AllowNull),
     /// Id of a wayland object
     Object(AllowNull),
@@ -53,11 +53,11 @@ pub enum Argument<Id, Fd> {
     Uint(u32),
     /// A signed fixed point number with 1/256 precision
     Fixed(i32),
-    /// CString
+    /// `Cow<'static, CStr>`
     ///
     /// The value is boxed to reduce the stack size of Argument. The performance
     /// impact is negligible as `string` arguments are pretty rare in the protocol.
-    Str(Option<Box<CString>>),
+    Str(Option<Box<Cow<'static, CStr>>>),
     /// Id of a wayland object
     Object(Id),
     /// Id of a newly created wayland object

--- a/wayland-backend/src/rs/server_impl/client.rs
+++ b/wayland-backend/src/rs/server_impl/client.rs
@@ -282,7 +282,7 @@ impl<D> Client<D> {
                 [
                     Argument::Object(ObjectId { id: object_id.clone() }),
                     Argument::Uint(error_code),
-                    Argument::Str(Some(Box::new(message))),
+                    Argument::Str(Some(Box::new(message.into()))),
                 ],
             ),
             // wl_display.error is not a destructor, this argument will not be used

--- a/wayland-backend/src/rs/server_impl/registry.rs
+++ b/wayland-backend/src/rs/server_impl/registry.rs
@@ -231,7 +231,7 @@ fn send_global_to<D>(
             0, // wl_registry.global
             [
                 Argument::Uint(global.id.id),
-                Argument::Str(Some(Box::new(CString::new(global.interface.name).unwrap()))),
+                Argument::Str(Some(Box::new(CString::new(global.interface.name).unwrap().into()))),
                 Argument::Uint(global.version),
             ],
         ),

--- a/wayland-backend/src/rs/socket.rs
+++ b/wayland-backend/src/rs/socket.rs
@@ -373,7 +373,7 @@ mod tests {
             args: smallvec![
                 Argument::Uint(3),
                 Argument::Fixed(-89),
-                Argument::Str(Some(Box::new(CString::new(&b"I like trains!"[..]).unwrap()))),
+                Argument::Str(Some(Box::new(CString::new(&b"I like trains!"[..]).unwrap().into()))),
                 Argument::Array(vec![1, 2, 3, 4, 5, 6, 7, 8, 9].into()),
                 Argument::Object(88),
                 Argument::NewId(56),
@@ -457,7 +457,7 @@ mod tests {
                 opcode: 0,
                 args: smallvec![
                     Argument::Int(42),
-                    Argument::Str(Some(Box::new(CString::new(&b"I like trains"[..]).unwrap()))),
+                    Argument::Str(Some(Box::new(CString::new(&b"I like trains"[..]).unwrap().into()))),
                 ],
             },
             Message {
@@ -518,7 +518,7 @@ mod tests {
             opcode: 0,
             args: smallvec![
                 Argument::Uint(18),
-                Argument::Str(Some(Box::new(CString::new(&b"wl_shell"[..]).unwrap()))),
+                Argument::Str(Some(Box::new(CString::new(&b"wl_shell"[..]).unwrap().into()))),
                 Argument::Uint(1),
             ],
         };

--- a/wayland-backend/src/rs/wire.rs
+++ b/wayland-backend/src/rs/wire.rs
@@ -118,7 +118,7 @@ pub fn write_to_buffers(
             Argument::Int(i) => write_buf(i as u32, payload)?,
             Argument::Uint(u) => write_buf(u, payload)?,
             Argument::Fixed(f) => write_buf(f as u32, payload)?,
-            Argument::Str(Some(ref s)) => write_array_to_payload(s.as_bytes_with_nul(), payload)?,
+            Argument::Str(Some(ref s)) => write_array_to_payload(s.to_bytes_with_nul(), payload)?,
             Argument::Str(None) => write_array_to_payload(&[], payload)?,
             Argument::Object(o) => write_buf(o, payload)?,
             Argument::NewId(n) => write_buf(n, payload)?,
@@ -210,7 +210,8 @@ pub fn parse_message<'a>(
                             tail = rest;
                             if !v.is_empty() {
                                 match CStr::from_bytes_with_nul(v) {
-                                    Ok(s) => Ok(Argument::Str(Some(Box::new(s.into())))),
+                                    // TODO: to_owned could be remove if using Cow<'_, CStr>, its lifetime is within the BufferedSocket.
+                                    Ok(s) => Ok(Argument::Str(Some(Box::new(s.to_owned().into())))),
                                     Err(_) => Err(MessageParseError::Malformed),
                                 }
                             } else {
@@ -266,7 +267,7 @@ mod tests {
             args: smallvec![
                 Argument::Uint(3),
                 Argument::Fixed(-89),
-                Argument::Str(Some(Box::new(CString::new(&b"I like trains!"[..]).unwrap()))),
+                Argument::Str(Some(Box::new(CString::new(&b"I like trains!"[..]).unwrap().into()))),
                 Argument::Array(vec![1, 2, 3, 4, 5, 6, 7, 8, 9].into()),
                 Argument::Object(88),
                 Argument::NewId(56),

--- a/wayland-backend/src/sys/client_impl/mod.rs
+++ b/wayland-backend/src/sys/client_impl/mod.rs
@@ -862,7 +862,8 @@ unsafe extern "C" fn dispatcher_func(
                 // Safety: the c-string provided by libwayland must be valid
                 if !ptr.is_null() {
                     let cstr = unsafe { std::ffi::CStr::from_ptr(ptr) };
-                    parsed_args.push(Argument::Str(Some(Box::new(cstr.into()))));
+                    // TODO: to_owned could be removed if using Cow<'_, CStr>, its lifetime is within the scope.
+                    parsed_args.push(Argument::Str(Some(Box::new(cstr.to_owned().into()))));
                 } else {
                     parsed_args.push(Argument::Str(None));
                 }

--- a/wayland-backend/src/test/destructors.rs
+++ b/wayland-backend/src/test/destructors.rs
@@ -103,7 +103,9 @@ expand_test!(destructor_request, {
                 [
                     Argument::Uint(1),
                     Argument::Str(Some(Box::new(
-                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
+                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes())
+                            .unwrap()
+                            .into(),
                     ))),
                     Argument::Uint(3),
                     Argument::NewId(client_backend::ObjectId::null()),
@@ -164,7 +166,9 @@ expand_test!(destructor_cleanup, {
                 [
                     Argument::Uint(1),
                     Argument::Str(Some(Box::new(
-                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
+                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes())
+                            .unwrap()
+                            .into(),
                     ))),
                     Argument::Uint(3),
                     Argument::NewId(client_backend::ObjectId::null()),

--- a/wayland-backend/src/test/many_args.rs
+++ b/wayland-backend/src/test/many_args.rs
@@ -70,7 +70,7 @@ macro_rules! serverdata_impls {
                             Argument::Int(-53),
                             Argument::Fixed(9823),
                             Argument::Array(Box::new(vec![10, 20, 30, 40, 50, 60, 70, 80, 90])),
-                            Argument::Str(Some(Box::new(CString::new("I want cake".as_bytes()).unwrap()))),
+                            Argument::Str(Some(Box::new(CString::new("I want cake".as_bytes()).unwrap().into()))),
                             Argument::Fd(1), // stdout
                         ],
                     ))
@@ -153,7 +153,9 @@ expand_test!(many_args, {
                 [
                     Argument::Uint(1),
                     Argument::Str(Some(Box::new(
-                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
+                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes())
+                            .unwrap()
+                            .into(),
                     ))),
                     Argument::Uint(1),
                     Argument::NewId(client_backend::ObjectId::null()),
@@ -182,7 +184,7 @@ expand_test!(many_args, {
                     Argument::Fixed(4589),
                     Argument::Array(Box::new(vec![1, 2, 3, 4, 5, 6, 7, 8, 9])),
                     Argument::Str(Some(Box::new(
-                        CString::new("I like trains".as_bytes()).unwrap()
+                        CString::new("I like trains".as_bytes()).unwrap().into()
                     ))),
                     Argument::Fd(0), // stdin
                 ],

--- a/wayland-backend/src/test/object_args.rs
+++ b/wayland-backend/src/test/object_args.rs
@@ -156,7 +156,9 @@ expand_test!(create_objects, {
                 [
                     Argument::Uint(1),
                     Argument::Str(Some(Box::new(
-                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
+                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes())
+                            .unwrap()
+                            .into(),
                     ))),
                     Argument::Uint(3),
                     Argument::NewId(client_backend::ObjectId::null()),
@@ -255,7 +257,7 @@ expand_test!(panic bad_interface, {
                 [
                     Argument::Uint(1),
                     Argument::Str(Some(Box::new(
-                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
+                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap().into(),
                     ))),
                     Argument::Uint(3),
                     Argument::NewId(client_backend::ObjectId::null()),
@@ -315,7 +317,7 @@ expand_test!(panic double_null, {
                 [
                     Argument::Uint(1),
                     Argument::Str(Some(Box::new(
-                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
+                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap().into(),
                     ))),
                     Argument::Uint(3),
                     Argument::NewId(client_backend::ObjectId::null()),
@@ -372,7 +374,9 @@ expand_test!(null_obj_followed_by_interface, {
                 [
                     Argument::Uint(1),
                     Argument::Str(Some(Box::new(
-                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
+                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes())
+                            .unwrap()
+                            .into(),
                     ))),
                     Argument::Uint(3),
                     Argument::NewId(client_backend::ObjectId::null()),
@@ -441,7 +445,9 @@ expand_test!(new_id_null_and_non_null, {
                 [
                     Argument::Uint(1),
                     Argument::Str(Some(Box::new(
-                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
+                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes())
+                            .unwrap()
+                            .into(),
                     ))),
                     Argument::Uint(5),
                     Argument::NewId(client_backend::ObjectId::null()),

--- a/wayland-backend/src/test/protocol_error.rs
+++ b/wayland-backend/src/test/protocol_error.rs
@@ -70,7 +70,7 @@ expand_test!(protocol_error, {
                 [
                     Argument::Uint(1),
                     Argument::Str(Some(Box::new(
-                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
+                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap().into(),
                     ))),
                     Argument::Uint(3),
                     Argument::NewId(client_backend::ObjectId::null()),
@@ -288,7 +288,7 @@ expand_test!(protocol_error_in_request_without_object_init, {
                 [
                     Argument::Uint(1),
                     Argument::Str(Some(Box::new(
-                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
+                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap().into(),
                     ))),
                     Argument::Uint(3),
                     Argument::NewId(client_backend::ObjectId::null()),

--- a/wayland-backend/src/test/server_created_objects.rs
+++ b/wayland-backend/src/test/server_created_objects.rs
@@ -137,7 +137,9 @@ expand_test!(server_created_object, {
                 [
                     Argument::Uint(1),
                     Argument::Str(Some(Box::new(
-                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes()).unwrap(),
+                        CString::new(interfaces::TEST_GLOBAL_INTERFACE.name.as_bytes())
+                            .unwrap()
+                            .into(),
                     ))),
                     Argument::Uint(1),
                     Argument::NewId(client_backend::ObjectId::null()),

--- a/wayland-client/examples/list_globals.rs
+++ b/wayland-client/examples/list_globals.rs
@@ -27,7 +27,8 @@ impl Dispatch<wl_registry::WlRegistry, ()> for AppData {
         // `global` event, which signals a new available global.
         // When receiving this event, we just print its characteristics in this example.
         if let wl_registry::Event::Global { name, interface, version } = event {
-            println!("[{}] {} (v{})", name, interface, version);
+            let interface = String::from_utf8_lossy(interface.to_bytes());
+            println!("[{}] {:?} (v{})", name, interface, version);
         }
     }
 }

--- a/wayland-client/examples/list_globals_no_dispatch.rs
+++ b/wayland-client/examples/list_globals_no_dispatch.rs
@@ -24,7 +24,12 @@ impl backend::ObjectData for RegistryData {
         // Similar to the dispatch example, we only care about the global event and
         // will print out the received globals.
         if let wl_registry::Event::Global { name, interface, version } = event {
-            println!("[{}] {} (v{})", name, interface, version);
+            println!(
+                "[{}] {:?} (v{})",
+                name,
+                String::from_utf8_lossy(interface.to_bytes()),
+                version
+            );
         }
         None
     }

--- a/wayland-client/examples/simple_window.rs
+++ b/wayland-client/examples/simple_window.rs
@@ -55,7 +55,8 @@ impl Dispatch<wl_registry::WlRegistry, ()> for State {
         qh: &QueueHandle<Self>,
     ) {
         if let wl_registry::Event::Global { name, interface, .. } = event {
-            match &interface[..] {
+            let interface = String::from_utf8_lossy(interface.to_bytes());
+            match interface.as_ref() {
                 "wl_compositor" => {
                     let compositor =
                         registry.bind::<wl_compositor::WlCompositor, _, _>(name, 1, qh, ());
@@ -137,7 +138,7 @@ impl State {
 
         let xdg_surface = wm_base.get_xdg_surface(base_surface, qh, ());
         let toplevel = xdg_surface.get_toplevel(qh, ());
-        toplevel.set_title("A fantastic window!".into());
+        toplevel.set_title(std::ffi::CString::new("A fantastic window!").unwrap().into());
 
         base_surface.commit();
 

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -328,7 +328,11 @@ where
             match event {
                 wl_registry::Event::Global { name, interface, version } => {
                     let mut guard = self.globals.contents.lock().unwrap();
-                    guard.push(Global { name, interface, version });
+                    guard.push(Global {
+                        name,
+                        interface: String::from_utf8_lossy(interface.to_bytes()).into_owned(),
+                        version,
+                    });
                 }
 
                 wl_registry::Event::GlobalRemove { name: remove } => {

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -80,7 +80,8 @@
 //!         // `global` event, which signals a new available global.
 //!         // When receiving this event, we just print its characteristics in this example.
 //!         if let wl_registry::Event::Global { name, interface, version } = event {
-//!             println!("[{}] {} (v{})", name, interface, version);
+//!             let interface = String::from_utf8_lossy(interface.to_bytes());
+//!             println!("[{}] {:?} (v{})", name, interface, version);
 //!         }
 //!     }
 //! }

--- a/wayland-scanner/src/client_gen.rs
+++ b/wayland-scanner/src/client_gen.rs
@@ -210,7 +210,7 @@ fn gen_methods(interface: &Interface) -> TokenStream {
                     Type::Uint => quote! { u32 },
                     Type::Int => quote! { i32 },
                     Type::Fixed => quote! { f64 },
-                    Type::String => if arg.allow_null { quote!{ Option<String> } } else { quote!{ String } },
+                    Type::String => if arg.allow_null { quote!{ Option<std::borrow::Cow<'static, std::ffi::CStr>> } } else { quote!{ std::borrow::Cow<'static, std::ffi::CStr> } },
                     Type::Array => if arg.allow_null { quote!{ Option<Vec<u8>> } } else { quote!{ Vec<u8> } },
                     Type::Fd => quote! { ::std::os::unix::io::BorrowedFd<'_> },
                     Type::Object => {
@@ -329,7 +329,8 @@ mod tests {
         let reference = crate::format_rust_code(&reference);
 
         if reference != generated {
-            let diff = similar::TextDiff::from_lines(&reference, &generated);
+            let diff: similar::TextDiff<'_, '_, '_, str> =
+                similar::TextDiff::from_lines(&reference, &generated);
             print!("{}", diff.unified_diff().context_radius(10).header("reference", "generated"));
             panic!("Generated does not match reference!")
         }

--- a/wayland-scanner/src/common.rs
+++ b/wayland-scanner/src/common.rs
@@ -182,98 +182,102 @@ pub(crate) fn gen_message_enum(
 
             let doc_attr = to_doc_attr(&docs);
             let msg_name = Ident::new(&snake_to_camel(&msg.name), Span::call_site());
-            let msg_variant_decl =
-                if msg.args.is_empty() {
-                    msg_name.into_token_stream()
-                } else {
-                    let fields = msg.args.iter().flat_map(|arg| {
-                let field_name =
-                    format_ident!("{}{}", if is_keyword(&arg.name) { "_" } else { "" }, arg.name);
-                let field_type_inner = if let Some(ref enu) = arg.enum_ {
-                    let enum_type = dotted_to_relname(enu);
-                    quote! { WEnum<#enum_type> }
-                } else {
-                    match arg.typ {
-                        Type::Uint => quote! { u32 },
-                        Type::Int => quote! { i32 },
-                        Type::Fixed => quote! { f64 },
-                        Type::String => quote! { String },
-                        Type::Array => quote! { Vec<u8> },
-                        Type::Fd => {
-                            if receiver {
-                                quote! { OwnedFd }
-                            } else {
-                                quote! { std::os::unix::io::BorrowedFd<'a> }
-                            }
-                        }
-                        Type::Object => {
-                            if let Some(ref iface) = arg.interface {
-                                let iface_mod = Ident::new(iface, Span::call_site());
-                                let iface_type =
-                                    Ident::new(&snake_to_camel(iface), Span::call_site());
-                                quote! { super::#iface_mod::#iface_type }
-                            } else if side == Side::Client {
-                                quote! { super::wayland_client::ObjectId }
-                            } else {
-                                quote! { super::wayland_server::ObjectId }
-                            }
-                        }
-                        Type::NewId if !receiver && side == Side::Client => {
-                            // Client-side sending does not have a pre-existing object
-                            // so skip serializing it
-                            if arg.interface.is_some() {
-                                return None;
-                            } else {
-                                quote! { (&'static Interface, u32) }
-                            }
-                        }
-                        Type::NewId => {
-                            if let Some(ref iface) = arg.interface {
-                                let iface_mod = Ident::new(iface, Span::call_site());
-                                let iface_type =
-                                    Ident::new(&snake_to_camel(iface), Span::call_site());
-                                if receiver && side == Side::Server {
-                                    quote! { New<super::#iface_mod::#iface_type> }
+            let msg_variant_decl = if msg.args.is_empty() {
+                msg_name.into_token_stream()
+            } else {
+                let fields = msg.args.iter().flat_map(|arg| {
+                    let field_name = format_ident!(
+                        "{}{}",
+                        if is_keyword(&arg.name) { "_" } else { "" },
+                        arg.name
+                    );
+                    let field_type_inner = if let Some(ref enu) = arg.enum_ {
+                        let enum_type = dotted_to_relname(enu);
+                        quote! { WEnum<#enum_type> }
+                    } else {
+                        match arg.typ {
+                            Type::Uint => quote! { u32 },
+                            Type::Int => quote! { i32 },
+                            Type::Fixed => quote! { f64 },
+                            Type::String => quote! { std::borrow::Cow<'static, std::ffi::CStr> },
+                            Type::Array => quote! { Vec<u8> },
+                            Type::Fd => {
+                                if receiver {
+                                    quote! { OwnedFd }
                                 } else {
+                                    quote! { std::os::unix::io::BorrowedFd<'a> }
+                                }
+                            }
+                            Type::Object => {
+                                if let Some(ref iface) = arg.interface {
+                                    let iface_mod = Ident::new(iface, Span::call_site());
+                                    let iface_type =
+                                        Ident::new(&snake_to_camel(iface), Span::call_site());
                                     quote! { super::#iface_mod::#iface_type }
-                                }
-                            } else {
-                                // bind-like function
-                                if side == Side::Client {
-                                    quote! { (String, u32, super::wayland_client::ObjectId) }
+                                } else if side == Side::Client {
+                                    quote! { super::wayland_client::ObjectId }
                                 } else {
-                                    quote! { (String, u32, super::wayland_server::ObjectId) }
+                                    quote! { super::wayland_server::ObjectId }
                                 }
                             }
+                            Type::NewId if !receiver && side == Side::Client => {
+                                // Client-side sending does not have a pre-existing object
+                                // so skip serializing it
+                                if arg.interface.is_some() {
+                                    return None;
+                                } else {
+                                    quote! { (&'static Interface, u32) }
+                                }
+                            }
+                            Type::NewId => {
+                                if let Some(ref iface) = arg.interface {
+                                    let iface_mod = Ident::new(iface, Span::call_site());
+                                    let iface_type =
+                                        Ident::new(&snake_to_camel(iface), Span::call_site());
+                                    if receiver && side == Side::Server {
+                                        quote! { New<super::#iface_mod::#iface_type> }
+                                    } else {
+                                        quote! { super::#iface_mod::#iface_type }
+                                    }
+                                } else {
+                                    // bind-like function
+                                    if side == Side::Client {
+                                        quote! { (String, u32, super::wayland_client::ObjectId) }
+                                    } else {
+                                        quote! { (String, u32, super::wayland_server::ObjectId) }
+                                    }
+                                }
+                            }
+                            Type::Destructor => {
+                                panic!("An argument cannot have type \"destructor\".")
+                            }
                         }
-                        Type::Destructor => panic!("An argument cannot have type \"destructor\"."),
+                    };
+
+                    let field_type = if arg.allow_null {
+                        quote! { Option<#field_type_inner> }
+                    } else {
+                        field_type_inner.into_token_stream()
+                    };
+
+                    let doc_attr = arg
+                        .description
+                        .as_ref()
+                        .map(description_to_doc_attr)
+                        .or_else(|| arg.summary.as_ref().map(|s| to_doc_attr(s)));
+
+                    Some(quote! {
+                        #doc_attr
+                        #field_name: #field_type
+                    })
+                });
+
+                quote! {
+                    #msg_name {
+                        #(#fields,)*
                     }
-                };
-
-                let field_type = if arg.allow_null {
-                    quote! { Option<#field_type_inner> }
-                } else {
-                    field_type_inner.into_token_stream()
-                };
-
-                let doc_attr = arg
-                    .description
-                    .as_ref()
-                    .map(description_to_doc_attr)
-                    .or_else(|| arg.summary.as_ref().map(|s| to_doc_attr(s)));
-
-                Some(quote! {
-                    #doc_attr
-                    #field_name: #field_type
-                })
-            });
-
-                    quote! {
-                        #msg_name {
-                            #(#fields,)*
-                        }
-                    }
-                };
+                }
+            };
 
             quote! {
                 #doc_attr
@@ -348,7 +352,6 @@ pub(crate) fn gen_parse_body(interface: &Interface, side: Side) -> TokenStream {
         },
         Span::call_site(),
     );
-
     let match_arms = msgs.iter().enumerate().map(|(opcode, msg)| {
         let opcode = opcode as u16;
         let msg_name = Ident::new(&snake_to_camel(&msg.name), Span::call_site());
@@ -371,7 +374,6 @@ pub(crate) fn gen_parse_body(interface: &Interface, side: Side) -> TokenStream {
         });
 
         let args_iter = msg.args.iter().map(|_| quote!{ arg_iter.next() });
-
         let arg_names = msg.args.iter().map(|arg| {
             let arg_name = format_ident!("{}{}", if is_keyword(&arg.name) { "_" } else { "" }, arg.name);
             if arg.enum_.is_some() {
@@ -383,11 +385,11 @@ pub(crate) fn gen_parse_body(interface: &Interface, side: Side) -> TokenStream {
                     Type::String => {
                         if arg.allow_null {
                             quote! {
-                                #arg_name: #arg_name.as_ref().map(|s| String::from_utf8_lossy(s.as_bytes()).into_owned())
+                                #arg_name: #arg_name.map(|s| *s)
                             }
                         } else {
                             quote! {
-                                #arg_name: String::from_utf8_lossy(#arg_name.as_ref().unwrap().as_bytes()).into_owned()
+                                #arg_name: *#arg_name.unwrap()
                             }
                         }
                     },
@@ -538,9 +540,9 @@ pub(crate) fn gen_write_body(interface: &Interface, side: Side) -> TokenStream {
                     vec![quote! { Argument::Array(Box::new(#arg_name)) }]
                 },
                 Type::String => if arg.allow_null {
-                    vec![quote! { Argument::Str(#arg_name.map(|s| Box::new(std::ffi::CString::new(s).unwrap()))) }]
+                        vec![quote! { Argument::Str(#arg_name.map(|s| Box::new(s))) }]
                 } else {
-                    vec![quote! { Argument::Str(Some(Box::new(std::ffi::CString::new(#arg_name).unwrap()))) }]
+                        vec![quote! { Argument::Str(Some(Box::new(#arg_name))) }]
                 },
                 Type::NewId => if side == Side::Client {
                     if let Some(ref created_interface) = arg.interface {
@@ -559,7 +561,7 @@ pub(crate) fn gen_write_body(interface: &Interface, side: Side) -> TokenStream {
                         });
                         vec![
                             quote! {
-                                Argument::Str(Some(Box::new(std::ffi::CString::new(#arg_name.0.name).unwrap())))
+                                Argument::Str(Some(Box::new(std::ffi::CString::new(#arg_name.0.name).unwrap().into())))
                             },
                             quote! {
                                 Argument::Uint(#arg_name.1)

--- a/wayland-scanner/src/server_gen.rs
+++ b/wayland-scanner/src/server_gen.rs
@@ -206,9 +206,9 @@ fn gen_methods(interface: &Interface) -> TokenStream {
                         Type::Fixed => quote! { f64 },
                         Type::String => {
                             if arg.allow_null {
-                                quote! { Option<String> }
+                                quote! { Option<std::borrow::Cow<'static, std::ffi::CStr>> }
                             } else {
-                                quote! { String }
+                                quote! { std::borrow::Cow<'static, std::ffi::CStr> }
                             }
                         }
                         Type::Array => {

--- a/wayland-scanner/tests/scanner_assets/test-server-code.rs
+++ b/wayland-scanner/tests/scanner_assets/test-server-code.rs
@@ -231,7 +231,7 @@ pub mod test_global {
             #[doc = "an array"]
             number_array: Vec<u8>,
             #[doc = "some text"]
-            some_text: String,
+            some_text: std::borrow::Cow<'static, std::ffi::CStr>,
             #[doc = "a file descriptor"]
             file_descriptor: OwnedFd,
         },
@@ -286,7 +286,7 @@ pub mod test_global {
             #[doc = "an array"]
             number_array: Vec<u8>,
             #[doc = "some text"]
-            some_text: String,
+            some_text: std::borrow::Cow<'static, std::ffi::CStr>,
             #[doc = "a file descriptor"]
             file_descriptor: std::os::unix::io::BorrowedFd<'a>,
         },
@@ -416,10 +416,7 @@ pub mod test_global {
                                 signed_int,
                                 fixed_point: (fixed_point as f64) / 256.,
                                 number_array: *number_array,
-                                some_text: String::from_utf8_lossy(
-                                    some_text.as_ref().unwrap().as_bytes(),
-                                )
-                                .into_owned(),
+                                some_text: *some_text.unwrap(),
                                 file_descriptor,
                             },
                         ))
@@ -699,7 +696,7 @@ pub mod test_global {
                         Argument::Int(signed_int),
                         Argument::Fixed((fixed_point * 256.) as i32),
                         Argument::Array(Box::new(number_array)),
-                        Argument::Str(Some(Box::new(std::ffi::CString::new(some_text).unwrap()))),
+                        Argument::Str(Some(Box::new(some_text))),
                         Argument::Fd(file_descriptor),
                     ]),
                 }),
@@ -745,7 +742,7 @@ pub mod test_global {
             signed_int: i32,
             fixed_point: f64,
             number_array: Vec<u8>,
-            some_text: String,
+            some_text: std::borrow::Cow<'static, std::ffi::CStr>,
             file_descriptor: ::std::os::unix::io::BorrowedFd<'_>,
         ) {
             let _ = self.send_event(Event::ManyArgsEvt {

--- a/wayland-tests/tests/client_globals_helpers.rs
+++ b/wayland-tests/tests/client_globals_helpers.rs
@@ -199,7 +199,7 @@ impl wayc::Dispatch<wl_registry::WlRegistry, GlobalListContents> for ClientHandl
     ) {
         if let wl_registry::Event::Global { name, interface, version } = event {
             assert_eq!(name, 3);
-            assert_eq!(interface, "wl_output");
+            assert_eq!(String::from_utf8_lossy(interface.to_bytes()), "wl_output");
             assert_eq!(version, 2);
             state.0 = true;
         } else if let wl_registry::Event::GlobalRemove { name } = event {

--- a/wayland-tests/tests/helpers/globals.rs
+++ b/wayland-tests/tests/helpers/globals.rs
@@ -41,7 +41,11 @@ where
         let me = handle.as_mut();
         match event {
             wl_registry::Event::Global { name, interface, version } => {
-                me.globals.push(GlobalDescription { name, interface, version });
+                me.globals.push(GlobalDescription {
+                    name,
+                    interface: String::from_utf8_lossy(interface.to_bytes()).into_owned(),
+                    version,
+                });
             }
             wl_registry::Event::GlobalRemove { name } => {
                 me.globals.retain(|desc| desc.name != name);

--- a/wayland-tests/tests/server_created_object.rs
+++ b/wayland-tests/tests/server_created_object.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 mod helpers;
 
+use std::ffi::CString;
+
 use helpers::{globals, roundtrip, wayc, ways, TestServer};
 
 use ways::protocol::wl_data_device::WlDataDevice as ServerDD;
@@ -186,7 +188,7 @@ fn server_created_race() {
 
     roundtrip(&mut client, &mut server, &mut client_ddata, &mut server_ddata).unwrap();
 
-    offer.offer("text".into());
+    offer.offer(CString::new("text").unwrap().into());
 
     roundtrip(&mut client, &mut server, &mut client_ddata, &mut server_ddata).unwrap();
 
@@ -195,7 +197,7 @@ fn server_created_race() {
     // now the client will conccurently destroy the object as the server sends an event to it
     // this should not crash and the events to the zombie object should be silently dropped
 
-    offer.offer("utf8".into());
+    offer.offer(CString::new("utf8").unwrap().into());
     let client_do = client_ddata.data_offer.take().unwrap();
     client_do.destroy();
 
@@ -404,7 +406,7 @@ impl wayc::Dispatch<ClientDO, ()> for ClientHandler {
     ) {
         match event {
             wayc::protocol::wl_data_offer::Event::Offer { mime_type } => {
-                state.received = Some(mime_type);
+                state.received = Some(String::from_utf8_lossy(mime_type.to_bytes()).into_owned());
             }
             _ => unimplemented!(),
         }


### PR DESCRIPTION
Closes https://github.com/Smithay/wayland-rs/issues/748.
Leave construction of string argument to caller and make `ffi` process less panic-proned, and is benefit for users whose rust version is above 1.77 to use [C-string literals](https://doc.rust-lang.org/edition-guide/rust-2021/c-string-literals.html#c-string-literals)