### PR TITLE
Guard unstable coverage flags behind independent cfg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
           args: --workspace --exclude 'wayland-tests'
         env:
           LLVM_PROFILE_FILE: "wayland-rs-%p-%m.profraw"
-          RUSTFLAGS: "-Cinstrument-coverage --cfg coverage"
+          RUSTFLAGS: "-Cinstrument-coverage --cfg coverage --cfg unstable_coverage"
 
       - name: Coverage
         run: grcov . --binary-path ./target/debug -s . -t lcov --branch --llvm --ignore-not-existing --ignore 'wayland-backend/src/test/*' --ignore '*/examples/*' --ignore '*/tests/*' --ignore '*/.cargo/registry/*' --excl-br-start "mod tests \{" --excl-start "mod tests \{" --excl-br-line "#\[derive\(" --excl-line "#\[derive\(" -o lcov.info
@@ -370,7 +370,7 @@ jobs:
           args: -p wayland-tests --features "${{ matrix.client_feature }} ${{ matrix.server_feature}}"
         env:
           LLVM_PROFILE_FILE: "wayland-rs-%p-%m.profraw"
-          RUSTFLAGS: "-Cinstrument-coverage --cfg coverage"
+          RUSTFLAGS: "-Cinstrument-coverage --cfg coverage --cfg unstable_coverage"
       
       - name: Coverage
         run: grcov . --binary-path ./target/debug -s . -t lcov --branch --llvm --ignore-not-existing --ignore 'wayland-tests/*' --ignore '*/examples/*' --ignore '*/tests/*' --ignore '*/.cargo/registry/*' --excl-br-start "mod tests \{" --excl-start "mod tests \{" --excl-br-line "#\[derive\(" --excl-line "#\[derive\(" -o lcov.info

