### PR TITLE
protocols: Do not include all of `protocols/` submodule; and use stable tablet v2

### DIFF
--- a/wayland-protocols/Cargo.toml
+++ b/wayland-protocols/Cargo.toml
@@ -11,6 +11,20 @@ categories = ["gui", "api-bindings"]
 edition = "2021"
 rust-version = "1.65"
 readme = "README.md"
+include = [
+    "/src/**/*.rs",
+    "/Cargo.toml",
+    "/README.md",
+    "/LICENSE.txt",
+    "/protocols/stable/*/*.xml",
+    "/protocols/staging/*/*.xml",
+    "/protocols/unstable/*/*.xml",
+    # Exclude old version of stabalized protocols
+    "!/protocols/unstable/xdg-shell/xdg-shell-unstable-v5.xml",
+    "!/protocols/unstable/xdg-shell/xdg-shell-unstable-v6.xml",
+    "!/protocols/unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml",
+    "!/protocols/unstable/tablet/tablet-unstable-v2.xml",
+]
 
 [dependencies]
 wayland-scanner = { version = "0.31.6", path = "../wayland-scanner" }

--- a/wayland-protocols/src/wp.rs
+++ b/wayland-protocols/src/wp.rs
@@ -514,7 +514,7 @@ pub mod tablet {
     /// Unstable version 2
     pub mod zv2 {
         wayland_protocol!(
-            "./protocols/unstable/tablet/tablet-unstable-v2.xml",
+            "./protocols/stable/tablet/tablet-v2.xml",
             []
         );
     }


### PR DESCRIPTION
This should be an improvement on https://github.com/Smithay/wayland-rs/pull/827, using wildcards, and also `!` rules to exclude a few XML files we don't need.

Looks like we also need to update the tablet v2 protocol to use the `stable/` XML file.

Reduces size of `.crate` package from 216K to 152K.