### PR TITLE
scanner: Ignore comments before protocol tag

### DIFF
--- a/wayland-scanner/src/parse.rs
+++ b/wayland-scanner/src/parse.rs
@@ -39,7 +39,7 @@ fn init_protocol<R: BufRead>(reader: &mut Reader<R>) -> Protocol {
     // Check two firsts lines for protocol tag
     for _ in 0..3 {
         match reader.read_event_into(&mut Vec::new()) {
-            Ok(Event::Decl(_) | Event::DocType(_)) => {
+            Ok(Event::Decl(_) | Event::DocType(_) | Event::Comment(_)) => {
                 continue;
             }
             Ok(Event::Start(bytes)) => {


### PR DESCRIPTION
[If there is an XML comment before the protocol tag](https://github.com/linuxdeepin/treeland-protocols/blob/8c66c7ba29f80eaef2084805475f0552077b6129/xml/treeland-ddm-v1.xml#L3), the C language version of wayland-scanner can handle it normally, but the Rust version will report an error:
```
error: proc macro panicked
  --> treeland-protocols-rs/src/protocol_macro.rs:24:21
   |
24 |                       wayland_scanner::generate_interfaces!($path);
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
  ::: treeland-protocols-rs/src/lib.rs:26:9
   |
26 | /         wayland_protocol!(
27 | |             "./treeland-protocols/xml/treeland-ddm-v1.xml",
28 | |             []
29 | |         );
   | |_________- in this macro invocation
   |
   = help: message: Ill-formed protocol file
   = note: this error originates in the macro `wayland_protocol` (in Nightly builds, run with -Z macro-backtrace for more info)

```