--- a/wayland-backend/build.rs
+++ b/wayland-backend/build.rs
@@ -1,5 +1,6 @@
 fn main() {
     println!("cargo:rustc-check-cfg=cfg(coverage)");
+    println!("cargo:rustc-check-cfg=cfg(unstable_coverage)");
 
     if std::env::var("CARGO_FEATURE_LOG").ok().is_some() {
         // build the client shim

--- a/wayland-backend/src/client_api.rs
+++ b/wayland-backend/src/client_api.rs
@@ -41,7 +41,7 @@ pub trait ObjectData: downcast_rs::DowncastSync {
     /// Helper for forwarding a Debug implementation of your `ObjectData` type
     ///
     /// By default will just print `ObjectData { ... }`
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ObjectData").finish_non_exhaustive()
     }
@@ -57,7 +57,7 @@ pub trait ObjectData: downcast_rs::DowncastSync {
 }
 
 impl std::fmt::Debug for dyn ObjectData {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.debug(f)
     }
@@ -77,7 +77,7 @@ pub struct ObjectId {
 }
 
 impl fmt::Display for ObjectId {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.id.fmt(f)
@@ -85,7 +85,7 @@ impl fmt::Display for ObjectId {
 }
 
 impl fmt::Debug for ObjectId {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.id.fmt(f)
@@ -333,7 +333,7 @@ impl ReadEventsGuard {
 pub(crate) struct DumbObjectData;
 
 impl ObjectData for DumbObjectData {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn event(
         self: Arc<Self>,
         _handle: &Backend,
@@ -342,7 +342,7 @@ impl ObjectData for DumbObjectData {
         unreachable!()
     }
 
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn destroyed(&self, _object_id: ObjectId) {
         unreachable!()
     }
@@ -351,7 +351,7 @@ impl ObjectData for DumbObjectData {
 pub(crate) struct UninitObjectData;
 
 impl ObjectData for UninitObjectData {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn event(
         self: Arc<Self>,
         _handle: &Backend,
@@ -360,10 +360,10 @@ impl ObjectData for UninitObjectData {
         panic!("Received a message on an uninitialized object: {msg:?}");
     }
 
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn destroyed(&self, _object_id: ObjectId) {}
 
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("UninitObjectData").finish()
     }

--- a/wayland-backend/src/debug.rs
+++ b/wayland-backend/src/debug.rs
@@ -16,7 +16,7 @@ pub fn has_debug_client_env() -> bool {
 /// Print the dispatched message to stderr in a following format:
 ///
 /// `[timestamp] <- interface@id.msg_name(args)`
-#[cfg_attr(coverage, coverage(off))]
+#[cfg_attr(unstable_coverage, coverage(off))]
 pub fn print_dispatched_message<Id: Display, Fd: AsRawFd>(
     interface: &str,
     id: u32,
@@ -35,7 +35,7 @@ pub fn print_dispatched_message<Id: Display, Fd: AsRawFd>(
 /// Print the send message to stderr in a following format:
 ///
 /// `[timestamp] -> interface@id.msg_name(args)`
-#[cfg_attr(coverage, coverage(off))]
+#[cfg_attr(unstable_coverage, coverage(off))]
 pub fn print_send_message<Id: Display, Fd: AsRawFd>(
     interface: &str,
     id: u32,
@@ -59,7 +59,7 @@ pub fn print_send_message<Id: Display, Fd: AsRawFd>(
 pub(crate) struct DisplaySlice<'a, D>(pub &'a [D]);
 
 impl<D: Display> Display for DisplaySlice<'_, D> {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut it = self.0.iter();
         if let Some(val) = it.next() {
@@ -73,7 +73,7 @@ impl<D: Display> Display for DisplaySlice<'_, D> {
 }
 
 /// Print timestamp in seconds.microseconds format.
-#[cfg_attr(coverage, coverage(off))]
+#[cfg_attr(unstable_coverage, coverage(off))]
 fn print_timestamp() {
     if let Ok(timestamp) = SystemTime::now().duration_since(UNIX_EPOCH) {
         // NOTE this is all to make timestamps the same with libwayland, so the log doesn't look

--- a/wayland-backend/src/lib.rs
+++ b/wayland-backend/src/lib.rs
@@ -47,7 +47,7 @@
 #![warn(missing_docs, missing_debug_implementations)]
 // The api modules are imported two times each, this is not accidental
 #![allow(clippy::duplicate_mod)]
-#![cfg_attr(coverage, feature(coverage_attribute))]
+#![cfg_attr(unstable_coverage, feature(coverage_attribute))]
 // Doc feature labels can be tested locally by running RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc -p <crate>
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 

--- a/wayland-backend/src/protocol.rs
+++ b/wayland-backend/src/protocol.rs
@@ -121,7 +121,7 @@ impl<Id: PartialEq, Fd: AsRawFd> PartialEq for Argument<Id, Fd> {
 impl<Id: Eq, Fd: AsRawFd> Eq for Argument<Id, Fd> {}
 
 impl<Id: std::fmt::Display, Fd: AsRawFd> std::fmt::Display for Argument<Id, Fd> {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Int(value) => write!(f, "{value}"),
@@ -155,7 +155,7 @@ pub struct Interface {
 }
 
 impl std::fmt::Display for Interface {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.name)
     }
@@ -254,7 +254,7 @@ impl<Id: Eq, Fd: AsRawFd> Eq for Message<Id, Fd> {}
 impl std::error::Error for ProtocolError {}
 
 impl std::fmt::Display for ProtocolError {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
         write!(
             f,

--- a/wayland-backend/src/rs/client_impl/mod.rs
+++ b/wayland-backend/src/rs/client_impl/mod.rs
@@ -61,14 +61,14 @@ impl std::hash::Hash for InnerObjectId {
 }
 
 impl fmt::Display for InnerObjectId {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}@{}", self.interface.name, self.id)
     }
 }
 
 impl fmt::Debug for InnerObjectId {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "ObjectId({}, {})", self, self.serial)
     }

--- a/wayland-backend/src/rs/server_impl/mod.rs
+++ b/wayland-backend/src/rs/server_impl/mod.rs
@@ -43,14 +43,14 @@ impl InnerObjectId {
 }
 
 impl fmt::Display for InnerObjectId {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}@{}[{}]", self.interface.name, self.id, self.client_id.id)
     }
 }
 
 impl fmt::Debug for InnerObjectId {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "ObjectId({}, {})", self, self.serial)
     }
@@ -106,7 +106,7 @@ pub(crate) struct Data<D: 'static> {
 }
 
 impl<D> Clone for Data<D> {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn clone(&self) -> Self {
         Self { user_data: self.user_data.clone(), serial: self.serial }
     }
@@ -115,7 +115,7 @@ impl<D> Clone for Data<D> {
 struct UninitObjectData;
 
 impl<D> ObjectData<D> for UninitObjectData {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn request(
         self: Arc<Self>,
         _: &Handle,
@@ -126,10 +126,10 @@ impl<D> ObjectData<D> for UninitObjectData {
         panic!("Received a message on an uninitialized object: {msg:?}");
     }
 
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn destroyed(self: Arc<Self>, _: &Handle, _: &mut D, _: ClientId, _: ObjectId) {}
 
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("UninitObjectData").finish()
     }

--- a/wayland-backend/src/rs/wire.rs
+++ b/wayland-backend/src/rs/wire.rs
@@ -20,7 +20,7 @@ pub enum MessageWriteError {
 impl std::error::Error for MessageWriteError {}
 
 impl std::fmt::Display for MessageWriteError {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
         match self {
             Self::BufferTooSmall => {
@@ -50,7 +50,7 @@ pub enum MessageParseError {
 impl std::error::Error for MessageParseError {}
 
 impl std::fmt::Display for MessageParseError {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
         match *self {
             Self::MissingFD => {

--- a/wayland-backend/src/server_api.rs
+++ b/wayland-backend/src/server_api.rs
@@ -43,7 +43,7 @@ pub trait ObjectData<D>: downcast_rs::DowncastSync {
     /// Helper for forwarding a Debug implementation of your `ObjectData` type
     ///
     /// By default will just print `ObjectData { ... }`
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ObjectData").finish_non_exhaustive()
     }
@@ -52,7 +52,7 @@ pub trait ObjectData<D>: downcast_rs::DowncastSync {
 downcast_rs::impl_downcast!(sync ObjectData<D>);
 
 impl<D: 'static> std::fmt::Debug for dyn ObjectData<D> {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.debug(f)
     }
@@ -91,14 +91,14 @@ pub trait GlobalHandler<D>: downcast_rs::DowncastSync {
     /// Helper for forwarding a Debug implementation of your `GlobalHandler` type
     ///
     /// By default will just print `GlobalHandler { ... }`
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GlobalHandler").finish_non_exhaustive()
     }
 }
 
 impl<D: 'static> std::fmt::Debug for dyn GlobalHandler<D> {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.debug(f)
     }
@@ -115,14 +115,14 @@ pub trait ClientData: downcast_rs::DowncastSync {
     /// Helper for forwarding a Debug implementation of your `ClientData` type
     ///
     /// By default will just print `GlobalHandler { ... }`
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ClientData").finish_non_exhaustive()
     }
 }
 
 impl std::fmt::Debug for dyn ClientData {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.debug(f)
     }
@@ -185,14 +185,14 @@ impl ObjectId {
 }
 
 impl fmt::Display for ObjectId {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.id.fmt(f)
     }
 }
 
 impl fmt::Debug for ObjectId {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.id.fmt(f)
     }
@@ -209,7 +209,7 @@ pub struct ClientId {
 }
 
 impl fmt::Debug for ClientId {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.id.fmt(f)
     }
@@ -222,7 +222,7 @@ pub struct GlobalId {
 }
 
 impl fmt::Debug for GlobalId {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.id.fmt(f)
     }
@@ -587,7 +587,7 @@ pub(crate) struct DumbObjectData;
 
 #[allow(dead_code)]
 impl<D> ObjectData<D> for DumbObjectData {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn request(
         self: Arc<Self>,
         _handle: &Handle,
@@ -598,7 +598,7 @@ impl<D> ObjectData<D> for DumbObjectData {
         unreachable!()
     }
 
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn destroyed(
         self: Arc<Self>,
         _handle: &Handle,

--- a/wayland-backend/src/sys/client_impl/mod.rs
+++ b/wayland-backend/src/sys/client_impl/mod.rs
@@ -149,14 +149,14 @@ impl InnerObjectId {
 }
 
 impl std::fmt::Display for InnerObjectId {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}@{}", self.interface.name, self.id)
     }
 }
 
 impl std::fmt::Debug for InnerObjectId {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "ObjectId({self})")
     }

--- a/wayland-backend/src/sys/server_impl/mod.rs
+++ b/wayland-backend/src/sys/server_impl/mod.rs
@@ -71,14 +71,14 @@ impl std::hash::Hash for InnerObjectId {
 }
 
 impl std::fmt::Display for InnerObjectId {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}@{}", self.interface.name, self.id)
     }
 }
 
 impl std::fmt::Debug for InnerObjectId {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "ObjectId({self})")
     }
@@ -1635,7 +1635,7 @@ extern "C" {
 struct UninitObjectData;
 
 impl<D> ObjectData<D> for UninitObjectData {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn request(
         self: Arc<Self>,
         _: &Handle,
@@ -1646,10 +1646,10 @@ impl<D> ObjectData<D> for UninitObjectData {
         panic!("Received a message on an uninitialized object: {msg:?}");
     }
 
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn destroyed(self: Arc<Self>, _: &Handle, _: &mut D, _: ClientId, _: ObjectId) {}
 
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("UninitObjectData").finish()
     }

--- a/wayland-backend/src/types/client.rs
+++ b/wayland-backend/src/types/client.rs
@@ -5,7 +5,7 @@ pub struct NoWaylandLib;
 impl std::error::Error for NoWaylandLib {}
 
 impl std::fmt::Display for NoWaylandLib {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
         f.write_str("could not load libwayland-client.so")
     }
@@ -21,7 +21,7 @@ pub enum WaylandError {
 }
 
 impl std::error::Error for WaylandError {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn cause(&self) -> Option<&dyn std::error::Error> {
         match self {
             Self::Io(e) => Some(e),
@@ -31,7 +31,7 @@ impl std::error::Error for WaylandError {
 }
 
 impl std::fmt::Display for WaylandError {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
         match self {
             Self::Io(e) => write!(f, "Io error: {e}"),
@@ -41,7 +41,7 @@ impl std::fmt::Display for WaylandError {
 }
 
 impl Clone for WaylandError {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn clone(&self) -> Self {
         match self {
             Self::Protocol(e) => Self::Protocol(e.clone()),
@@ -57,14 +57,14 @@ impl Clone for WaylandError {
 }
 
 impl From<crate::protocol::ProtocolError> for WaylandError {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn from(err: crate::protocol::ProtocolError) -> Self {
         Self::Protocol(err)
     }
 }
 
 impl From<std::io::Error> for WaylandError {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn from(err: std::io::Error) -> Self {
         Self::Io(err)
     }
@@ -77,7 +77,7 @@ pub struct InvalidId;
 impl std::error::Error for InvalidId {}
 
 impl std::fmt::Display for InvalidId {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
         write!(f, "Invalid ObjectId")
     }

--- a/wayland-backend/src/types/server.rs
+++ b/wayland-backend/src/types/server.rs
@@ -21,7 +21,7 @@ pub enum InitError {
 }
 
 impl std::error::Error for InitError {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn cause(&self) -> Option<&dyn std::error::Error> {
         match self {
             InitError::Io(ref err) => Some(err),
@@ -31,7 +31,7 @@ impl std::error::Error for InitError {
 }
 
 impl std::fmt::Display for InitError {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
         match self {
             InitError::Io(ref err) => std::fmt::Display::fmt(err, f),
@@ -47,7 +47,7 @@ pub struct InvalidId;
 impl std::error::Error for InvalidId {}
 
 impl std::fmt::Display for InvalidId {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
         write!(f, "Invalid Id")
     }

--- a/wayland-client/build.rs
+++ b/wayland-client/build.rs
@@ -1,3 +1,4 @@
 fn main() {
     println!("cargo:rustc-check-cfg=cfg(coverage)");
+    println!("cargo:rustc-check-cfg=cfg(unstable_coverage)");
 }

--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -124,7 +124,7 @@ where
     /// [`event_created_child!()`] macro is provided for overriding it.
     ///
     /// [`event_created_child!()`]: crate::event_created_child!()
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn event_created_child(opcode: u16, _qhandle: &QueueHandle<State>) -> Arc<dyn ObjectData> {
         panic!(
             "Missing event_created_child specialization for event opcode {} of {}",
@@ -198,7 +198,7 @@ type QueueCallback<State> = fn(
 struct QueueEvent<State>(QueueCallback<State>, Message<ObjectId, OwnedFd>, Arc<dyn ObjectData>);
 
 impl<State> std::fmt::Debug for QueueEvent<State> {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QueueEvent").field("msg", &self.1).finish_non_exhaustive()
     }
@@ -348,7 +348,7 @@ impl<State> EventQueueInner<State> {
 }
 
 impl<State> std::fmt::Debug for EventQueue<State> {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EventQueue").field("handle", &self.handle).finish_non_exhaustive()
     }
@@ -590,7 +590,7 @@ pub struct QueueFreezeGuard<'a, State> {
 }
 
 impl<State> std::fmt::Debug for QueueHandle<State> {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QueueHandle").field("inner", &Arc::as_ptr(&self.inner)).finish()
     }
@@ -697,7 +697,7 @@ where
 }
 
 impl<I: Proxy, U: std::fmt::Debug, State> std::fmt::Debug for QueueProxyData<I, U, State> {
-    #[cfg_attr(coverage, coverage(off))]
+    #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QueueProxyData").field("udata", &self.udata).finish()
     }

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -163,7 +163,7 @@
 #![allow(clippy::needless_doctest_main)]
 #![warn(missing_docs, missing_debug_implementations)]
 #![forbid(improper_ctypes, unsafe_op_in_unsafe_fn)]
-#![cfg_attr(coverage, feature(coverage_attribute))]
+#![cfg_attr(unstable_coverage, feature(coverage_attribute))]
 // Doc feature labels can be tested locally by running RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc -p <crate>
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 


### PR DESCRIPTION
This PR prevents tools like `cargo-llvm-cov` from trying to enable nightly features on stable, while still allowing other downstream crates to use `cfg(coverage)` for other things when coverage tools set the attribute.

I've tested this locally in an internal repo that uses `wayland-client` via `wl-clipboard-rs` and it resolved the nightly feature compilation failures.

Once the coverage attribute stabilizes, and `wayland-rs` bumps its MSRV, this could be removed in favor of just `cfg(coverage)` again.

Resolves https://github.com/Smithay/wayland-rs/issues/717

