### PR TITLE
chore: Release

### DIFF
--- a/wayland-backend/Cargo.toml
+++ b/wayland-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-backend"
-version = "0.3.10"
+version = "0.3.11"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
 edition = "2021"
 rust-version = "1.65"
@@ -14,7 +14,7 @@ readme = "README.md"
 build = "build.rs"
 
 [dependencies]
-wayland-sys = { version = "0.31.6", path = "../wayland-sys", features = [] }
+wayland-sys = { version = "0.31.7", path = "../wayland-sys", features = [] }
 log = { version = "0.4", optional = true }
 scoped-tls = { version = "1.0", optional = true }
 downcast-rs = "1.2"

--- a/wayland-client/CHANGELOG.md
+++ b/wayland-client/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.31.11 -- 2025-07-28
+
 - Updated Wayland core protocol to 1.24
 
 ## 0.31.7 -- 2024-10-23

--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-client"
-version = "0.31.10"
+version = "0.31.11"
 documentation = "https://docs.rs/wayland-client/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -13,8 +13,8 @@ description = "Bindings to the standard C implementation of the wayland protocol
 readme = "README.md"
 
 [dependencies]
-wayland-backend = { version = "0.3.10", path = "../wayland-backend" }
-wayland-scanner = { version = "0.31.6", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.11", path = "../wayland-backend" }
+wayland-scanner = { version = "0.31.7", path = "../wayland-scanner" }
 bitflags = "2"
 rustix = { version = "1.0.2", features = ["event"] }
 log = { version = "0.4", optional = true }

--- a/wayland-cursor/Cargo.toml
+++ b/wayland-cursor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-cursor"
-version = "0.31.10"
+version = "0.31.11"
 documentation = "https://docs.rs/wayland-cursor/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -13,7 +13,7 @@ description = "Bindings to libwayland-cursor."
 readme = "README.md"
 
 [dependencies]
-wayland-client = { version = "0.31.10", path = "../wayland-client" }
+wayland-client = { version = "0.31.11", path = "../wayland-client" }
 xcursor = "0.3.1"
 rustix = { version = "1.0.2", features = ["shm"] }
 

--- a/wayland-egl/Cargo.toml
+++ b/wayland-egl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-egl"
-version = "0.32.7"
+version = "0.32.8"
 documentation = "https://docs.rs/wayland-egl/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -13,8 +13,8 @@ description = "Bindings to libwayland-egl."
 readme = "README.md"
 
 [dependencies]
-wayland-backend = { version = "0.3.10", path = "../wayland-backend", features = ["client_system"] }
-wayland-sys = { version = "0.31.6", path="../wayland-sys", features = ["egl"] }
+wayland-backend = { version = "0.3.11", path = "../wayland-backend", features = ["client_system"] }
+wayland-sys = { version = "0.31.7", path="../wayland-sys", features = ["egl"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wayland-protocols-experimental/CHANGELOG.md
+++ b/wayland-protocols-experimental/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 20250721.0.1 -- 2025-07-28
+
 ### Additions
 
 - Introduce protocol `session_management-v1`,

--- a/wayland-protocols-experimental/Cargo.toml
+++ b/wayland-protocols-experimental/Cargo.toml
@@ -17,11 +17,11 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wayland-scanner = { version = "0.31.6", path = "../wayland-scanner" }
-wayland-backend = { version = "0.3.10", path = "../wayland-backend" }
-wayland-client = { version = "0.31.10", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.9", path = "../wayland-server", optional = true }
-wayland-protocols = { version = "0.32.8", path = "../wayland-protocols", features=["unstable"] }
+wayland-scanner = { version = "0.31.7", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.11", path = "../wayland-backend" }
+wayland-client = { version = "0.31.11", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.10", path = "../wayland-server", optional = true }
+wayland-protocols = { version = "0.32.9", path = "../wayland-protocols", features=["unstable"] }
 bitflags = "2"
 
 [features]

--- a/wayland-protocols-misc/Cargo.toml
+++ b/wayland-protocols-misc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-protocols-misc"
-version = "0.3.8"
+version = "0.3.9"
 documentation = "https://docs.rs/wayland-protocols-misc/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -15,11 +15,11 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wayland-scanner = { version = "0.31.6", path = "../wayland-scanner" }
-wayland-backend = { version = "0.3.10", path = "../wayland-backend" }
-wayland-client = { version = "0.31.10", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.9", path = "../wayland-server", optional = true }
-wayland-protocols = { version = "0.32.8", path = "../wayland-protocols", features=["unstable"] }
+wayland-scanner = { version = "0.31.7", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.11", path = "../wayland-backend" }
+wayland-client = { version = "0.31.11", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.10", path = "../wayland-server", optional = true }
+wayland-protocols = { version = "0.32.9", path = "../wayland-protocols", features=["unstable"] }
 bitflags = "2"
 
 [features]

--- a/wayland-protocols-plasma/Cargo.toml
+++ b/wayland-protocols-plasma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-protocols-plasma"
-version = "0.3.8"
+version = "0.3.9"
 documentation = "https://docs.rs/wayland-protocols-plasma/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -15,11 +15,11 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wayland-scanner = { version = "0.31.6", path = "../wayland-scanner" }
-wayland-backend = { version = "0.3.10", path = "../wayland-backend" }
-wayland-client = { version = "0.31.10", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.9", path = "../wayland-server", optional = true }
-wayland-protocols = { version = "0.32.8", path = "../wayland-protocols"}
+wayland-scanner = { version = "0.31.7", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.11", path = "../wayland-backend" }
+wayland-client = { version = "0.31.11", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.10", path = "../wayland-server", optional = true }
+wayland-protocols = { version = "0.32.9", path = "../wayland-protocols"}
 bitflags = "2"
 
 [features]

--- a/wayland-protocols-wlr/Cargo.toml
+++ b/wayland-protocols-wlr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-protocols-wlr"
-version = "0.3.8"
+version = "0.3.9"
 documentation = "https://docs.rs/wayland-protocols-wlr/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -15,11 +15,11 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wayland-scanner = { version = "0.31.6", path = "../wayland-scanner" }
-wayland-backend = { version = "0.3.10", path = "../wayland-backend" }
-wayland-client = { version = "0.31.10", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.9", path = "../wayland-server", optional = true }
-wayland-protocols = { version = "0.32.8", path = "../wayland-protocols"}
+wayland-scanner = { version = "0.31.7", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.11", path = "../wayland-backend" }
+wayland-client = { version = "0.31.11", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.10", path = "../wayland-server", optional = true }
+wayland-protocols = { version = "0.32.9", path = "../wayland-protocols"}
 bitflags = "2"
 
 [features]

--- a/wayland-protocols/CHANGELOG.md
+++ b/wayland-protocols/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 0.32.9 -- 2025-07-28
+
+- Bump wayland-protocols to 1.45
+  - New staging protocols:
+    * `ext-background-effect-v1`
+    * `pointer-warp-v1`
+
 ## 0.32.7 -- 2025-04-28
 
 - Bump wayland-protocols to 1.41
@@ -16,10 +23,6 @@
 - Bump wayland-protocols to 1.44
   - New staging protocol:
     * `color-representation-v1`
-- Bump wayland-protocols to 1.45
-  - New staging protocols:
-    * `ext-background-effect-v1`
-    * `pointer-warp-v1`
 
 ## 0.32.6 -- 2025-01-31
 

--- a/wayland-protocols/Cargo.toml
+++ b/wayland-protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-protocols"
-version = "0.32.8"
+version = "0.32.9"
 documentation = "https://docs.rs/wayland-protocols/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -27,10 +27,10 @@ include = [
 ]
 
 [dependencies]
-wayland-scanner = { version = "0.31.6", path = "../wayland-scanner" }
-wayland-backend = { version = "0.3.10", path = "../wayland-backend" }
-wayland-client = { version = "0.31.10", path = "../wayland-client", optional = true }
-wayland-server = { version = "0.31.9", path = "../wayland-server", optional = true }
+wayland-scanner = { version = "0.31.7", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.11", path = "../wayland-backend" }
+wayland-client = { version = "0.31.11", path = "../wayland-client", optional = true }
+wayland-server = { version = "0.31.10", path = "../wayland-server", optional = true }
 bitflags = "2"
 
 [features]

--- a/wayland-scanner/Cargo.toml
+++ b/wayland-scanner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-scanner"
-version = "0.31.6"
+version = "0.31.7"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
 repository = "https://github.com/smithay/wayland-rs"
 documentation = "https://docs.rs/wayland-scanner/"

--- a/wayland-server/CHANGELOG.md
+++ b/wayland-server/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.31.10 - 2025-07-28
+
 - Updated Wayland core protocol to 1.24
 
 ## 0.31.6 -- 2024-10-23

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-server"
-version = "0.31.9"
+version = "0.31.10"
 documentation = "https://docs.rs/wayland-server/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
@@ -13,8 +13,8 @@ rust-version = "1.65"
 readme = "README.md"
 
 [dependencies]
-wayland-backend = { version = "0.3.10", path = "../wayland-backend" }
-wayland-scanner = { version = "0.31.6", path = "../wayland-scanner" }
+wayland-backend = { version = "0.3.11", path = "../wayland-backend" }
+wayland-scanner = { version = "0.31.7", path = "../wayland-scanner" }
 bitflags = "2"
 log = { version = "0.4", optional = true }
 downcast-rs = "1.2"

--- a/wayland-sys/Cargo.toml
+++ b/wayland-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-sys"
-version = "0.31.6"
+version = "0.31.7"
 repository = "https://github.com/smithay/wayland-rs"
 documentation = "https://docs.rs/wayland-sys/"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]

--- a/wayland-tests/Cargo.toml
+++ b/wayland-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-tests"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 rust-version = "1.65"
 publish = false


### PR DESCRIPTION
`cargo release --no-publish --no-tag --no-push --execute patch --prev-tag-name release-2025-04-29`, but don't bump `wayland-protocols-experimental` version.

Updated changelogs.