### PR TITLE
Update delegate_dispatch docs

### DIFF
--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -716,7 +716,7 @@ impl<I: Proxy, U: std::fmt::Debug, State> std::fmt::Debug for QueueProxyData<I, 
 /// # Usage
 ///
 /// For example, say you want to delegate events for [`WlRegistry`][crate::protocol::wl_registry::WlRegistry]
-/// to the struct `DelegateToMe` for the [`Dispatch`] documentatione example.
+/// to the struct `DelegateToMe` for the [`Dispatch`] documentation example.
 ///
 /// ```
 /// use wayland_client::{delegate_dispatch, protocol::wl_registry};

--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -772,6 +772,26 @@ impl<I: Proxy, U: std::fmt::Debug, State> std::fmt::Debug for QueueProxyData<I, 
 /// }
 ///
 /// assert_is_registry_delegate::<ExampleApp>();
+///
+/// // This macro can also be applied to a generic type using the `@<>` syntax:
+///
+/// /// The application state
+/// struct GenericApp<T: Copy> {
+///     /// The delegate for handling wl_registry events.
+///     delegate: DelegateToMe,
+///     app_data: T,
+/// }
+///
+/// delegate_dispatch!(@<T: Copy> GenericApp<T>: [wl_registry::WlRegistry: MyUserData] => DelegateToMe);
+///
+/// impl<T: Copy> AsMut<DelegateToMe> for GenericApp<T> {
+///     fn as_mut(&mut self) -> &mut DelegateToMe {
+///         &mut self.delegate
+///     }
+/// }
+///
+/// // Assert that the above setup applies to a concrete GenericApp type
+/// assert_is_registry_delegate::<GenericApp<u32>>();
 /// ```
 #[macro_export]
 macro_rules! delegate_dispatch {


### PR DESCRIPTION
This fixes a typo and includes a description of the `@<>` syntax which allows delegatng over a generic type.

I needed this feature but it wasn't documented, so I was lucky to catch a dev and asked. With this description, even unlucky people can find this feature.