### PR TITLE
client,server,scanner: Use default impls in `Proxy`/`Resource`

### DIFF
--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -247,7 +247,9 @@ pub trait Proxy: Clone + std::fmt::Debug + Sized {
     }
 
     /// Access the user-data associated with this object
-    fn data<U: Send + Sync + 'static>(&self) -> Option<&U>;
+    fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
+        self.object_data().as_ref().and_then(|arc| arc.data_as_any().downcast_ref::<U>())
+    }
 
     /// Access the raw data associated with this object.
     ///
@@ -277,7 +279,12 @@ pub trait Proxy: Clone + std::fmt::Debug + Sized {
     ///
     /// It is an error to use this function on requests that create objects; use
     /// [`send_constructor()`][Self::send_constructor()] for such requests.
-    fn send_request(&self, req: Self::Request<'_>) -> Result<(), InvalidId>;
+    fn send_request(&self, req: Self::Request<'_>) -> Result<(), InvalidId> {
+        let conn = Connection::from_backend(self.backend().upgrade().ok_or(InvalidId)?);
+        let id = conn.send_request(self, req, None)?;
+        debug_assert!(id.is_null());
+        Ok(())
+    }
 
     /// Send a request for this object that creates another object.
     ///
@@ -287,7 +294,11 @@ pub trait Proxy: Clone + std::fmt::Debug + Sized {
         &self,
         req: Self::Request<'_>,
         data: Arc<dyn ObjectData>,
-    ) -> Result<I, InvalidId>;
+    ) -> Result<I, InvalidId> {
+        let conn = Connection::from_backend(self.backend().upgrade().ok_or(InvalidId)?);
+        let id = conn.send_request(self, req, Some(data))?;
+        Proxy::from_id(&conn, id)
+    }
 
     /// Parse a event for this object
     ///

--- a/wayland-scanner/src/client_gen.rs
+++ b/wayland-scanner/src/client_gen.rs
@@ -122,30 +122,12 @@ fn generate_objects_for(interface: &Interface) -> TokenStream {
                     self.version
                 }
 
-                #[inline]
-                fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
-                    self.data.as_ref().and_then(|arc| arc.data_as_any().downcast_ref::<U>())
-                }
-
                 fn object_data(&self) -> Option<&Arc<dyn ObjectData>> {
                     self.data.as_ref()
                 }
 
                 fn backend(&self) -> &WeakBackend {
                     &self.backend
-                }
-
-                fn send_request(&self, req: Self::Request<'_>) -> Result<(), InvalidId> {
-                    let conn = Connection::from_backend(self.backend.upgrade().ok_or(InvalidId)?);
-                    let id = conn.send_request(self, req, None)?;
-                    debug_assert!(id.is_null());
-                    Ok(())
-                }
-
-                fn send_constructor<I: Proxy>(&self, req: Self::Request<'_>, data: Arc<dyn ObjectData>) -> Result<I, InvalidId> {
-                    let conn = Connection::from_backend(self.backend.upgrade().ok_or(InvalidId)?);
-                    let id = conn.send_request(self, req, Some(data))?;
-                    Proxy::from_id(&conn, id)
                 }
 
                 #[inline]

