### PR TITLE
chore: Release

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.3.9 -- 2025-04-28
+
 #### Bugfixes
 
 - backend/sys: Prevent send_request being called in parallel with dispatch_pending

--- a/wayland-backend/Cargo.toml
+++ b/wayland-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-backend"
-version = "0.3.8"
+version = "0.3.9"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
 edition = "2021"
 rust-version = "1.65"

--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-client"
-version = "0.31.8"
+version = "0.31.9"
 documentation = "https://docs.rs/wayland-client/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -13,7 +13,7 @@ description = "Bindings to the standard C implementation of the wayland protocol
 readme = "README.md"
 
 [dependencies]
-wayland-backend = { version = "0.3.8", path = "../wayland-backend" }
+wayland-backend = { version = "0.3.9", path = "../wayland-backend" }
 wayland-scanner = { version = "0.31.6", path = "../wayland-scanner" }
 bitflags = "2"
 rustix = { version = "0.38.0", features = ["event"] }

--- a/wayland-cursor/Cargo.toml
+++ b/wayland-cursor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-cursor"
-version = "0.31.8"
+version = "0.31.9"
 documentation = "https://docs.rs/wayland-cursor/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -13,7 +13,7 @@ description = "Bindings to libwayland-cursor."
 readme = "README.md"
 
 [dependencies]
-wayland-client = { version = "0.31.8", path = "../wayland-client" }
+wayland-client = { version = "0.31.9", path = "../wayland-client" }
 xcursor = "0.3.1"
 rustix = { version = "0.38.15", features = ["shm"] }
 

--- a/wayland-egl/Cargo.toml
+++ b/wayland-egl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-egl"
-version = "0.32.5"
+version = "0.32.6"
 documentation = "https://docs.rs/wayland-egl/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -13,7 +13,7 @@ description = "Bindings to libwayland-egl."
 readme = "README.md"
 
 [dependencies]
-wayland-backend = { version = "0.3.8", path = "../wayland-backend", features = ["client_system"] }
+wayland-backend = { version = "0.3.9", path = "../wayland-backend", features = ["client_system"] }
 wayland-sys = { version = "0.31.6", path="../wayland-sys", features = ["egl"] }
 
 [package.metadata.docs.rs]

--- a/wayland-protocols-misc/Cargo.toml
+++ b/wayland-protocols-misc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-protocols-misc"
-version = "0.3.6"
+version = "0.3.7"
 documentation = "https://docs.rs/wayland-protocols-misc/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -16,10 +16,10 @@ readme = "README.md"
 
 [dependencies]
 wayland-scanner = { version = "0.31.6", path = "../wayland-scanner" }
-wayland-backend = { version = "0.3.8", path = "../wayland-backend" }
-wayland-client = { version = "0.31.8", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.7", path = "../wayland-server", optional = true }
-wayland-protocols = { version = "0.32.6", path = "../wayland-protocols", features=["unstable"] }
+wayland-backend = { version = "0.3.9", path = "../wayland-backend" }
+wayland-client = { version = "0.31.9", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.8", path = "../wayland-server", optional = true }
+wayland-protocols = { version = "0.32.7", path = "../wayland-protocols", features=["unstable"] }
 bitflags = "2"
 
 [features]

--- a/wayland-protocols-plasma/CHANGELOG.md
+++ b/wayland-protocols-plasma/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.3.7 -- 2025-04-28
+
 - Update plasma-wayland-protocols to 1.16.0
   * New protocols:
     - `kde-external-brightness-v1`

--- a/wayland-protocols-plasma/Cargo.toml
+++ b/wayland-protocols-plasma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-protocols-plasma"
-version = "0.3.6"
+version = "0.3.7"
 documentation = "https://docs.rs/wayland-protocols-plasma/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -16,10 +16,10 @@ readme = "README.md"
 
 [dependencies]
 wayland-scanner = { version = "0.31.6", path = "../wayland-scanner" }
-wayland-backend = { version = "0.3.8", path = "../wayland-backend" }
-wayland-client = { version = "0.31.8", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.7", path = "../wayland-server", optional = true }
-wayland-protocols = { version = "0.32.6", path = "../wayland-protocols"}
+wayland-backend = { version = "0.3.9", path = "../wayland-backend" }
+wayland-client = { version = "0.31.9", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.8", path = "../wayland-server", optional = true }
+wayland-protocols = { version = "0.32.7", path = "../wayland-protocols"}
 bitflags = "2"
 
 [features]

--- a/wayland-protocols-wlr/Cargo.toml
+++ b/wayland-protocols-wlr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-protocols-wlr"
-version = "0.3.6"
+version = "0.3.7"
 documentation = "https://docs.rs/wayland-protocols-wlr/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -16,10 +16,10 @@ readme = "README.md"
 
 [dependencies]
 wayland-scanner = { version = "0.31.6", path = "../wayland-scanner" }
-wayland-backend = { version = "0.3.8", path = "../wayland-backend" }
-wayland-client = { version = "0.31.8", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.7", path = "../wayland-server", optional = true }
-wayland-protocols = { version = "0.32.6", path = "../wayland-protocols"}
+wayland-backend = { version = "0.3.9", path = "../wayland-backend" }
+wayland-client = { version = "0.31.9", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.8", path = "../wayland-server", optional = true }
+wayland-protocols = { version = "0.32.7", path = "../wayland-protocols"}
 bitflags = "2"
 
 [features]

--- a/wayland-protocols/CHANGELOG.md
+++ b/wayland-protocols/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.32.7 -- 2025-04-28
+
 - Bump wayland-protocols to 1.41
   - New staging protocol:
     * `color-management-v1`

--- a/wayland-protocols/Cargo.toml
+++ b/wayland-protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-protocols"
-version = "0.32.6"
+version = "0.32.7"
 documentation = "https://docs.rs/wayland-protocols/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -14,9 +14,9 @@ readme = "README.md"
 
 [dependencies]
 wayland-scanner = { version = "0.31.6", path = "../wayland-scanner" }
-wayland-backend = { version = "0.3.8", path = "../wayland-backend" }
-wayland-client = { version = "0.31.8", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.7", path = "../wayland-server", optional = true }
+wayland-backend = { version = "0.3.9", path = "../wayland-backend" }
+wayland-client = { version = "0.31.9", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.8", path = "../wayland-server", optional = true }
 bitflags = "2"
 
 [features]

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-server"
-version = "0.31.7"
+version = "0.31.8"
 documentation = "https://docs.rs/wayland-server/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -13,7 +13,7 @@ rust-version = "1.65"
 readme = "README.md"
 
 [dependencies]
-wayland-backend = { version = "0.3.8", path = "../wayland-backend" }
+wayland-backend = { version = "0.3.9", path = "../wayland-backend" }
 wayland-scanner = { version = "0.31.6", path = "../wayland-scanner" }
 bitflags = "2"
 log = { version = "0.4", optional = true }

--- a/wayland-tests/Cargo.toml
+++ b/wayland-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-tests"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 rust-version = "1.65"
 publish = false


### PR DESCRIPTION
Ran `cargo release --no-publish --no-tag --no-push --execute patch --prev-tag-name release-2025-01-31 --exclude wayland-sys --exclude wayland-scanner`.

Then updated `CHANGELOG` files.