### PR TITLE
Exclude tests for `backend` and `scanner`

### DIFF
--- a/wayland-backend/Cargo.toml
+++ b/wayland-backend/Cargo.toml
@@ -12,6 +12,13 @@ keywords = ["wayland"]
 description = "Low-level bindings to the Wayland protocol"
 readme = "README.md"
 build = "build.rs"
+include = [
+    "README.md",
+    "LICENSE.txt",
+    "CHANGELOG.md",
+    "/src/**/*.rs",
+    "build.rs"
+]
 
 [dependencies]
 wayland-sys = { version = "0.31.8", path = "../wayland-sys", features = [] }

--- a/wayland-scanner/Cargo.toml
+++ b/wayland-scanner/Cargo.toml
@@ -11,6 +11,12 @@ keywords = ["wayland", "codegen"]
 edition = "2021"
 rust-version = "1.65"
 readme = "README.md"
+include = [
+    "README.md",
+    "LICENSE.txt",
+    "CHANGELOG.md",
+    "/src/**/*.rs"
+]
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Hi everyone,
during a dependency review we noticed that the `wayland-backend` and `wayland-scanner` crates include tests in the package published to crates.io. Reducing the amount of code (including the number of test files) makes reviewing crates and the whole supply chain much easier and since you already make use. of `include` in one of your `Cargo.toml` files I thought I'd go ahead and open this PR to apply this to `backend` and `scanner` as well.

Please let me know if anything needs changing or if there are further questions.