--- a/wayland-scanner/src/client_gen.rs
+++ b/wayland-scanner/src/client_gen.rs
@@ -324,6 +324,11 @@ mod tests {
         let generated: String = super::generate_client_objects(&protocol_parsed).to_string();
         let generated = crate::format_rust_code(&generated);
 
+        if std::env::var("WAYLAND_SCANNER_UPDATE_TESTS").is_ok() {
+            std::fs::write("./tests/scanner_assets/test-client-code.rs", generated).unwrap();
+            return;
+        }
+
         let reference =
             std::fs::read_to_string("./tests/scanner_assets/test-client-code.rs").unwrap();
         let reference = crate::format_rust_code(&reference);

--- a/wayland-scanner/src/interfaces.rs
+++ b/wayland-scanner/src/interfaces.rs
@@ -129,6 +129,11 @@ mod tests {
         let generated: String = super::generate(&protocol_parsed, true).to_string();
         let generated = crate::format_rust_code(&generated);
 
+        if std::env::var("WAYLAND_SCANNER_UPDATE_TESTS").is_ok() {
+            std::fs::write("./tests/scanner_assets/test-interfaces.rs", generated).unwrap();
+            return;
+        }
+
         let reference =
             std::fs::read_to_string("./tests/scanner_assets/test-interfaces.rs").unwrap();
         let reference = crate::format_rust_code(&reference);

--- a/wayland-scanner/src/server_gen.rs
+++ b/wayland-scanner/src/server_gen.rs
@@ -285,6 +285,11 @@ mod tests {
         let generated: String = super::generate_server_objects(&protocol_parsed).to_string();
         let generated = crate::format_rust_code(&generated);
 
+        if std::env::var("WAYLAND_SCANNER_UPDATE_TESTS").is_ok() {
+            std::fs::write("./tests/scanner_assets/test-server-code.rs", generated).unwrap();
+            return;
+        }
+
         let reference =
             std::fs::read_to_string("./tests/scanner_assets/test-server-code.rs").unwrap();
         let reference = crate::format_rust_code(&reference);

--- a/wayland-scanner/src/server_gen.rs
+++ b/wayland-scanner/src/server_gen.rs
@@ -159,11 +159,6 @@ fn generate_objects_for(interface: &Interface) -> TokenStream {
                     Ok(#iface_name { id, data, version, handle: conn.backend_handle().downgrade() })
                 }
 
-                fn send_event(&self, evt: Self::Event<'_>) -> Result<(), InvalidId> {
-                    let handle = DisplayHandle::from(self.handle.upgrade().ok_or(InvalidId)?);
-                    handle.send_event(self, evt)
-                }
-
                 fn parse_request(conn: &DisplayHandle, msg: Message<ObjectId, OwnedFd>) -> Result<(Self, Self::Request), DispatchError> {
                     #parse_body
                 }

--- a/wayland-scanner/tests/scanner_assets/test-client-code.rs
+++ b/wayland-scanner/tests/scanner_assets/test-client-code.rs
@@ -7,8 +7,8 @@ pub mod wl_display {
         },
         Connection, Dispatch, DispatchError, Proxy, QueueHandle, QueueProxyData, Weak,
     };
-    use std::sync::Arc;
     use std::os::unix::io::OwnedFd;
+    use std::sync::Arc;
     #[doc = "global error values\n\nThese errors are global and can be emitted in response to any\nserver request."]
     #[repr(u32)]
     #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -150,30 +150,11 @@ pub mod wl_display {
         fn version(&self) -> u32 {
             self.version
         }
-        #[inline]
-        fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
-            self.data.as_ref().and_then(|arc| arc.data_as_any().downcast_ref::<U>())
-        }
         fn object_data(&self) -> Option<&Arc<dyn ObjectData>> {
             self.data.as_ref()
         }
         fn backend(&self) -> &WeakBackend {
             &self.backend
-        }
-        fn send_request(&self, req: Self::Request<'_>) -> Result<(), InvalidId> {
-            let conn = Connection::from_backend(self.backend.upgrade().ok_or(InvalidId)?);
-            let id = conn.send_request(self, req, None)?;
-            debug_assert!(id.is_null());
-            Ok(())
-        }
-        fn send_constructor<I: Proxy>(
-            &self,
-            req: Self::Request<'_>,
-            data: Arc<dyn ObjectData>,
-        ) -> Result<I, InvalidId> {
-            let conn = Connection::from_backend(self.backend.upgrade().ok_or(InvalidId)?);
-            let id = conn.send_request(self, req, Some(data))?;
-            Proxy::from_id(&conn, id)
         }
         #[inline]
         fn from_id(conn: &Connection, id: ObjectId) -> Result<Self, InvalidId> {
@@ -245,7 +226,10 @@ pub mod wl_display {
             conn: &Connection,
             msg: Self::Request<'a>,
         ) -> Result<
-            (Message<ObjectId, std::os::unix::io::BorrowedFd<'a>>, Option<(&'static Interface, u32)>),
+            (
+                Message<ObjectId, std::os::unix::io::BorrowedFd<'a>>,
+                Option<(&'static Interface, u32)>,
+            ),
             InvalidId,
         > {
             match msg {
@@ -321,8 +305,8 @@ pub mod wl_registry {
         },
         Connection, Dispatch, DispatchError, Proxy, QueueHandle, QueueProxyData, Weak,
     };
-    use std::sync::Arc;
     use std::os::unix::io::OwnedFd;
+    use std::sync::Arc;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_BIND_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this request"]
@@ -431,30 +415,11 @@ pub mod wl_registry {
         fn version(&self) -> u32 {
             self.version
         }
-        #[inline]
-        fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
-            self.data.as_ref().and_then(|arc| arc.data_as_any().downcast_ref::<U>())
-        }
         fn object_data(&self) -> Option<&Arc<dyn ObjectData>> {
             self.data.as_ref()
         }
         fn backend(&self) -> &WeakBackend {
             &self.backend
-        }
-        fn send_request(&self, req: Self::Request<'_>) -> Result<(), InvalidId> {
-            let conn = Connection::from_backend(self.backend.upgrade().ok_or(InvalidId)?);
-            let id = conn.send_request(self, req, None)?;
-            debug_assert!(id.is_null());
-            Ok(())
-        }
-        fn send_constructor<I: Proxy>(
-            &self,
-            req: Self::Request<'_>,
-            data: Arc<dyn ObjectData>,
-        ) -> Result<I, InvalidId> {
-            let conn = Connection::from_backend(self.backend.upgrade().ok_or(InvalidId)?);
-            let id = conn.send_request(self, req, Some(data))?;
-            Proxy::from_id(&conn, id)
         }
         #[inline]
         fn from_id(conn: &Connection, id: ObjectId) -> Result<Self, InvalidId> {
@@ -526,7 +491,10 @@ pub mod wl_registry {
             conn: &Connection,
             msg: Self::Request<'a>,
         ) -> Result<
-            (Message<ObjectId, std::os::unix::io::BorrowedFd<'a>>, Option<(&'static Interface, u32)>),
+            (
+                Message<ObjectId, std::os::unix::io::BorrowedFd<'a>>,
+                Option<(&'static Interface, u32)>,
+            ),
             InvalidId,
         > {
             match msg {
@@ -575,8 +543,8 @@ pub mod wl_callback {
         },
         Connection, Dispatch, DispatchError, Proxy, QueueHandle, QueueProxyData, Weak,
     };
-    use std::sync::Arc;
     use std::os::unix::io::OwnedFd;
+    use std::sync::Arc;
     #[doc = r" The minimal object version supporting this event"]
     pub const EVT_DONE_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this event"]
@@ -659,30 +627,11 @@ pub mod wl_callback {
         fn version(&self) -> u32 {
             self.version
         }
-        #[inline]
-        fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
-            self.data.as_ref().and_then(|arc| arc.data_as_any().downcast_ref::<U>())
-        }
         fn object_data(&self) -> Option<&Arc<dyn ObjectData>> {
             self.data.as_ref()
         }
         fn backend(&self) -> &WeakBackend {
             &self.backend
-        }
-        fn send_request(&self, req: Self::Request<'_>) -> Result<(), InvalidId> {
-            let conn = Connection::from_backend(self.backend.upgrade().ok_or(InvalidId)?);
-            let id = conn.send_request(self, req, None)?;
-            debug_assert!(id.is_null());
-            Ok(())
-        }
-        fn send_constructor<I: Proxy>(
-            &self,
-            req: Self::Request<'_>,
-            data: Arc<dyn ObjectData>,
-        ) -> Result<I, InvalidId> {
-            let conn = Connection::from_backend(self.backend.upgrade().ok_or(InvalidId)?);
-            let id = conn.send_request(self, req, Some(data))?;
-            Proxy::from_id(&conn, id)
         }
         #[inline]
         fn from_id(conn: &Connection, id: ObjectId) -> Result<Self, InvalidId> {
@@ -728,7 +677,10 @@ pub mod wl_callback {
             conn: &Connection,
             msg: Self::Request<'a>,
         ) -> Result<
-            (Message<ObjectId, std::os::unix::io::BorrowedFd<'a>>, Option<(&'static Interface, u32)>),
+            (
+                Message<ObjectId, std::os::unix::io::BorrowedFd<'a>>,
+                Option<(&'static Interface, u32)>,
+            ),
             InvalidId,
         > {
             match msg {
@@ -746,8 +698,8 @@ pub mod test_global {
         },
         Connection, Dispatch, DispatchError, Proxy, QueueHandle, QueueProxyData, Weak,
     };
-    use std::sync::Arc;
     use std::os::unix::io::OwnedFd;
+    use std::sync::Arc;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_MANY_ARGS_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this request"]
@@ -919,30 +871,11 @@ pub mod test_global {
         fn version(&self) -> u32 {
             self.version
         }
-        #[inline]
-        fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
-            self.data.as_ref().and_then(|arc| arc.data_as_any().downcast_ref::<U>())
-        }
         fn object_data(&self) -> Option<&Arc<dyn ObjectData>> {
             self.data.as_ref()
         }
         fn backend(&self) -> &WeakBackend {
             &self.backend
-        }
-        fn send_request(&self, req: Self::Request<'_>) -> Result<(), InvalidId> {
-            let conn = Connection::from_backend(self.backend.upgrade().ok_or(InvalidId)?);
-            let id = conn.send_request(self, req, None)?;
-            debug_assert!(id.is_null());
-            Ok(())
-        }
-        fn send_constructor<I: Proxy>(
-            &self,
-            req: Self::Request<'_>,
-            data: Arc<dyn ObjectData>,
-        ) -> Result<I, InvalidId> {
-            let conn = Connection::from_backend(self.backend.upgrade().ok_or(InvalidId)?);
-            let id = conn.send_request(self, req, Some(data))?;
-            Proxy::from_id(&conn, id)
         }
         #[inline]
         fn from_id(conn: &Connection, id: ObjectId) -> Result<Self, InvalidId> {
@@ -1092,7 +1025,10 @@ pub mod test_global {
             conn: &Connection,
             msg: Self::Request<'a>,
         ) -> Result<
-            (Message<ObjectId, std::os::unix::io::BorrowedFd<'a>>, Option<(&'static Interface, u32)>),
+            (
+                Message<ObjectId, std::os::unix::io::BorrowedFd<'a>>,
+                Option<(&'static Interface, u32)>,
+            ),
             InvalidId,
         > {
             match msg {
@@ -1329,8 +1265,8 @@ pub mod secondary {
         },
         Connection, Dispatch, DispatchError, Proxy, QueueHandle, QueueProxyData, Weak,
     };
-    use std::sync::Arc;
     use std::os::unix::io::OwnedFd;
+    use std::sync::Arc;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 2u32;
     #[doc = r" The wire opcode for this request"]
@@ -1408,30 +1344,11 @@ pub mod secondary {
         fn version(&self) -> u32 {
             self.version
         }
-        #[inline]
-        fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
-            self.data.as_ref().and_then(|arc| arc.data_as_any().downcast_ref::<U>())
-        }
         fn object_data(&self) -> Option<&Arc<dyn ObjectData>> {
             self.data.as_ref()
         }
         fn backend(&self) -> &WeakBackend {
             &self.backend
-        }
-        fn send_request(&self, req: Self::Request<'_>) -> Result<(), InvalidId> {
-            let conn = Connection::from_backend(self.backend.upgrade().ok_or(InvalidId)?);
-            let id = conn.send_request(self, req, None)?;
-            debug_assert!(id.is_null());
-            Ok(())
-        }
-        fn send_constructor<I: Proxy>(
-            &self,
-            req: Self::Request<'_>,
-            data: Arc<dyn ObjectData>,
-        ) -> Result<I, InvalidId> {
-            let conn = Connection::from_backend(self.backend.upgrade().ok_or(InvalidId)?);
-            let id = conn.send_request(self, req, Some(data))?;
-            Proxy::from_id(&conn, id)
         }
         #[inline]
         fn from_id(conn: &Connection, id: ObjectId) -> Result<Self, InvalidId> {
@@ -1466,7 +1383,10 @@ pub mod secondary {
             conn: &Connection,
             msg: Self::Request<'a>,
         ) -> Result<
-            (Message<ObjectId, std::os::unix::io::BorrowedFd<'a>>, Option<(&'static Interface, u32)>),
+            (
+                Message<ObjectId, std::os::unix::io::BorrowedFd<'a>>,
+                Option<(&'static Interface, u32)>,
+            ),
             InvalidId,
         > {
             match msg {
@@ -1499,8 +1419,8 @@ pub mod tertiary {
         },
         Connection, Dispatch, DispatchError, Proxy, QueueHandle, QueueProxyData, Weak,
     };
-    use std::sync::Arc;
     use std::os::unix::io::OwnedFd;
+    use std::sync::Arc;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 3u32;
     #[doc = r" The wire opcode for this request"]
@@ -1578,30 +1498,11 @@ pub mod tertiary {
         fn version(&self) -> u32 {
             self.version
         }
-        #[inline]
-        fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
-            self.data.as_ref().and_then(|arc| arc.data_as_any().downcast_ref::<U>())
-        }
         fn object_data(&self) -> Option<&Arc<dyn ObjectData>> {
             self.data.as_ref()
         }
         fn backend(&self) -> &WeakBackend {
             &self.backend
-        }
-        fn send_request(&self, req: Self::Request<'_>) -> Result<(), InvalidId> {
-            let conn = Connection::from_backend(self.backend.upgrade().ok_or(InvalidId)?);
-            let id = conn.send_request(self, req, None)?;
-            debug_assert!(id.is_null());
-            Ok(())
-        }
-        fn send_constructor<I: Proxy>(
-            &self,
-            req: Self::Request<'_>,
-            data: Arc<dyn ObjectData>,
-        ) -> Result<I, InvalidId> {
-            let conn = Connection::from_backend(self.backend.upgrade().ok_or(InvalidId)?);
-            let id = conn.send_request(self, req, Some(data))?;
-            Proxy::from_id(&conn, id)
         }
         #[inline]
         fn from_id(conn: &Connection, id: ObjectId) -> Result<Self, InvalidId> {
@@ -1636,7 +1537,10 @@ pub mod tertiary {
             conn: &Connection,
             msg: Self::Request<'a>,
         ) -> Result<
-            (Message<ObjectId, std::os::unix::io::BorrowedFd<'a>>, Option<(&'static Interface, u32)>),
+            (
+                Message<ObjectId, std::os::unix::io::BorrowedFd<'a>>,
+                Option<(&'static Interface, u32)>,
+            ),
             InvalidId,
         > {
             match msg {
@@ -1669,8 +1573,8 @@ pub mod quad {
         },
         Connection, Dispatch, DispatchError, Proxy, QueueHandle, QueueProxyData, Weak,
     };
-    use std::sync::Arc;
     use std::os::unix::io::OwnedFd;
+    use std::sync::Arc;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 3u32;
     #[doc = r" The wire opcode for this request"]
@@ -1748,30 +1652,11 @@ pub mod quad {
         fn version(&self) -> u32 {
             self.version
         }
-        #[inline]
-        fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
-            self.data.as_ref().and_then(|arc| arc.data_as_any().downcast_ref::<U>())
-        }
         fn object_data(&self) -> Option<&Arc<dyn ObjectData>> {
             self.data.as_ref()
         }
         fn backend(&self) -> &WeakBackend {
             &self.backend
-        }
-        fn send_request(&self, req: Self::Request<'_>) -> Result<(), InvalidId> {
-            let conn = Connection::from_backend(self.backend.upgrade().ok_or(InvalidId)?);
-            let id = conn.send_request(self, req, None)?;
-            debug_assert!(id.is_null());
-            Ok(())
-        }
-        fn send_constructor<I: Proxy>(
-            &self,
-            req: Self::Request<'_>,
-            data: Arc<dyn ObjectData>,
-        ) -> Result<I, InvalidId> {
-            let conn = Connection::from_backend(self.backend.upgrade().ok_or(InvalidId)?);
-            let id = conn.send_request(self, req, Some(data))?;
-            Proxy::from_id(&conn, id)
         }
         #[inline]
         fn from_id(conn: &Connection, id: ObjectId) -> Result<Self, InvalidId> {
@@ -1806,7 +1691,10 @@ pub mod quad {
             conn: &Connection,
             msg: Self::Request<'a>,
         ) -> Result<
-            (Message<ObjectId, std::os::unix::io::BorrowedFd<'a>>, Option<(&'static Interface, u32)>),
+            (
+                Message<ObjectId, std::os::unix::io::BorrowedFd<'a>>,
+                Option<(&'static Interface, u32)>,
+            ),
             InvalidId,
         > {
             match msg {

--- a/wayland-scanner/tests/scanner_assets/test-server-code.rs
+++ b/wayland-scanner/tests/scanner_assets/test-server-code.rs
@@ -144,10 +144,6 @@ pub mod wl_registry {
             let data = conn.get_object_data(id.clone()).ok();
             Ok(WlRegistry { id, data, version, handle: conn.backend_handle().downgrade() })
         }
-        fn send_event(&self, evt: Self::Event<'_>) -> Result<(), InvalidId> {
-            let handle = DisplayHandle::from(self.handle.upgrade().ok_or(InvalidId)?);
-            handle.send_event(self, evt)
-        }
         fn parse_request(
             conn: &DisplayHandle,
             msg: Message<ObjectId, OwnedFd>,
@@ -214,8 +210,8 @@ pub mod wl_callback {
         },
         Dispatch, DispatchError, DisplayHandle, New, Resource, ResourceData, Weak,
     };
-    use std::sync::Arc;
     use std::os::unix::io::OwnedFd;
+    use std::sync::Arc;
     #[doc = r" The minimal object version supporting this event"]
     pub const EVT_DONE_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this event"]
@@ -323,10 +319,6 @@ pub mod wl_callback {
             let data = conn.get_object_data(id.clone()).ok();
             Ok(WlCallback { id, data, version, handle: conn.backend_handle().downgrade() })
         }
-        fn send_event(&self, evt: Self::Event<'_>) -> Result<(), InvalidId> {
-            let handle = DisplayHandle::from(self.handle.upgrade().ok_or(InvalidId)?);
-            handle.send_event(self, evt)
-        }
         fn parse_request(
             conn: &DisplayHandle,
             msg: Message<ObjectId, OwnedFd>,
@@ -382,8 +374,8 @@ pub mod test_global {
         },
         Dispatch, DispatchError, DisplayHandle, New, Resource, ResourceData, Weak,
     };
-    use std::sync::Arc;
     use std::os::unix::io::OwnedFd;
+    use std::sync::Arc;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_MANY_ARGS_SINCE: u32 = 1u32;
     #[doc = r" The wire opcode for this request"]
@@ -588,10 +580,6 @@ pub mod test_global {
             let version = conn.object_info(id.clone()).map(|info| info.version).unwrap_or(0);
             let data = conn.get_object_data(id.clone()).ok();
             Ok(TestGlobal { id, data, version, handle: conn.backend_handle().downgrade() })
-        }
-        fn send_event(&self, evt: Self::Event<'_>) -> Result<(), InvalidId> {
-            let handle = DisplayHandle::from(self.handle.upgrade().ok_or(InvalidId)?);
-            handle.send_event(self, evt)
         }
         fn parse_request(
             conn: &DisplayHandle,
@@ -991,8 +979,8 @@ pub mod secondary {
         },
         Dispatch, DispatchError, DisplayHandle, New, Resource, ResourceData, Weak,
     };
-    use std::sync::Arc;
     use std::os::unix::io::OwnedFd;
+    use std::sync::Arc;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 2u32;
     #[doc = r" The wire opcode for this request"]
@@ -1099,10 +1087,6 @@ pub mod secondary {
             let data = conn.get_object_data(id.clone()).ok();
             Ok(Secondary { id, data, version, handle: conn.backend_handle().downgrade() })
         }
-        fn send_event(&self, evt: Self::Event<'_>) -> Result<(), InvalidId> {
-            let handle = DisplayHandle::from(self.handle.upgrade().ok_or(InvalidId)?);
-            handle.send_event(self, evt)
-        }
         fn parse_request(
             conn: &DisplayHandle,
             msg: Message<ObjectId, OwnedFd>,
@@ -1154,8 +1138,8 @@ pub mod tertiary {
         },
         Dispatch, DispatchError, DisplayHandle, New, Resource, ResourceData, Weak,
     };
-    use std::sync::Arc;
     use std::os::unix::io::OwnedFd;
+    use std::sync::Arc;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 3u32;
     #[doc = r" The wire opcode for this request"]
@@ -1262,10 +1246,6 @@ pub mod tertiary {
             let data = conn.get_object_data(id.clone()).ok();
             Ok(Tertiary { id, data, version, handle: conn.backend_handle().downgrade() })
         }
-        fn send_event(&self, evt: Self::Event<'_>) -> Result<(), InvalidId> {
-            let handle = DisplayHandle::from(self.handle.upgrade().ok_or(InvalidId)?);
-            handle.send_event(self, evt)
-        }
         fn parse_request(
             conn: &DisplayHandle,
             msg: Message<ObjectId, OwnedFd>,
@@ -1317,8 +1297,8 @@ pub mod quad {
         },
         Dispatch, DispatchError, DisplayHandle, New, Resource, ResourceData, Weak,
     };
-    use std::sync::Arc;
     use std::os::unix::io::OwnedFd;
+    use std::sync::Arc;
     #[doc = r" The minimal object version supporting this request"]
     pub const REQ_DESTROY_SINCE: u32 = 3u32;
     #[doc = r" The wire opcode for this request"]
@@ -1424,10 +1404,6 @@ pub mod quad {
             let version = conn.object_info(id.clone()).map(|info| info.version).unwrap_or(0);
             let data = conn.get_object_data(id.clone()).ok();
             Ok(Quad { id, data, version, handle: conn.backend_handle().downgrade() })
-        }
-        fn send_event(&self, evt: Self::Event<'_>) -> Result<(), InvalidId> {
-            let handle = DisplayHandle::from(self.handle.upgrade().ok_or(InvalidId)?);
-            handle.send_event(self, evt)
         }
         fn parse_request(
             conn: &DisplayHandle,

--- a/wayland-scanner/update-tests.sh
+++ b/wayland-scanner/update-tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export WAYLAND_SCANNER_UPDATE_TESTS=1
+cargo test

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -192,7 +192,10 @@ pub trait Resource: Clone + std::fmt::Debug + Sized {
     fn from_id(dh: &DisplayHandle, id: ObjectId) -> Result<Self, InvalidId>;
 
     /// Send an event to this object
-    fn send_event(&self, evt: Self::Event<'_>) -> Result<(), InvalidId>;
+    fn send_event(&self, evt: Self::Event<'_>) -> Result<(), InvalidId> {
+        let handle = DisplayHandle::from(self.handle().upgrade().ok_or(InvalidId)?);
+        handle.send_event(self, evt)
+    }
 
     /// Trigger a protocol error on this object
     ///


### PR DESCRIPTION
A couple methods here can be trivially implemented in terms of other methods, so we don't need codegen to generate the same code for each of them.

Adding a default impl of the trait is not a breaking change. I guess this could technically be a breaking change if `wayland-scanner` was updated without updating `wayland-client`/`wayland-backend`? As a proc macro crate, it doesn't specify what version of the runtime dependency it requires...

That's probably fine though.