### PR TITLE
backend/server: Use `&self` instead of `&mut self`

### DIFF
--- a/wayland-backend/src/rs/server_impl/handle.rs
+++ b/wayland-backend/src/rs/server_impl/handle.rs
@@ -295,7 +295,7 @@ impl InnerHandle {
         state.registry.get_handler(id)
     }
 
-    pub fn flush(&mut self, client: Option<ClientId>) -> std::io::Result<()> {
+    pub fn flush(&self, client: Option<ClientId>) -> std::io::Result<()> {
         self.state.lock().unwrap().flush(client)
     }
 

--- a/wayland-backend/src/server_api.rs
+++ b/wayland-backend/src/server_api.rs
@@ -277,7 +277,7 @@ impl Handle {
     /// The `data` parameter contains data that will be associated with the client.
     #[inline]
     pub fn insert_client(
-        &mut self,
+        &self,
         stream: UnixStream,
         data: Arc<dyn ClientData>,
     ) -> std::io::Result<ClientId> {
@@ -518,7 +518,7 @@ impl Handle {
     /// Flushes pending events destined for a client.
     ///
     /// If no client is specified, all pending events are flushed to all clients.
-    pub fn flush(&mut self, client: Option<ClientId>) -> std::io::Result<()> {
+    pub fn flush(&self, client: Option<ClientId>) -> std::io::Result<()> {
         self.handle.flush(client)
     }
 
@@ -557,7 +557,7 @@ impl<D> Backend<D> {
     ///
     /// If no client is specified, all pending events are flushed to all clients.
     #[inline]
-    pub fn flush(&mut self, client: Option<ClientId>) -> std::io::Result<()> {
+    pub fn flush(&self, client: Option<ClientId>) -> std::io::Result<()> {
         self.backend.flush(client)
     }
 
@@ -597,7 +597,7 @@ impl<D> Backend<D> {
     /// [`Backend::dispatch_all_clients()`].
     #[inline]
     pub fn dispatch_single_client(
-        &mut self,
+        &self,
         data: &mut D,
         client_id: ClientId,
     ) -> std::io::Result<usize> {
@@ -614,7 +614,7 @@ impl<D> Backend<D> {
     /// file descriptor retrieved by [`Backend::poll_fd`] and only calling this method when messages are
     /// available.
     #[inline]
-    pub fn dispatch_all_clients(&mut self, data: &mut D) -> std::io::Result<usize> {
+    pub fn dispatch_all_clients(&self, data: &mut D) -> std::io::Result<usize> {
         self.backend.dispatch_all_clients(data)
     }
 }

--- a/wayland-backend/src/sys/server_impl/mod.rs
+++ b/wayland-backend/src/sys/server_impl/mod.rs
@@ -375,7 +375,7 @@ impl<D> InnerBackend<D> {
         })
     }
 
-    pub fn flush(&mut self, client: Option<ClientId>) -> std::io::Result<()> {
+    pub fn flush(&self, client: Option<ClientId>) -> std::io::Result<()> {
         self.state.lock().unwrap().flush(client)
     }
 
@@ -396,14 +396,14 @@ impl<D> InnerBackend<D> {
     }
 
     pub fn dispatch_client(
-        &mut self,
+        &self,
         data: &mut D,
         _client_id: InnerClientId,
     ) -> std::io::Result<usize> {
         self.dispatch_all_clients(data)
     }
 
-    pub fn dispatch_all_clients(&mut self, data: &mut D) -> std::io::Result<usize> {
+    pub fn dispatch_all_clients(&self, data: &mut D) -> std::io::Result<usize> {
         let state = self.state.clone() as Arc<Mutex<dyn ErasedState + Send>>;
         let display = self.display_ptr;
         let ret = HANDLE.set(&(state, data as *mut _ as *mut c_void), || unsafe {
@@ -834,7 +834,7 @@ impl InnerHandle {
         Ok(udata.handler.clone())
     }
 
-    pub fn flush(&mut self, client: Option<ClientId>) -> std::io::Result<()> {
+    pub fn flush(&self, client: Option<ClientId>) -> std::io::Result<()> {
         self.state.lock().unwrap().flush(client)
     }
 

--- a/wayland-backend/src/test/destroy_object.rs
+++ b/wayland-backend/src/test/destroy_object.rs
@@ -71,7 +71,7 @@ impl_client_objectdata!(client_sys);
 // create a global and destroy it
 expand_test!(destroy_global, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::new().unwrap();
+    let server = server_backend::Backend::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
@@ -119,7 +119,7 @@ expand_test!(destroy_global, {
 
 expand_test!(destroy_twice, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::new().unwrap();
+    let server = server_backend::Backend::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
@@ -168,7 +168,7 @@ expand_test!(destroy_twice, {
 
 expand_test!(destroy_flush_destroy, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::new().unwrap();
+    let server = server_backend::Backend::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
@@ -224,7 +224,7 @@ expand_test!(destroy_flush_destroy, {
 
 expand_test!(destroy_then_message, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::new().unwrap();
+    let server = server_backend::Backend::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 

--- a/wayland-backend/src/test/destructors.rs
+++ b/wayland-backend/src/test/destructors.rs
@@ -76,7 +76,7 @@ impl_client_objectdata!(client_sys);
 
 expand_test!(destructor_request, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::new().unwrap();
+    let server = server_backend::Backend::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
@@ -137,7 +137,7 @@ expand_test!(destructor_request, {
 
 expand_test!(destructor_cleanup, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::new().unwrap();
+    let server = server_backend::Backend::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
@@ -212,7 +212,7 @@ impl_server_clientdata!(server_sys);
 
 expand_test!(destructor_client_cleanup, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::new().unwrap();
+    let server = server_backend::Backend::new().unwrap();
     let client_data = Arc::new(ServerClientData(AtomicBool::new(false)));
     let _client_id = server.handle().insert_client(rx, client_data.clone()).unwrap();
 

--- a/wayland-backend/src/test/many_args.rs
+++ b/wayland-backend/src/test/many_args.rs
@@ -137,7 +137,7 @@ clientdata_impls!(client_sys);
 // create a global and send the many_args method
 expand_test!(many_args, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::new().unwrap();
+    let server = server_backend::Backend::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 

--- a/wayland-backend/src/test/object_args.rs
+++ b/wayland-backend/src/test/object_args.rs
@@ -140,7 +140,7 @@ impl_client_objectdata!(client_sys);
 // create a global and create objects
 expand_test!(create_objects, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::new().unwrap();
+    let server = server_backend::Backend::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
@@ -426,7 +426,7 @@ expand_test!(null_obj_followed_by_interface, {
 
 expand_test!(new_id_null_and_non_null, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::<()>::new().unwrap();
+    let server = server_backend::Backend::<()>::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 

--- a/wayland-backend/src/test/protocol_error.rs
+++ b/wayland-backend/src/test/protocol_error.rs
@@ -42,7 +42,7 @@ impl server_sys::GlobalHandler<()> for ServerData<server_sys::ObjectId> {
 
 expand_test!(protocol_error, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::new().unwrap();
+    let server = server_backend::Backend::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
@@ -114,7 +114,7 @@ expand_test!(protocol_error, {
 
 expand_test!(client_wrong_id, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::<()>::new().unwrap();
+    let server = server_backend::Backend::<()>::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
 
     let mut socket = BufferedSocket::new(Socket::from(tx), Some(DEFAULT_MAX_BUFFER_SIZE));
@@ -140,7 +140,7 @@ expand_test!(client_wrong_id, {
 
 expand_test!(client_wrong_opcode, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::<()>::new().unwrap();
+    let server = server_backend::Backend::<()>::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
 
     let mut socket = BufferedSocket::new(Socket::from(tx), Some(DEFAULT_MAX_BUFFER_SIZE));
@@ -164,7 +164,7 @@ expand_test!(client_wrong_opcode, {
 
 expand_test!(client_wrong_sender, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::<()>::new().unwrap();
+    let server = server_backend::Backend::<()>::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
 
     let mut socket = BufferedSocket::new(Socket::from(tx), Some(DEFAULT_MAX_BUFFER_SIZE));
@@ -260,7 +260,7 @@ impl<D> server_sys::ObjectData<D> for ProtocolErrorServerData {
 
 expand_test!(protocol_error_in_request_without_object_init, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::new().unwrap();
+    let server = server_backend::Backend::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
@@ -323,7 +323,7 @@ expand_test!(protocol_error_in_request_without_object_init, {
 
 expand_test!(protocol_version_check, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::new().unwrap();
+    let server = server_backend::Backend::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
 
     let object_id = Arc::new(Mutex::new(None));

--- a/wayland-backend/src/test/server_created_objects.rs
+++ b/wayland-backend/src/test/server_created_objects.rs
@@ -110,7 +110,7 @@ impl_client_objectdata!(client_sys);
 
 expand_test!(server_created_object, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::new().unwrap();
+    let server = server_backend::Backend::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 

--- a/wayland-backend/src/test/sync.rs
+++ b/wayland-backend/src/test/sync.rs
@@ -36,7 +36,7 @@ impl client_sys::ObjectData for SyncData {
 // send a wl_display.sync request and receive the response
 expand_test!(sync, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::new().unwrap();
+    let server = server_backend::Backend::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
@@ -69,7 +69,7 @@ expand_test!(sync, {
 
 expand_test!(panic test_bad_placeholder, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::new().unwrap();
+    let server = server_backend::Backend::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 
@@ -102,7 +102,7 @@ expand_test!(panic test_bad_placeholder, {
 
 expand_test!(panic test_bad_signature, {
     let (tx, rx) = std::os::unix::net::UnixStream::pair().unwrap();
-    let mut server = server_backend::Backend::new().unwrap();
+    let server = server_backend::Backend::new().unwrap();
     let _client_id = server.handle().insert_client(rx, Arc::new(())).unwrap();
     let client = client_backend::Backend::connect(tx).unwrap();
 


### PR DESCRIPTION
These methods use locking internally, on cloneable types, so `&mut` is unnecessarily, and may be confusing because of that. It is also inconsistent with other methods and `client_api.rs`.

This is probably a breaking change? At least in the strictest sense...