### PR TITLE
backend: Wrap `wl_interface` to make `wayland-sys` a private dep

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Breaking changes
 - Use `Message<_, BorrowedFd>` instead of `RawFd`
-- Wrap `wl_interface` so `wayland-sys` can be a private dependency
+- Wrap `wl_interface` so `wayland-sys` can be a private, optional dependency
   * (This API is generally used internally by `wayland-scanner`)
 
 ## 0.3.15 -- 2026-03-30

--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+#### Breaking changes
+- Use `Message<_, BorrowedFd>` instead of `RawFd`
+
 ## 0.3.15 -- 2026-03-30
 
 #### Bugfixes

--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Use `Message<_, BorrowedFd>` instead of `RawFd`
 - Wrap `wl_interface` so `wayland-sys` can be a private, optional dependency
   * (This API is generally used internally by `wayland-scanner`)
+- Return `NonNull` from `as_ptr()`
 
 ## 0.3.15 -- 2026-03-30
 

--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### Breaking changes
 - Use `Message<_, BorrowedFd>` instead of `RawFd`
+- Wrap `wl_interface` so `wayland-sys` can be a private dependency
+  * (This API is generally used internally by `wayland-scanner`)
 
 ## 0.3.15 -- 2026-03-30
 

--- a/wayland-backend/Cargo.toml
+++ b/wayland-backend/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 build = "build.rs"
 
 [dependencies]
-wayland-sys = { version = "0.31.11", path = "../wayland-sys", features = [] }
+wayland-sys = { version = "0.31.11", path = "../wayland-sys", features = [], optional = true }
 log = { version = "0.4", optional = true }
 scoped-tls = { version = "1.0", optional = true }
 downcast-rs = "1.2"
@@ -50,12 +50,12 @@ env_logger = "0.11"
 scoped-tls = "1.0"
 
 [features]
-client_system = ["wayland-sys/client", "dep:scoped-tls"]
-server_system = ["wayland-sys/server", "dep:scoped-tls"]
-dlopen = ["wayland-sys/dlopen"]
-libwayland_client_1_23 = ["wayland-sys/libwayland_client_1_23"]
-libwayland_server_1_22 = ["wayland-sys/libwayland_server_1_22"]
-libwayland_server_1_23 = ["wayland-sys/libwayland_server_1_23", "libwayland_server_1_22"]
+client_system = ["dep:wayland-sys", "wayland-sys/client", "dep:scoped-tls"]
+server_system = ["dep:wayland-sys", "wayland-sys/server", "dep:scoped-tls"]
+dlopen = ["wayland-sys?/dlopen"]
+libwayland_client_1_23 = ["wayland-sys?/libwayland_client_1_23"]
+libwayland_server_1_22 = ["wayland-sys?/libwayland_server_1_22"]
+libwayland_server_1_23 = ["wayland-sys?/libwayland_server_1_23", "libwayland_server_1_22"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wayland-backend/src/core_interfaces.rs
+++ b/wayland-backend/src/core_interfaces.rs
@@ -50,7 +50,7 @@ pub static WL_DISPLAY_INTERFACE: Interface = Interface {
             arg_interfaces: &[],
         },
     ],
-    c_ptr: None,
+    c_interface: None,
 };
 
 /// Interface `wl_registry`
@@ -88,7 +88,7 @@ pub static WL_REGISTRY_INTERFACE: Interface = Interface {
             arg_interfaces: &[],
         },
     ],
-    c_ptr: None,
+    c_interface: None,
 };
 
 /// Interface `wl_callback`
@@ -104,5 +104,5 @@ pub static WL_CALLBACK_INTERFACE: Interface = Interface {
         child_interface: None,
         arg_interfaces: &[],
     }],
-    c_ptr: None,
+    c_interface: None,
 };

--- a/wayland-backend/src/protocol.rs
+++ b/wayland-backend/src/protocol.rs
@@ -5,7 +5,16 @@ use std::{
     os::unix::io::AsRawFd,
 };
 
+#[cfg(any(feature = "client_system", feature = "server_system"))]
 use wayland_sys::common::{wl_interface, wl_message};
+
+// Zero-size placeholder with same auto traits, for consistency
+#[cfg(not(any(feature = "client_system", feature = "server_system")))]
+#[allow(non_camel_case_types)]
+type wl_interface = std::marker::PhantomData<*const ()>;
+#[allow(non_camel_case_types)]
+#[cfg(not(any(feature = "client_system", feature = "server_system")))]
+type wl_message = std::marker::PhantomData<*const ()>;
 
 /// Describes whether an argument may have a null value.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -166,6 +175,7 @@ unsafe impl Sync for CWlInterface {}
 
 impl CWlInterface {
     /// Construct a `wl_interface` to store in a static
+    #[cfg(any(feature = "client_system", feature = "server_system"))]
     pub const fn new(
         name: &'static CStr,
         version: u32,
@@ -181,6 +191,18 @@ impl CWlInterface {
             events: events.as_ptr() as _,
         })
     }
+
+    /// Construct a `wl_interface` to store in a static
+    #[cfg(not(any(feature = "client_system", feature = "server_system")))]
+    pub const fn new(
+        name: &'static CStr,
+        version: u32,
+        requests: &'static [CWlMessage],
+        events: &'static [CWlMessage],
+    ) -> Self {
+        let _ = (name, version, requests, events);
+        Self(std::marker::PhantomData)
+    }
 }
 
 /// Wrapper around `wl_message` used in libwayland to define messages in interfaces
