### PR TITLE
client: support complex trait bounds via optional where clauses in macros

### DIFF
--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -795,8 +795,8 @@ impl<I: Proxy, U: std::fmt::Debug, State> std::fmt::Debug for QueueProxyData<I, 
 /// ```
 #[macro_export]
 macro_rules! delegate_dispatch {
-    ($(@< $( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? $dispatch_from:ty : [$interface: ty: $udata: ty] => $dispatch_to: ty) => {
-        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::Dispatch<$interface, $udata> for $dispatch_from {
+    ($(@< $( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? $dispatch_from: ty : [$interface: ty: $udata: ty] => $dispatch_to: ty $( where $($bounds: tt)+ )?) => {
+        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::Dispatch<$interface, $udata> for $dispatch_from $( where $($bounds)+ )? {
             fn event(
                 state: &mut Self,
                 proxy: &$interface,
@@ -845,8 +845,8 @@ macro_rules! delegate_dispatch {
 /// This last example will execute `unreachable!()` if the interface emits any events.
 #[macro_export]
 macro_rules! delegate_noop {
-    ($(@< $( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? $dispatch_from: ty : $interface: ty) => {
-        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::Dispatch<$interface, ()> for $dispatch_from {
+    ($(@< $( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? $dispatch_from: ty : $interface: ty $( where $($bounds: tt)+ )?) => {
+        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::Dispatch<$interface, ()> for $dispatch_from $( where $($bounds)+ )? {
             fn event(
                 _: &mut Self,
                 _: &$interface,
@@ -860,8 +860,8 @@ macro_rules! delegate_noop {
         }
     };
 
-    ($(@< $( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? $dispatch_from: ty : ignore $interface: ty) => {
-        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::Dispatch<$interface, ()> for $dispatch_from {
+    ($(@< $( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? $dispatch_from: ty : ignore $interface: ty $( where $($bounds: tt)+ )?) => {
+        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $crate::Dispatch<$interface, ()> for $dispatch_from $( where $($bounds)+ )? {
             fn event(
                 _: &mut Self,
                 _: &$interface,


### PR DESCRIPTION
We can't simply use `@<T: SomeTrait, U: CustomTrait<T>>` because "<>" are not [“grouping” tokens](https://lukaswirth.dev/tlborm/syntax-extensions/source-analysis.html#token-trees)

There is another solution using "[]" that I have tested and is working but it's a breaking change (or duplicated code)

This solution with where allow us to use `@<T, U> ... where T: SomeTrait, U: CustomTrait<T>` and for those who have already done something like `@<T: 'static + MyTrait> ...`, nothing is broken since the `where` clause is optional

I wanted to use it for `delegate_dispatch` but since `delegate_noop` does almost the same, I added it there to to keep consistency

I did not add it to `event_created_child` as the `lt`, `clt` and `dlt` are not used inside (should be deleted ?) so bounds even if added would not be used either.