### PR TITLE
ci: Downgrade `proc-macro2` in MSRV test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,12 @@ jobs:
           command: update
           args: -p log --precise 0.4.28
 
+      - name: Downgrade proc-macro2
+        uses: actions-rs/cargo@v1
+        with:
+          command: update
+          args: -p proc-macro2 --precise 1.0.103
+
       - name: Check
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
We can just bump the MSRV several versions as soon as wayland-rs itself has a use for a feature in a newer version. But for now, we can just keep fixing the MSRV test.