@@ -192,6 +214,7 @@ unsafe impl Sync for CWlMessage {}
 
 impl CWlMessage {
     /// Construct a `wl_message` to store in a static
+    #[cfg(any(feature = "client_system", feature = "server_system"))]
     pub const fn new(
         name: &'static CStr,
         signature: &'static CStr,
@@ -203,6 +226,17 @@ impl CWlMessage {
             signature: signature.as_ptr(),
             types: types.as_ptr() as *const *const wl_interface,
         })
+    }
+
+    /// Construct a `wl_message` to store in a static
+    #[cfg(not(any(feature = "client_system", feature = "server_system")))]
+    pub const fn new(
+        name: &'static CStr,
+        signature: &'static CStr,
+        types: &'static [Option<&'static CWlInterface>],
+    ) -> Self {
+        let _ = (name, signature, types);
+        Self(std::marker::PhantomData)
     }
 }
 

--- a/wayland-backend/src/protocol.rs
+++ b/wayland-backend/src/protocol.rs
@@ -1,8 +1,11 @@
 //! Types and utilities for manipulating the Wayland protocol
 
-use std::{ffi::CString, os::unix::io::AsRawFd};
+use std::{
+    ffi::{CStr, CString},
+    os::unix::io::AsRawFd,
+};
 
-pub use wayland_sys::common::{wl_argument, wl_interface, wl_message};
+use wayland_sys::common::{wl_interface, wl_message};
 
 /// Describes whether an argument may have a null value.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -151,7 +154,56 @@ pub struct Interface {
     /// A list that describes every event this interface supports.
     pub events: &'static [MessageDesc],
     /// A C representation of this interface that may be used to interoperate with libwayland.
