### PR TITLE
wayland-sys: Fix CI

### DIFF
--- a/wayland-backend/src/lib.rs
+++ b/wayland-backend/src/lib.rs
@@ -47,6 +47,8 @@
 #![warn(missing_docs, missing_debug_implementations)]
 // The api modules are imported two times each, this is not accidental
 #![allow(clippy::duplicate_mod)]
+// Allow the existing usage
+#![allow(clippy::uninlined_format_args)]
 #![cfg_attr(coverage, feature(coverage_attribute))]
 // Doc feature labels can be tested locally by running RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc -p <crate>
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/wayland-client/examples/list_globals.rs
+++ b/wayland-client/examples/list_globals.rs
@@ -15,6 +15,8 @@ struct AppData;
 // In this example, we just use () as we don't have any value to associate. See
 // the `Dispatch` documentation for more details about this.
 impl Dispatch<wl_registry::WlRegistry, ()> for AppData {
+    // Allow the existing usage
+    #[allow(clippy::uninlined_format_args)]
     fn event(
         _: &mut Self,
         _: &wl_registry::WlRegistry,

--- a/wayland-client/examples/list_globals_no_dispatch.rs
+++ b/wayland-client/examples/list_globals_no_dispatch.rs
@@ -13,6 +13,8 @@ struct RegistryData(Arc<Connection>);
 // ObjectData for our registry. This is required to receive events
 // (specifically, the wl_registry.global events) after our wl_registry.get_registry request.
 impl backend::ObjectData for RegistryData {
+    // Allow the existing usage
+    #[allow(clippy::uninlined_format_args)]
     fn event(
         self: Arc<Self>,
         _: &Backend,

--- a/wayland-sys/src/lib.rs
+++ b/wayland-sys/src/lib.rs
@@ -27,6 +27,8 @@
 //! `is_lib_available()` which returns whether the library could be loaded. They always return true
 //! if the feature `dlopen` is absent, as we link against the library directly in that case.
 #![allow(non_camel_case_types)]
+// Allow the existing usage
+#![allow(clippy::uninlined_format_args)]
 #![forbid(improper_ctypes, unsafe_op_in_unsafe_fn)]
 // Doc feature labels can be tested locally by running RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc -p <crate>
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/wayland-tests/tests/backend_socket_out_limits.rs
+++ b/wayland-tests/tests/backend_socket_out_limits.rs
@@ -151,6 +151,8 @@ client_ignore_impl!(ClientHandler => [
 // Use a modified version of helpers::roundtrip here
 // which gracefully handles ErrorKind::WouldBlock from socket reads and flushes
 // to enable testing with the large amount of Wayland messages this test requires
+// Allow the existing usage
+#[allow(clippy::uninlined_format_args)]
 fn roundtrip<CD: 'static, SD: 'static>(
     client: &mut TestClient<CD>,
     server: &mut TestServer<SD>,

--- a/wayland-tests/tests/client_connect_to_socket.rs
+++ b/wayland-tests/tests/client_connect_to_socket.rs
@@ -8,6 +8,8 @@ use ways::protocol::wl_output::WlOutput as ServerOutput;
 use std::os::unix::io::IntoRawFd;
 use std::sync::Arc;
 
+// Allow the existing usage
+#[allow(clippy::uninlined_format_args)]
 fn main() {
     let mut server = TestServer::new();
     server.display.handle().create_global::<ServerData, ServerOutput, _>(2, ());

--- a/wayland-tests/tests/client_proxies.rs
+++ b/wayland-tests/tests/client_proxies.rs
@@ -266,6 +266,8 @@ impl wayc::Dispatch<wayc::protocol::wl_compositor::WlCompositor, usize> for Clie
     }
 }
 
+// Allow the existing usage
+#[allow(clippy::uninlined_format_args)]
 impl wayc::Dispatch<wayc::protocol::wl_surface::WlSurface, ()> for ClientHandler {
     fn event(
         state: &mut Self,


### PR DESCRIPTION
The CI is set up that changes in external projects can fail a pipeline without any change in the code. This adds an exception to clippy to allow existing usage contradicting the uninlined_format_args rule.