### PR TITLE
Use `doc_cfg` feature instead of `doc_auto_cfg` on `docsrs`

### DIFF
--- a/wayland-backend/src/lib.rs
+++ b/wayland-backend/src/lib.rs
@@ -49,7 +49,7 @@
 #![allow(clippy::duplicate_mod)]
 #![cfg_attr(unstable_coverage, feature(coverage_attribute))]
 // Doc feature labels can be tested locally by running RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc -p <crate>
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 /// Reexport of the `smallvec` crate, which is part of `wayland-backend`'s public API.
 pub extern crate smallvec;

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -165,7 +165,7 @@
 #![forbid(improper_ctypes, unsafe_op_in_unsafe_fn)]
 #![cfg_attr(unstable_coverage, feature(coverage_attribute))]
 // Doc feature labels can be tested locally by running RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc -p <crate>
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use std::{
     fmt,

--- a/wayland-protocols-experimental/src/lib.rs
+++ b/wayland-protocols-experimental/src/lib.rs
@@ -11,7 +11,7 @@
 
 #![warn(missing_docs)]
 #![forbid(improper_ctypes, unsafe_op_in_unsafe_fn)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 #[macro_use]

--- a/wayland-protocols-misc/src/lib.rs
+++ b/wayland-protocols-misc/src/lib.rs
@@ -11,7 +11,7 @@
 
 #![warn(missing_docs)]
 #![forbid(improper_ctypes, unsafe_op_in_unsafe_fn)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 #[macro_use]

--- a/wayland-protocols-plasma/src/lib.rs
+++ b/wayland-protocols-plasma/src/lib.rs
@@ -8,7 +8,7 @@
 //! controlled by the two cargo features `client` and `server`.
 
 #![forbid(improper_ctypes, unsafe_op_in_unsafe_fn)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 #[macro_use]

--- a/wayland-protocols-wlr/src/lib.rs
+++ b/wayland-protocols-wlr/src/lib.rs
@@ -9,7 +9,7 @@
 
 #![warn(missing_docs)]
 #![forbid(improper_ctypes, unsafe_op_in_unsafe_fn)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 #[macro_use]

--- a/wayland-protocols/src/lib.rs
+++ b/wayland-protocols/src/lib.rs
@@ -45,7 +45,7 @@
 
 #![warn(missing_docs)]
 #![forbid(improper_ctypes, unsafe_op_in_unsafe_fn)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[macro_use]
 mod protocol_macro;

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -73,7 +73,7 @@
 //! using [`ObjectId::from_ptr()`], and then make the resources using [`Resource::from_id()`].
 #![forbid(improper_ctypes, unsafe_op_in_unsafe_fn)]
 // Doc feature labels can be tested locally by running RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc -p <crate>
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use std::{
     fmt,

--- a/wayland-sys/src/lib.rs
+++ b/wayland-sys/src/lib.rs
@@ -29,7 +29,7 @@
 #![allow(non_camel_case_types)]
 #![forbid(improper_ctypes, unsafe_op_in_unsafe_fn)]
 // Doc feature labels can be tested locally by running RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc -p <crate>
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 // If compiling with neither the `client` or `server` feature (non-sensical but
 // it's what happens when running `cargo test --all` from the workspace root),


### PR DESCRIPTION
Fixes build with recent nightly, as now used by docs.rs.