-    pub c_ptr: Option<&'static wayland_sys::common::wl_interface>,
+    pub c_interface: Option<&'static CWlInterface>,
+}
+
+/// Wrapper around `wl_interface` used in libwayland to define interfaces
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct CWlInterface(pub(crate) wl_interface);
+
+unsafe impl Sync for CWlInterface {}
+
+impl CWlInterface {
+    /// Construct a `wl_interface` to store in a static
+    pub const fn new(
+        name: &'static CStr,
+        version: u32,
+        requests: &'static [CWlMessage],
+        events: &'static [CWlMessage],
+    ) -> Self {
+        Self(wl_interface {
+            name: name.as_ptr(),
+            version: version as _,
+            request_count: requests.len() as _,
+            requests: requests.as_ptr() as _,
+            event_count: events.len() as _,
+            events: events.as_ptr() as _,
+        })
+    }
+}
+
+/// Wrapper around `wl_message` used in libwayland to define messages in interfaces
+#[allow(missing_debug_implementations)]
+#[repr(transparent)]
+pub struct CWlMessage(wl_message);
+
+unsafe impl Sync for CWlMessage {}
+
+impl CWlMessage {
+    /// Construct a `wl_message` to store in a static
+    pub const fn new(
+        name: &'static CStr,
+        signature: &'static CStr,
+        // `Option<&wl_interface>` has the same repr as `*const wl_interface`
+        types: &'static [Option<&'static CWlInterface>],
+    ) -> Self {
+        Self(wl_message {
+            name: name.as_ptr(),
+            signature: signature.as_ptr(),
+            types: types.as_ptr() as *const *const wl_interface,
+        })
+    }
 }
 
 impl std::fmt::Display for Interface {
@@ -182,7 +234,7 @@ pub struct MessageDesc {
 
 /// Special interface representing an anonymous object
 pub static ANONYMOUS_INTERFACE: Interface =
-    Interface { name: "<anonymous>", version: 0, requests: &[], events: &[], c_ptr: None };
+    Interface { name: "<anonymous>", version: 0, requests: &[], events: &[], c_interface: None };
 
 /// Description of the protocol-level information of an object
 #[derive(Copy, Clone, Debug)]

--- a/wayland-backend/src/sys/client_impl/mod.rs
+++ b/wayland-backend/src/sys/client_impl/mod.rs
@@ -108,8 +108,9 @@ impl InnerObjectId {
         let provided_iface_name = unsafe {
             CStr::from_ptr(
                 interface
-                    .c_ptr
-                    .expect("[wayland-backend-sys] Cannot use Interface without c_ptr!")
+                    .c_interface
+                    .expect("[wayland-backend-sys] Cannot use Interface without c_interface!")
+                    .0
                     .name,
             )
         };
@@ -633,8 +634,9 @@ impl InnerBackend {
         let child_interface_ptr = child_spec
             .as_ref()
             .map(|(i, _)| {
-                i.c_ptr.expect("[wayland-backend-sys] Cannot use Interface without c_ptr!")
-                    as *const _
+                &i.c_interface
+                    .expect("[wayland-backend-sys] Cannot use Interface without c_interface!")
+                    .0 as *const _
             })
             .unwrap_or(std::ptr::null());
         let child_version = child_spec.as_ref().map(|(_, v)| *v).unwrap_or(parent_version);

--- a/wayland-backend/src/sys/mod.rs
+++ b/wayland-backend/src/sys/mod.rs
@@ -63,10 +63,14 @@ impl client::ObjectId {
 
     /// Get the underlying libwayland pointer for this object
     ///
-    /// Returns `NULL` if the proxy has already been destroyed.
-    // TODO(breaking): Return `Result`
-    pub fn as_ptr(&self) -> *mut wayland_sys::client::wl_proxy {
-        self.id.as_ptr().map_or(std::ptr::null_mut(), |p| p.as_ptr())
+    /// # Errors
+    ///
+    /// This function returns an [`InvalidId`][client::InvalidId] error if proxy has already
+    /// been destroyed.
+    pub fn as_ptr(
+        &self,
+    ) -> Result<std::ptr::NonNull<wayland_sys::client::wl_proxy>, client::InvalidId> {
+        self.id.as_ptr()
     }
 
     /// Get the underlying display pointer for this object.
@@ -211,10 +215,14 @@ impl server::ObjectId {
     ///
     /// The pointer may be used to interoperate with libwayland.
     ///
-    /// Returns `NULL` if the resource has already been destroyed.
-    // TODO(breaking): Return `Result`
-    pub fn as_ptr(&self) -> *mut wayland_sys::server::wl_resource {
-        self.id.as_ptr().map_or(std::ptr::null_mut(), |p| p.as_ptr())
+    /// # Errors
+    ///
+    /// This function returns an [`InvalidId`][server::InvalidId] error if resource has already
+    /// been destroyed.
+    pub fn as_ptr(
+        &self,
+    ) -> Result<std::ptr::NonNull<wayland_sys::server::wl_resource>, server::InvalidId> {
+        self.id.as_ptr()
     }
 }
 

--- a/wayland-backend/src/sys/server_impl/mod.rs
+++ b/wayland-backend/src/sys/server_impl/mod.rs
@@ -156,8 +156,10 @@ impl InnerObjectId {
             }
             Ok(InnerObjectId { id, ptr, alive, interface: udata_iface })
         } else if let Some(interface) = interface {
-            let iface_c_ptr =
-                interface.c_ptr.expect("[wayland-backend-sys] Cannot use Interface without c_ptr!");
+            let iface_c_ptr = &interface
+                .c_interface
+                .expect("[wayland-backend-sys] Cannot use Interface without c_interface!")
+                .0;
             // Safety: the provided pointer must be a valid wayland object
             let ptr_iface_name = unsafe {
                 CStr::from_ptr(ffi_dispatch!(wayland_server_handle(), wl_resource_get_class, ptr))
@@ -545,8 +547,10 @@ impl InnerHandle {
             return Err(InvalidId);
         }
 
-        let interface_ptr =
-            interface.c_ptr.expect("Interface without c_ptr are unsupported by the sys backend.");
+        let interface_ptr = &interface
+            .c_interface
+            .expect("Interface without c_interface are unsupported by the sys backend.")
+            .0;
 
         let resource = unsafe {
             ffi_dispatch!(
@@ -609,8 +613,11 @@ impl InnerHandle {
             return Err(InvalidId);
         }
 
-        let iface_c_ptr =
-            id.interface.c_ptr.expect("[wayland-backend-sys] Cannot use Interface without c_ptr!");
+        let iface_c_ptr = &id
+            .interface
+            .c_interface
+            .expect("[wayland-backend-sys] Cannot use Interface without c_interface!")
+            .0;
         let is_managed = unsafe {
             ffi_dispatch!(
                 wayland_server_handle(),
@@ -654,8 +661,11 @@ impl InnerHandle {
             return Err(InvalidId);
         }
 
-        let iface_c_ptr =
-            id.interface.c_ptr.expect("[wayland-backend-sys] Cannot use Interface without c_ptr!");
+        let iface_c_ptr = &id
+            .interface
+            .c_interface
+            .expect("[wayland-backend-sys] Cannot use Interface without c_interface!")
+            .0;
         let is_managed = unsafe {
             ffi_dispatch!(
                 wayland_server_handle(),
@@ -703,8 +713,10 @@ impl InnerHandle {
 
         let alive = Arc::new(AtomicBool::new(true));
 
-        let interface_ptr =
-            interface.c_ptr.expect("Interface without c_ptr are unsupported by the sys backend.");
+        let interface_ptr = &interface
+            .c_interface
+            .expect("Interface without c_interface are unsupported by the sys backend.")
+            .0;
 
         let udata = Box::into_raw(Box::new(GlobalUserData {
             handler,
@@ -1063,8 +1075,11 @@ impl<D: 'static> ErasedState for State<D> {
             return Err(InvalidId);
         }
 
-        let iface_c_ptr =
-            id.interface.c_ptr.expect("[wayland-backend-sys] Cannot use Interface without c_ptr!");
+        let iface_c_ptr = &id
+            .interface
+            .c_interface
+            .expect("[wayland-backend-sys] Cannot use Interface without c_interface!")
+            .0;
         let is_managed = unsafe {
             ffi_dispatch!(
                 wayland_server_handle(),
@@ -1430,7 +1445,7 @@ unsafe extern "C" fn global_bind<D: 'static>(
     };
 
     // this must be Some(), checked at creation of the global
-    let interface_ptr = global_udata.interface.c_ptr.unwrap();
+    let interface_ptr = &global_udata.interface.c_interface.unwrap().0;
 
     HANDLE.with(|&(ref state_arc, data_ptr)| {
         // Safety: the data_ptr is a valid pointer that live outside code put there
@@ -1614,7 +1629,7 @@ unsafe extern "C" fn resource_dispatcher<D: 'static>(
                         wayland_server_handle(),
                         wl_resource_create,
                         client,
-                        child_interface.c_ptr.unwrap(),
+                        &child_interface.c_interface.unwrap().0,
                         version,
                         new_id
                     );

--- a/wayland-egl/CHANGELOG.md
+++ b/wayland-egl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+#### Breaking changes
+- Use `NonNull` in argument accepting pointer
+
 ## 0.32.0 -- 2023-09-02
 
 #### Breaking changes

--- a/wayland-egl/src/lib.rs
+++ b/wayland-egl/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! See [`WlEglSurface`] documentation for details.
 
-use std::{fmt, os::raw::c_void};
+use std::{fmt, os::raw::c_void, ptr::NonNull};
 
 use wayland_backend::client::ObjectId;
 use wayland_sys::{client::wl_proxy, egl::*, ffi_dispatch};
@@ -48,13 +48,10 @@ impl WlEglSurface {
             return Err(Error::InvalidId);
         }
 
-        let ptr = surface.as_ptr();
-        if ptr.is_null() {
-            // ObjectId::as_ptr() returns NULL if the surface is no longer alive
-            Err(Error::InvalidId)
-        } else {
+        match surface.as_ptr() {
             // SAFETY: We are sure the pointer is valid and the interface is correct.
-            unsafe { Self::new_from_raw(ptr, width, height) }
+            Ok(ptr) => unsafe { Self::new_from_raw(ptr, width, height) },
+            Err(wayland_backend::client::InvalidId) => Err(Error::InvalidId),
         }
     }
 
@@ -64,14 +61,20 @@ impl WlEglSurface {
     ///
     /// The provided pointer must be a valid `wl_surface` pointer from `libwayland-client`.
     pub unsafe fn new_from_raw(
-        surface: *mut wl_proxy,
+        surface: NonNull<wl_proxy>,
         width: i32,
         height: i32,
     ) -> Result<Self, Error> {
         if width <= 0 || height <= 0 {
             return Err(Error::InvalidSize);
         }
-        let ptr = ffi_dispatch!(wayland_egl_handle(), wl_egl_window_create, surface, width, height);
+        let ptr = ffi_dispatch!(
+            wayland_egl_handle(),
+            wl_egl_window_create,
+            surface.as_ptr(),
+            width,
+            height
+        );
         if ptr.is_null() {
             panic!("egl window allocation failed");
         }

--- a/wayland-scanner/src/c_interfaces.rs
+++ b/wayland-scanner/src/c_interfaces.rs
@@ -19,12 +19,9 @@ pub(crate) fn generate_interfaces_prefix(protocol: &Protocol) -> TokenStream {
     let types_null_len = Literal::usize_unsuffixed(longest_nulls);
 
     quote! {
-        use std::ptr::null;
-        struct SyncWrapper<T>(T);
-        unsafe impl<T> Sync for SyncWrapper<T> {}
-        static types_null: SyncWrapper<[*const wayland_backend::protocol::wl_interface; #types_null_len]> = SyncWrapper([
-            null::<wayland_backend::protocol::wl_interface>(); #types_null_len
-        ]);
+        static types_null: [Option<&wayland_backend::protocol::CWlInterface>; #types_null_len] = [
+            None; #types_null_len
+        ];
     }
 }
 
@@ -35,33 +32,30 @@ pub(crate) fn generate_interface(interface: &Interface) -> TokenStream {
     let interface_ident = format_ident!("{}_interface", interface.name);
     let name_value = null_terminated_byte_string_literal(&interface.name);
     let version_value = Literal::i32_unsuffixed(interface.version as i32);
-    let request_count_value = Literal::i32_unsuffixed(interface.requests.len() as i32);
     let requests_value = if interface.requests.is_empty() {
-        quote! { null::<wayland_backend::protocol::wl_message>() }
+        quote! { &[] }
     } else {
         let requests_ident = format_ident!("{}_requests", interface.name);
-        quote! { #requests_ident.0.as_ptr() }
+        quote! { &#requests_ident }
     };
-    let event_count_value = Literal::i32_unsuffixed(interface.events.len() as i32);
     let events_value = if interface.events.is_empty() {
-        quote! { null::<wayland_backend::protocol::wl_message>() }
+        quote! { &[] }
     } else {
         let events_ident = format_ident!("{}_events", interface.name);
-        quote! { #events_ident.0.as_ptr() }
+        quote! { &#events_ident }
     };
 
     quote! {
         #requests
         #events
 
-        pub static #interface_ident: wayland_backend::protocol::wl_interface = wayland_backend::protocol::wl_interface {
-            name: #name_value as *const u8 as *const std::os::raw::c_char,
-            version: #version_value,
-            request_count: #request_count_value,
-            requests: #requests_value,
-            event_count: #event_count_value,
-            events: #events_value,
-        };
+        pub static #interface_ident: wayland_backend::protocol::CWlInterface = wayland_backend::protocol::CWlInterface::new(
+            // TODO c"" literal
+            unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(#name_value) },
+            #version_value,
+            #requests_value,
+            #events_value,
+        );
     }
 }
 
@@ -70,55 +64,45 @@ fn gen_messages(interface: &Interface, messages: &[Message], which: &str) -> Tok
         return TokenStream::new();
     }
 
-    let types_arrays = messages.iter().filter_map(|msg| {
-        if msg.all_null() {
-            None
-        } else {
-            let array_ident = format_ident!("{}_{}_{}_types", interface.name, which, msg.name);
-            let array_len = Literal::usize_unsuffixed(msg.args.len());
-            let array_values = msg.args.iter().map(|arg| match (arg.typ, &arg.interface) {
-                (Type::Object, &Some(ref inter)) | (Type::NewId, &Some(ref inter)) => {
-                    let interface_ident =format_ident!("{}_interface", inter);
-                    quote! { &#interface_ident as *const wayland_backend::protocol::wl_interface }
-                }
-                _ => quote! { null::<wayland_backend::protocol::wl_interface>() },
-            });
-
-            Some(quote! {
-                static #array_ident: SyncWrapper<[*const wayland_backend::protocol::wl_interface; #array_len]> = SyncWrapper([
-                    #(#array_values,)*
-                ]);
-            })
-        }
-    });
-
     let message_array_ident = format_ident!("{}_{}", interface.name, which);
     let message_array_len = Literal::usize_unsuffixed(messages.len());
     let message_array_values = messages.iter().map(|msg| {
         let name_value = null_terminated_byte_string_literal(&msg.name);
         let signature_value = Literal::byte_string(&message_signature(msg));
 
-        let types_ident = if msg.all_null() {
-            format_ident!("types_null")
+        let types_array = if msg.all_null() {
+            let ident = format_ident!("types_null");
+            quote!(#ident)
         } else {
-            format_ident!("{}_{}_{}_types", interface.name, which, msg.name)
+            let array_values = msg.args.iter().map(|arg| match (arg.typ, &arg.interface) {
+                (Type::Object, &Some(ref inter)) | (Type::NewId, &Some(ref inter)) => {
+                    let interface_ident = format_ident!("{}_interface", inter);
+                    quote! { Some(&#interface_ident) }
+                }
+                _ => quote! { None },
+            });
+
+            quote! {
+                [
+                    #(#array_values,)*
+                ]
+            }
         };
 
         quote! {
-            wayland_backend::protocol::wl_message {
-                name: #name_value as *const u8 as *const std::os::raw::c_char,
-                signature: #signature_value as *const u8 as *const std::os::raw::c_char,
-                types: #types_ident.0.as_ptr(),
-            }
+            wayland_backend::protocol::CWlMessage::new(
+                // TODO c"" literal
+                unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(#name_value) },
+                unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(#signature_value) },
+                &#types_array,
+            )
         }
     });
 
     quote! {
-        #(#types_arrays)*
-
-        static #message_array_ident: SyncWrapper<[wayland_backend::protocol::wl_message; #message_array_len]> = SyncWrapper([
+        static #message_array_ident: [wayland_backend::protocol::CWlMessage; #message_array_len] = [
             #(#message_array_values,)*
-        ]);
+        ];
     }
 }
 

--- a/wayland-scanner/src/interfaces.rs
+++ b/wayland-scanner/src/interfaces.rs
@@ -35,7 +35,7 @@ pub(crate) fn generate_interface(interface: &Interface, with_c: bool) -> TokenSt
                 version: #iface_version,
                 requests: #requests,
                 events: #events,
-                c_ptr: Some(unsafe { & #c_name }),
+                c_interface: Some(unsafe { & #c_name }),
             };
 
             #c_iface
@@ -47,7 +47,7 @@ pub(crate) fn generate_interface(interface: &Interface, with_c: bool) -> TokenSt
                 version: #iface_version,
                 requests: #requests,
                 events: #events,
-                c_ptr: None,
+                c_interface: None,
             };
         }
     }

--- a/wayland-scanner/tests/scanner_assets/test-interfaces.rs
+++ b/wayland-scanner/tests/scanner_assets/test-interfaces.rs
@@ -1,8 +1,4 @@
-use std::ptr::null;
-struct SyncWrapper<T>(T);
-unsafe impl<T> Sync for SyncWrapper<T> {}
-static types_null: SyncWrapper<[*const wayland_backend::protocol::wl_interface; 6]> =
-    SyncWrapper([null::<wayland_backend::protocol::wl_interface>(); 6]);
+static types_null: [Option<&wayland_backend::protocol::CWlInterface>; 6] = [None; 6];
 pub static WL_DISPLAY_INTERFACE: wayland_backend::protocol::Interface =
     wayland_backend::protocol::Interface {
         name: "wl_display",
@@ -51,48 +47,39 @@ pub static WL_DISPLAY_INTERFACE: wayland_backend::protocol::Interface =
                 arg_interfaces: &[],
             },
         ],
-        c_ptr: Some(unsafe { &wl_display_interface }),
+        c_interface: Some(unsafe { &wl_display_interface }),
     };
-static wl_display_requests_sync_types: SyncWrapper<
-    [*const wayland_backend::protocol::wl_interface; 1],
-> = SyncWrapper([&wl_callback_interface as *const wayland_backend::protocol::wl_interface]);
-static wl_display_requests_get_registry_types: SyncWrapper<
-    [*const wayland_backend::protocol::wl_interface; 1],
-> = SyncWrapper([&wl_registry_interface as *const wayland_backend::protocol::wl_interface]);
-static wl_display_requests: SyncWrapper<[wayland_backend::protocol::wl_message; 2]> =
-    SyncWrapper([
-        wayland_backend::protocol::wl_message {
-            name: b"sync\0" as *const u8 as *const std::os::raw::c_char,
-            signature: b"n\0" as *const u8 as *const std::os::raw::c_char,
-            types: wl_display_requests_sync_types.0.as_ptr(),
-        },
-        wayland_backend::protocol::wl_message {
-            name: b"get_registry\0" as *const u8 as *const std::os::raw::c_char,
-            signature: b"n\0" as *const u8 as *const std::os::raw::c_char,
-            types: wl_display_requests_get_registry_types.0.as_ptr(),
-        },
-    ]);
-static wl_display_events: SyncWrapper<[wayland_backend::protocol::wl_message; 2]> = SyncWrapper([
-    wayland_backend::protocol::wl_message {
-        name: b"error\0" as *const u8 as *const std::os::raw::c_char,
-        signature: b"ous\0" as *const u8 as *const std::os::raw::c_char,
-        types: types_null.0.as_ptr(),
-    },
-    wayland_backend::protocol::wl_message {
-        name: b"delete_id\0" as *const u8 as *const std::os::raw::c_char,
-        signature: b"u\0" as *const u8 as *const std::os::raw::c_char,
-        types: types_null.0.as_ptr(),
-    },
-]);
-pub static wl_display_interface: wayland_backend::protocol::wl_interface =
-    wayland_backend::protocol::wl_interface {
-        name: b"wl_display\0" as *const u8 as *const std::os::raw::c_char,
-        version: 1,
-        request_count: 2,
-        requests: wl_display_requests.0.as_ptr(),
-        event_count: 2,
-        events: wl_display_events.0.as_ptr(),
-    };
+static wl_display_requests: [wayland_backend::protocol::CWlMessage; 2] = [
+    wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"sync\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"n\0") },
+        &[Some(&wl_callback_interface)],
+    ),
+    wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"get_registry\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"n\0") },
+        &[Some(&wl_registry_interface)],
+    ),
+];
+static wl_display_events: [wayland_backend::protocol::CWlMessage; 2] = [
+    wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"error\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"ous\0") },
+        &types_null,
+    ),
+    wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"delete_id\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"u\0") },
+        &types_null,
+    ),
+];
+pub static wl_display_interface: wayland_backend::protocol::CWlInterface =
+    wayland_backend::protocol::CWlInterface::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"wl_display\0") },
+        1,
+        &wl_display_requests,
+        &wl_display_events,
+    );
 pub static WL_REGISTRY_INTERFACE: wayland_backend::protocol::Interface =
     wayland_backend::protocol::Interface {
         name: "wl_registry",
@@ -136,35 +123,33 @@ pub static WL_REGISTRY_INTERFACE: wayland_backend::protocol::Interface =
                 arg_interfaces: &[],
             },
         ],
-        c_ptr: Some(unsafe { &wl_registry_interface }),
+        c_interface: Some(unsafe { &wl_registry_interface }),
     };
-static wl_registry_requests: SyncWrapper<[wayland_backend::protocol::wl_message; 1]> =
-    SyncWrapper([wayland_backend::protocol::wl_message {
-        name: b"bind\0" as *const u8 as *const std::os::raw::c_char,
-        signature: b"usun\0" as *const u8 as *const std::os::raw::c_char,
-        types: types_null.0.as_ptr(),
-    }]);
-static wl_registry_events: SyncWrapper<[wayland_backend::protocol::wl_message; 2]> = SyncWrapper([
-    wayland_backend::protocol::wl_message {
-        name: b"global\0" as *const u8 as *const std::os::raw::c_char,
-        signature: b"usu\0" as *const u8 as *const std::os::raw::c_char,
-        types: types_null.0.as_ptr(),
-    },
-    wayland_backend::protocol::wl_message {
-        name: b"global_remove\0" as *const u8 as *const std::os::raw::c_char,
-        signature: b"u\0" as *const u8 as *const std::os::raw::c_char,
-        types: types_null.0.as_ptr(),
-    },
-]);
-pub static wl_registry_interface: wayland_backend::protocol::wl_interface =
-    wayland_backend::protocol::wl_interface {
-        name: b"wl_registry\0" as *const u8 as *const std::os::raw::c_char,
-        version: 1,
-        request_count: 1,
-        requests: wl_registry_requests.0.as_ptr(),
-        event_count: 2,
-        events: wl_registry_events.0.as_ptr(),
-    };
+static wl_registry_requests: [wayland_backend::protocol::CWlMessage; 1] =
+    [wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"bind\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"usun\0") },
+        &types_null,
+    )];
+static wl_registry_events: [wayland_backend::protocol::CWlMessage; 2] = [
+    wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"global\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"usu\0") },
+        &types_null,
+    ),
+    wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"global_remove\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"u\0") },
+        &types_null,
+    ),
+];
+pub static wl_registry_interface: wayland_backend::protocol::CWlInterface =
+    wayland_backend::protocol::CWlInterface::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"wl_registry\0") },
+        1,
+        &wl_registry_requests,
+        &wl_registry_events,
+    );
 pub static WL_CALLBACK_INTERFACE: wayland_backend::protocol::Interface =
     wayland_backend::protocol::Interface {
         name: "wl_callback",
@@ -178,23 +163,21 @@ pub static WL_CALLBACK_INTERFACE: wayland_backend::protocol::Interface =
             child_interface: None,
             arg_interfaces: &[],
         }],
-        c_ptr: Some(unsafe { &wl_callback_interface }),
+        c_interface: Some(unsafe { &wl_callback_interface }),
     };
-static wl_callback_events: SyncWrapper<[wayland_backend::protocol::wl_message; 1]> =
-    SyncWrapper([wayland_backend::protocol::wl_message {
-        name: b"done\0" as *const u8 as *const std::os::raw::c_char,
-        signature: b"u\0" as *const u8 as *const std::os::raw::c_char,
-        types: types_null.0.as_ptr(),
-    }]);
-pub static wl_callback_interface: wayland_backend::protocol::wl_interface =
-    wayland_backend::protocol::wl_interface {
-        name: b"wl_callback\0" as *const u8 as *const std::os::raw::c_char,
-        version: 1,
-        request_count: 0,
-        requests: null::<wayland_backend::protocol::wl_message>(),
-        event_count: 1,
-        events: wl_callback_events.0.as_ptr(),
-    };
+static wl_callback_events: [wayland_backend::protocol::CWlMessage; 1] =
+    [wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"done\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"u\0") },
+        &types_null,
+    )];
+pub static wl_callback_interface: wayland_backend::protocol::CWlInterface =
+    wayland_backend::protocol::CWlInterface::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"wl_callback\0") },
+        1,
+        &[],
+        &wl_callback_events,
+    );
 pub static TEST_GLOBAL_INTERFACE: wayland_backend::protocol::Interface =
     wayland_backend::protocol::Interface {
         name: "test_global",
@@ -331,107 +314,69 @@ pub static TEST_GLOBAL_INTERFACE: wayland_backend::protocol::Interface =
                 arg_interfaces: &[&QUAD_INTERFACE],
             },
         ],
