### PR TITLE
backend,egl: Use `NonNull<c_void>` in public API

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Wrap `wl_interface` so `wayland-sys` can be a private, optional dependency
   * (This API is generally used internally by `wayland-scanner`)
 - Return `NonNull` from `as_ptr()`
+- Use `c_void` pointers in API
 - Remove `WEnum`
 - Do not use `downcast_rs` traits in API
 - Remove depreacted raw-window-handle 0.5 support

--- a/wayland-backend/src/sys/client_impl/mod.rs
+++ b/wayland-backend/src/sys/client_impl/mod.rs
@@ -98,8 +98,10 @@ impl InnerObjectId {
 
     pub unsafe fn from_ptr(
         interface: &'static Interface,
-        ptr: *mut wl_proxy,
+        ptr: NonNull<wl_proxy>,
     ) -> Result<Self, InvalidId> {
+        let ptr = ptr.as_ptr();
+
         // Safety: the provided pointer must be a valid wayland object
         let ptr_iface_name = unsafe {
             CStr::from_ptr(ffi_dispatch!(wayland_client_handle(), wl_proxy_get_class, ptr))
@@ -269,8 +271,8 @@ impl InnerBackend {
         Ok(Self::from_display(display, true))
     }
 
-    pub unsafe fn from_foreign_display(display: *mut wl_display) -> Self {
-        Self::from_display(display, false)
+    pub unsafe fn from_foreign_display(display: NonNull<wl_display>) -> Self {
+        Self::from_display(display.as_ptr(), false)
     }
 
     fn from_display(display: *mut wl_display, owned: bool) -> Self {

--- a/wayland-backend/src/sys/mod.rs
+++ b/wayland-backend/src/sys/mod.rs
@@ -7,6 +7,9 @@ use wayland_sys::common::{wl_argument, wl_array};
 
 use crate::protocol::{ArgumentType, Interface};
 
+#[cfg(any(test, feature = "client_system", feature = "server_system"))]
+use std::ffi::c_void;
+
 #[cfg(any(test, feature = "client_system"))]
 mod client_impl;
 #[cfg(any(test, feature = "server_system"))]
@@ -56,9 +59,11 @@ impl client::ObjectId {
     /// long as the retrieved `ObjectId` is used.
     pub unsafe fn from_ptr(
         interface: &'static crate::protocol::Interface,
-        ptr: *mut wayland_sys::client::wl_proxy,
+        ptr: *mut c_void,
     ) -> Result<Self, client::InvalidId> {
-        Ok(Self { id: unsafe { client_impl::InnerObjectId::from_ptr(interface, ptr) }? })
+        Ok(Self {
+            id: unsafe { client_impl::InnerObjectId::from_ptr(interface, ptr.cast::<wl_proxy>()) }?,
+        })
     }
 
     /// Get the underlying libwayland pointer for this object
@@ -67,10 +72,8 @@ impl client::ObjectId {
     ///
     /// This function returns an [`InvalidId`][client::InvalidId] error if proxy has already
     /// been destroyed.
-    pub fn as_ptr(
-        &self,
-    ) -> Result<std::ptr::NonNull<wayland_sys::client::wl_proxy>, client::InvalidId> {
-        self.id.as_ptr()
+    pub fn as_ptr(&self) -> Result<std::ptr::NonNull<c_void>, client::InvalidId> {
+        Ok(self.id.as_ptr()?.cast())
     }
 
     /// Get the underlying display pointer for this object.
@@ -80,9 +83,8 @@ impl client::ObjectId {
     #[cfg(feature = "libwayland_client_1_23")]
     pub fn display_ptr(
         &self,
-    ) -> Result<std::ptr::NonNull<wayland_sys::client::wl_display>, crate::types::client::InvalidId>
-    {
-        self.id.display_ptr()
+    ) -> Result<std::ptr::NonNull<c_void>, crate::types::client::InvalidId> {
+        Ok(self.id.display_ptr()?.cast())
     }
 }
 
@@ -103,8 +105,14 @@ impl client::Backend {
     ///
     /// You need to ensure the `*mut wl_display` remains live as long as the  [`Backend`][Self]
     /// (or its clones) exist.
-    pub unsafe fn from_foreign_display(display: *mut wayland_sys::client::wl_display) -> Self {
-        Self { backend: unsafe { client_impl::InnerBackend::from_foreign_display(display) } }
+    pub unsafe fn from_foreign_display(display: *mut c_void) -> Self {
+        Self {
+            backend: unsafe {
+                client_impl::InnerBackend::from_foreign_display(
+                    display.cast::<wayland_sys::client::wl_display>(),
+                )
+            },
+        }
     }
 
     /// Returns the underlying `wl_display` pointer to this backend.
@@ -112,8 +120,8 @@ impl client::Backend {
     /// This pointer is needed to interface with EGL, Vulkan and other C libraries.
     ///
     /// This pointer is only valid for the lifetime of the backend.
-    pub fn display_ptr(&self) -> *mut wayland_sys::client::wl_display {
-        self.backend.display_ptr()
+    pub fn display_ptr(&self) -> *mut c_void {
+        self.backend.display_ptr().cast()
     }
 
     /// Take over handling for a proxy created by a third party.
@@ -129,10 +137,10 @@ impl client::Backend {
     pub unsafe fn manage_object(
         &self,
         interface: &'static Interface,
-        proxy: *mut wl_proxy,
+        proxy: *mut c_void,
         data: Arc<dyn ObjectData>,
     ) -> ObjectId {
-        unsafe { self.backend.manage_object(interface, proxy, data) }
+        unsafe { self.backend.manage_object(interface, proxy.cast::<wl_proxy>(), data) }
     }
 }
 
@@ -193,9 +201,16 @@ impl server::ObjectId {
     /// long as the retrieved `ObjectId` is used.
     pub unsafe fn from_ptr(
         interface: &'static crate::protocol::Interface,
-        ptr: *mut wayland_sys::server::wl_resource,
+        ptr: *mut c_void,
     ) -> Result<Self, server::InvalidId> {
-        Ok(Self { id: unsafe { server_impl::InnerObjectId::from_ptr(Some(interface), ptr) }? })
+        Ok(Self {
+            id: unsafe {
+                server_impl::InnerObjectId::from_ptr(
+                    Some(interface),
+                    ptr.cast::<wayland_sys::server::wl_resource>(),
+                )
+            }?,
+        })
     }
 
     /// Returns the pointer that represents this object.
@@ -206,17 +221,15 @@ impl server::ObjectId {
     ///
     /// This function returns an [`InvalidId`][server::InvalidId] error if resource has already
     /// been destroyed.
-    pub fn as_ptr(
-        &self,
-    ) -> Result<std::ptr::NonNull<wayland_sys::server::wl_resource>, server::InvalidId> {
-        self.id.as_ptr()
+    pub fn as_ptr(&self) -> Result<std::ptr::NonNull<c_void>, server::InvalidId> {
+        Ok(self.id.as_ptr()?.cast())
     }
 }
 
 #[cfg(any(test, feature = "server_system"))]
 impl server::Handle {
     /// Access the underlying `*mut wl_display` pointer
-    pub fn display_ptr(&self) -> *mut wayland_sys::server::wl_display {
-        self.handle.display_ptr()
+    pub fn display_ptr(&self) -> *mut c_void {
+        self.handle.display_ptr().cast()
     }
 }

--- a/wayland-backend/src/sys/mod.rs
+++ b/wayland-backend/src/sys/mod.rs
@@ -1,5 +1,6 @@
 //! Implementations of the Wayland backends using the system `libwayland`
 
+use std::ptr::NonNull;
 use std::sync::Arc;
 
 use wayland_sys::client::wl_proxy;
@@ -59,7 +60,7 @@ impl client::ObjectId {
     /// long as the retrieved `ObjectId` is used.
     pub unsafe fn from_ptr(
         interface: &'static crate::protocol::Interface,
-        ptr: *mut c_void,
+        ptr: NonNull<c_void>,
     ) -> Result<Self, client::InvalidId> {
         Ok(Self {
             id: unsafe { client_impl::InnerObjectId::from_ptr(interface, ptr.cast::<wl_proxy>()) }?,
@@ -72,7 +73,7 @@ impl client::ObjectId {
     ///
     /// This function returns an [`InvalidId`][client::InvalidId] error if proxy has already
     /// been destroyed.
-    pub fn as_ptr(&self) -> Result<std::ptr::NonNull<c_void>, client::InvalidId> {
+    pub fn as_ptr(&self) -> Result<NonNull<c_void>, client::InvalidId> {
         Ok(self.id.as_ptr()?.cast())
     }
 
@@ -81,9 +82,7 @@ impl client::ObjectId {
     /// This pointer is associated with the original display this object
     /// belongs to.
     #[cfg(feature = "libwayland_client_1_23")]
-    pub fn display_ptr(
-        &self,
-    ) -> Result<std::ptr::NonNull<c_void>, crate::types::client::InvalidId> {
+    pub fn display_ptr(&self) -> Result<NonNull<c_void>, crate::types::client::InvalidId> {
         Ok(self.id.display_ptr()?.cast())
     }
 }
@@ -105,7 +104,7 @@ impl client::Backend {
     ///
     /// You need to ensure the `*mut wl_display` remains live as long as the  [`Backend`][Self]
     /// (or its clones) exist.
-    pub unsafe fn from_foreign_display(display: *mut c_void) -> Self {
+    pub unsafe fn from_foreign_display(display: NonNull<c_void>) -> Self {
         Self {
             backend: unsafe {
                 client_impl::InnerBackend::from_foreign_display(
@@ -201,7 +200,7 @@ impl server::ObjectId {
     /// long as the retrieved `ObjectId` is used.
     pub unsafe fn from_ptr(
         interface: &'static crate::protocol::Interface,
-        ptr: *mut c_void,
+        ptr: NonNull<c_void>,
     ) -> Result<Self, server::InvalidId> {
         Ok(Self {
             id: unsafe {
@@ -221,7 +220,7 @@ impl server::ObjectId {
     ///
     /// This function returns an [`InvalidId`][server::InvalidId] error if resource has already
     /// been destroyed.
-    pub fn as_ptr(&self) -> Result<std::ptr::NonNull<c_void>, server::InvalidId> {
+    pub fn as_ptr(&self) -> Result<NonNull<c_void>, server::InvalidId> {
         Ok(self.id.as_ptr()?.cast())
     }
 }

--- a/wayland-backend/src/sys/server_impl/mod.rs
+++ b/wayland-backend/src/sys/server_impl/mod.rs
@@ -112,8 +112,10 @@ impl InnerObjectId {
 
     pub unsafe fn from_ptr(
         interface: Option<&'static Interface>,
-        ptr: *mut wl_resource,
+        ptr: NonNull<wl_resource>,
     ) -> Result<InnerObjectId, InvalidId> {
+        let ptr = ptr.as_ptr();
+
         let id = ffi_dispatch!(wayland_server_handle(), wl_resource_get_id, ptr);
 
         // This is a horrible back to work around the fact that it is not possible to check if the
@@ -1022,6 +1024,8 @@ impl<D: 'static> ErasedState for State<D> {
             resource: *mut wl_resource,
             user_data: *mut c_void,
         ) -> c_int {
+            let resource = NonNull::new(resource).unwrap();
+
             // the closure is passed by double-reference because we only have 1 pointer of user data
             let closure = unsafe { &mut *(user_data as *mut &mut dyn FnMut(ObjectId)) };
 
@@ -1060,10 +1064,10 @@ impl<D: 'static> ErasedState for State<D> {
         let resource = unsafe {
             ffi_dispatch!(wayland_server_handle(), wl_client_get_object, client_id.ptr, protocol_id)
         };
-        if resource.is_null() {
-            Err(InvalidId)
-        } else {
+        if let Some(resource) = NonNull::new(resource) {
             unsafe { ObjectId::from_ptr(interface, resource.cast::<c_void>()) }
+        } else {
+            Err(InvalidId)
         }
     }
 
@@ -1602,7 +1606,7 @@ unsafe extern "C" fn resource_dispatcher<D: 'static>(
             ArgumentType::Object(_) => {
                 let obj = unsafe { (*args.add(i)).o as *mut wl_resource };
                 let next_interface = arg_interfaces.next().unwrap_or(&ANONYMOUS_INTERFACE);
-                let id = if !obj.is_null() {
+                let id = if let Some(obj) = NonNull::new(obj) {
                     ObjectId {
                         id: unsafe { InnerObjectId::from_ptr(Some(next_interface), obj) }
                             .expect("Received an invalid ID when parsing a message."),

--- a/wayland-backend/src/sys/server_impl/mod.rs
+++ b/wayland-backend/src/sys/server_impl/mod.rs
@@ -1063,7 +1063,7 @@ impl<D: 'static> ErasedState for State<D> {
         if resource.is_null() {
             Err(InvalidId)
         } else {
-            unsafe { ObjectId::from_ptr(interface, resource) }
+            unsafe { ObjectId::from_ptr(interface, resource.cast::<c_void>()) }
         }
     }
 

--- a/wayland-egl/CHANGELOG.md
+++ b/wayland-egl/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Breaking changes
 - Use `NonNull` in argument accepting pointer
+- Use `c_void` pointers in API
 - Make `wayland-backend` a default optional feature
 
 ## 0.32.0 -- 2023-09-02

--- a/wayland-egl/src/lib.rs
+++ b/wayland-egl/src/lib.rs
@@ -63,7 +63,7 @@ impl WlEglSurface {
     ///
     /// The provided pointer must be a valid `wl_surface` pointer from `libwayland-client`.
     pub unsafe fn new_from_raw(
-        surface: NonNull<wl_proxy>,
+        surface: NonNull<c_void>,
         width: i32,
         height: i32,
     ) -> Result<Self, Error> {
@@ -73,7 +73,7 @@ impl WlEglSurface {
         let ptr = ffi_dispatch!(
             wayland_egl_handle(),
             wl_egl_window_create,
-            surface.as_ptr(),
+            surface.as_ptr().cast::<wl_proxy>(),
             width,
             height
         );

--- a/wayland-scanner/src/util.rs
+++ b/wayland-scanner/src/util.rs
@@ -94,7 +94,7 @@ pub fn snake_to_camel(input: &str) -> String {
         })
         .collect::<String>();
 
-    if is_camel_keyword(&result) { format!("_{}", &result) } else { result }
+    if is_camel_keyword(&result) { format!("_{}", result) } else { result }
 }
 
 pub fn enum_relname(enum_ref: &EnumRef) -> TokenStream {


### PR DESCRIPTION
This, combined with the change previously made in
https://github.com/Smithay/wayland-rs/pull/901, should make wayland-sys a private dependency of wayland-backend.