-        c_ptr: Some(unsafe { &test_global_interface }),
+        c_interface: Some(unsafe { &test_global_interface }),
     };
-static test_global_requests_get_secondary_types: SyncWrapper<
-    [*const wayland_backend::protocol::wl_interface; 1],
-> = SyncWrapper([&secondary_interface as *const wayland_backend::protocol::wl_interface]);
-static test_global_requests_get_tertiary_types: SyncWrapper<
-    [*const wayland_backend::protocol::wl_interface; 1],
-> = SyncWrapper([&tertiary_interface as *const wayland_backend::protocol::wl_interface]);
-static test_global_requests_link_types: SyncWrapper<
-    [*const wayland_backend::protocol::wl_interface; 3],
-> = SyncWrapper([
-    &secondary_interface as *const wayland_backend::protocol::wl_interface,
-    &tertiary_interface as *const wayland_backend::protocol::wl_interface,
-    null::<wayland_backend::protocol::wl_interface>(),
-]);
-static test_global_requests_reverse_link_types: SyncWrapper<
-    [*const wayland_backend::protocol::wl_interface; 2],
-> = SyncWrapper([
-    &secondary_interface as *const wayland_backend::protocol::wl_interface,
-    &tertiary_interface as *const wayland_backend::protocol::wl_interface,
-]);
-static test_global_requests_newid_and_allow_null_types: SyncWrapper<
-    [*const wayland_backend::protocol::wl_interface; 3],
-> = SyncWrapper([
-    &quad_interface as *const wayland_backend::protocol::wl_interface,
-    &secondary_interface as *const wayland_backend::protocol::wl_interface,
-    &tertiary_interface as *const wayland_backend::protocol::wl_interface,
-]);
-static test_global_requests: SyncWrapper<[wayland_backend::protocol::wl_message; 7]> =
-    SyncWrapper([
-        wayland_backend::protocol::wl_message {
-            name: b"many_args\0" as *const u8 as *const std::os::raw::c_char,
-            signature: b"uifash\0" as *const u8 as *const std::os::raw::c_char,
-            types: types_null.0.as_ptr(),
-        },
-        wayland_backend::protocol::wl_message {
-            name: b"get_secondary\0" as *const u8 as *const std::os::raw::c_char,
-            signature: b"2n\0" as *const u8 as *const std::os::raw::c_char,
-            types: test_global_requests_get_secondary_types.0.as_ptr(),
-        },
-        wayland_backend::protocol::wl_message {
-            name: b"get_tertiary\0" as *const u8 as *const std::os::raw::c_char,
-            signature: b"3n\0" as *const u8 as *const std::os::raw::c_char,
-            types: test_global_requests_get_tertiary_types.0.as_ptr(),
-        },
-        wayland_backend::protocol::wl_message {
-            name: b"link\0" as *const u8 as *const std::os::raw::c_char,
-            signature: b"3o?ou\0" as *const u8 as *const std::os::raw::c_char,
-            types: test_global_requests_link_types.0.as_ptr(),
-        },
-        wayland_backend::protocol::wl_message {
-            name: b"destroy\0" as *const u8 as *const std::os::raw::c_char,
-            signature: b"4\0" as *const u8 as *const std::os::raw::c_char,
-            types: types_null.0.as_ptr(),
-        },
-        wayland_backend::protocol::wl_message {
-            name: b"reverse_link\0" as *const u8 as *const std::os::raw::c_char,
-            signature: b"5?oo\0" as *const u8 as *const std::os::raw::c_char,
-            types: test_global_requests_reverse_link_types.0.as_ptr(),
-        },
-        wayland_backend::protocol::wl_message {
-            name: b"newid_and_allow_null\0" as *const u8 as *const std::os::raw::c_char,
-            signature: b"5n?oo\0" as *const u8 as *const std::os::raw::c_char,
-            types: test_global_requests_newid_and_allow_null_types.0.as_ptr(),
-        },
-    ]);
-static test_global_events_ack_secondary_types: SyncWrapper<
-    [*const wayland_backend::protocol::wl_interface; 1],
-> = SyncWrapper([&secondary_interface as *const wayland_backend::protocol::wl_interface]);
-static test_global_events_cycle_quad_types: SyncWrapper<
-    [*const wayland_backend::protocol::wl_interface; 2],
-> = SyncWrapper([
-    &quad_interface as *const wayland_backend::protocol::wl_interface,
-    &quad_interface as *const wayland_backend::protocol::wl_interface,
-]);
-static test_global_events: SyncWrapper<[wayland_backend::protocol::wl_message; 3]> = SyncWrapper([
-    wayland_backend::protocol::wl_message {
-        name: b"many_args_evt\0" as *const u8 as *const std::os::raw::c_char,
-        signature: b"uifash\0" as *const u8 as *const std::os::raw::c_char,
-        types: types_null.0.as_ptr(),
-    },
-    wayland_backend::protocol::wl_message {
-        name: b"ack_secondary\0" as *const u8 as *const std::os::raw::c_char,
-        signature: b"o\0" as *const u8 as *const std::os::raw::c_char,
-        types: test_global_events_ack_secondary_types.0.as_ptr(),
-    },
-    wayland_backend::protocol::wl_message {
-        name: b"cycle_quad\0" as *const u8 as *const std::os::raw::c_char,
-        signature: b"n?o\0" as *const u8 as *const std::os::raw::c_char,
-        types: test_global_events_cycle_quad_types.0.as_ptr(),
-    },
-]);
-pub static test_global_interface: wayland_backend::protocol::wl_interface =
-    wayland_backend::protocol::wl_interface {
-        name: b"test_global\0" as *const u8 as *const std::os::raw::c_char,
-        version: 5,
-        request_count: 7,
-        requests: test_global_requests.0.as_ptr(),
-        event_count: 3,
-        events: test_global_events.0.as_ptr(),
-    };
+static test_global_requests: [wayland_backend::protocol::CWlMessage; 7] = [
+    wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"many_args\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"uifash\0") },
+        &types_null,
+    ),
+    wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"get_secondary\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"2n\0") },
+        &[Some(&secondary_interface)],
+    ),
+    wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"get_tertiary\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"3n\0") },
+        &[Some(&tertiary_interface)],
+    ),
+    wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"link\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"3o?ou\0") },
+        &[Some(&secondary_interface), Some(&tertiary_interface), None],
+    ),
+    wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"destroy\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"4\0") },
+        &types_null,
+    ),
+    wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"reverse_link\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"5?oo\0") },
+        &[Some(&secondary_interface), Some(&tertiary_interface)],
+    ),
+    wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"newid_and_allow_null\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"5n?oo\0") },
+        &[Some(&quad_interface), Some(&secondary_interface), Some(&tertiary_interface)],
+    ),
+];
+static test_global_events: [wayland_backend::protocol::CWlMessage; 3] = [
+    wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"many_args_evt\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"uifash\0") },
+        &types_null,
+    ),
+    wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"ack_secondary\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"o\0") },
+        &[Some(&secondary_interface)],
+    ),
+    wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"cycle_quad\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"n?o\0") },
+        &[Some(&quad_interface), Some(&quad_interface)],
+    ),
+];
+pub static test_global_interface: wayland_backend::protocol::CWlInterface =
+    wayland_backend::protocol::CWlInterface::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"test_global\0") },
+        5,
+        &test_global_requests,
+        &test_global_events,
+    );
 pub static SECONDARY_INTERFACE: wayland_backend::protocol::Interface =
     wayland_backend::protocol::Interface {
         name: "secondary",
@@ -445,23 +390,21 @@ pub static SECONDARY_INTERFACE: wayland_backend::protocol::Interface =
             arg_interfaces: &[],
         }],
         events: &[],
-        c_ptr: Some(unsafe { &secondary_interface }),
+        c_interface: Some(unsafe { &secondary_interface }),
     };
-static secondary_requests: SyncWrapper<[wayland_backend::protocol::wl_message; 1]> =
-    SyncWrapper([wayland_backend::protocol::wl_message {
-        name: b"destroy\0" as *const u8 as *const std::os::raw::c_char,
-        signature: b"2\0" as *const u8 as *const std::os::raw::c_char,
-        types: types_null.0.as_ptr(),
-    }]);
-pub static secondary_interface: wayland_backend::protocol::wl_interface =
-    wayland_backend::protocol::wl_interface {
-        name: b"secondary\0" as *const u8 as *const std::os::raw::c_char,
-        version: 5,
-        request_count: 1,
-        requests: secondary_requests.0.as_ptr(),
-        event_count: 0,
-        events: null::<wayland_backend::protocol::wl_message>(),
-    };
+static secondary_requests: [wayland_backend::protocol::CWlMessage; 1] =
+    [wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"destroy\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"2\0") },
+        &types_null,
+    )];
+pub static secondary_interface: wayland_backend::protocol::CWlInterface =
+    wayland_backend::protocol::CWlInterface::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"secondary\0") },
+        5,
+        &secondary_requests,
+        &[],
+    );
 pub static TERTIARY_INTERFACE: wayland_backend::protocol::Interface =
     wayland_backend::protocol::Interface {
         name: "tertiary",
@@ -475,23 +418,21 @@ pub static TERTIARY_INTERFACE: wayland_backend::protocol::Interface =
             arg_interfaces: &[],
         }],
         events: &[],
-        c_ptr: Some(unsafe { &tertiary_interface }),
+        c_interface: Some(unsafe { &tertiary_interface }),
     };
-static tertiary_requests: SyncWrapper<[wayland_backend::protocol::wl_message; 1]> =
-    SyncWrapper([wayland_backend::protocol::wl_message {
-        name: b"destroy\0" as *const u8 as *const std::os::raw::c_char,
-        signature: b"3\0" as *const u8 as *const std::os::raw::c_char,
-        types: types_null.0.as_ptr(),
-    }]);
-pub static tertiary_interface: wayland_backend::protocol::wl_interface =
-    wayland_backend::protocol::wl_interface {
-        name: b"tertiary\0" as *const u8 as *const std::os::raw::c_char,
-        version: 5,
-        request_count: 1,
-        requests: tertiary_requests.0.as_ptr(),
-        event_count: 0,
-        events: null::<wayland_backend::protocol::wl_message>(),
-    };
+static tertiary_requests: [wayland_backend::protocol::CWlMessage; 1] =
+    [wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"destroy\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"3\0") },
+        &types_null,
+    )];
+pub static tertiary_interface: wayland_backend::protocol::CWlInterface =
+    wayland_backend::protocol::CWlInterface::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"tertiary\0") },
+        5,
+        &tertiary_requests,
+        &[],
+    );
 pub static QUAD_INTERFACE: wayland_backend::protocol::Interface =
     wayland_backend::protocol::Interface {
         name: "quad",
@@ -505,20 +446,18 @@ pub static QUAD_INTERFACE: wayland_backend::protocol::Interface =
             arg_interfaces: &[],
         }],
         events: &[],
-        c_ptr: Some(unsafe { &quad_interface }),
+        c_interface: Some(unsafe { &quad_interface }),
     };
-static quad_requests: SyncWrapper<[wayland_backend::protocol::wl_message; 1]> =
-    SyncWrapper([wayland_backend::protocol::wl_message {
-        name: b"destroy\0" as *const u8 as *const std::os::raw::c_char,
-        signature: b"3\0" as *const u8 as *const std::os::raw::c_char,
-        types: types_null.0.as_ptr(),
-    }]);
-pub static quad_interface: wayland_backend::protocol::wl_interface =
-    wayland_backend::protocol::wl_interface {
-        name: b"quad\0" as *const u8 as *const std::os::raw::c_char,
-        version: 5,
-        request_count: 1,
-        requests: quad_requests.0.as_ptr(),
-        event_count: 0,
-        events: null::<wayland_backend::protocol::wl_message>(),
-    };
+static quad_requests: [wayland_backend::protocol::CWlMessage; 1] =
+    [wayland_backend::protocol::CWlMessage::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"destroy\0") },
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"3\0") },
+        &types_null,
+    )];
+pub static quad_interface: wayland_backend::protocol::CWlInterface =
+    wayland_backend::protocol::CWlInterface::new(
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"quad\0") },
+        5,
+        &quad_requests,
+        &[],
+    );


### PR DESCRIPTION
We could extract the shared types into yet another crate, or maybe make the re-exports `#[doc(hidden)]`, only to be used by wayland-scanner. Or just copy the definitions here.

But adding `#[repr(transparent)]` wrapper types seems to work, so we may as well do that.

Ideally it would be good to reduce some of the duplication between this and `Interface`/`MessageDesc`. Not sure how much that can be done.