### PR TITLE
client: Update `GlobalList` to use a `GlobalListHandler` trait instead of manual `Dispatch`

### DIFF
--- a/wayland-client/CHANGELOG.md
+++ b/wayland-client/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Replace `delegate_noop!` with `Noop` and `NoopIgnore` types providing generic
   dispatch implementations
 - `BindError` now includes the requested and available version, or interface name that failed to bind.
+- `GlobalList` now is updated with normal queueing, requires a `GlobalListHandler` implementation
 
 ## 0.31.14-- 2026-03-30
 

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -13,26 +13,15 @@
 //! ```no_run
 //! use wayland_client::{
 //!     Connection, Dispatch, QueueHandle,
-//!     globals::{registry_queue_init, Global, GlobalListContents},
+//!     globals::{registry_queue_init, Global, GlobalListHandler},
 //!     protocol::{wl_registry, wl_compositor},
 //! };
 //! # use std::sync::Mutex;
 //! # struct State;
 //!
-//! // You need to provide a Dispatch<WlRegistry, GlobalListContents> impl for your app
-//! impl wayland_client::Dispatch<wl_registry::WlRegistry, State> for GlobalListContents {
-//!     fn event(
-//!         // This mutex contains an up-to-date list of the currently known globals
-//!         // including the one that was just added or destroyed
-//!         &self,
-//!         state: &mut State,
-//!         proxy: &wl_registry::WlRegistry,
-//!         event: wl_registry::Event,
-//!         conn: &Connection,
-//!         qhandle: &QueueHandle<State>,
-//!     ) {
-//!         /* react to dynamic global events here */
-//!     }
+//! // You need to provide a GlobalListHandler impl for your app
+//! impl GlobalListHandler for State {
+//!     /* react to dynamic global events here */
 //! }
 //!
 //! let conn = Connection::connect_to_env().unwrap();
@@ -79,8 +68,7 @@ pub fn registry_queue_init<State>(
     conn: &Connection,
 ) -> Result<(GlobalList, EventQueue<State>), GlobalError>
 where
-    State: 'static,
-    GlobalListContents: Dispatch<wl_registry::WlRegistry, State> + 'static,
+    State: GlobalListHandler + 'static,
 {
     let event_queue = conn.new_event_queue();
     let display = conn.display();
@@ -96,6 +84,37 @@ where
     conn.roundtrip()?;
     data.initial_roundtrip_done.store(true, Ordering::Relaxed);
     Ok((GlobalList { registry }, event_queue))
+}
+
+/// Handler for runtime global addition/removal in [`GlobalList`] created with
+/// [`registry_queue_init`]
+pub trait GlobalListHandler: Sized {
+    /// A global has been added dynamically after creation of the [`GlobalList`]
+    ///
+    /// By default, does nothing.
+    fn runtime_add_global(
+        &mut self,
+        _globals: &GlobalList,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _name: u32,
+        _interface: &str,
+        _version: u32,
+    ) {
+    }
+
+    /// A global has been removed
+    ///
+    /// By default, does nothing.
+    fn runtime_remove_global(
+        &mut self,
+        _globals: &GlobalList,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _name: u32,
+        _interface: &str,
+    ) {
+    }
 }
 
 /// A helper for global initialization.
@@ -323,6 +342,43 @@ impl GlobalListContents {
     pub fn clone_list(&self) -> Vec<Global> {
         self.contents.lock().unwrap().clone()
     }
+
+    fn add(&self, global: Global) {
+        self.contents.lock().unwrap().push(global);
+    }
+
+    fn remove(&self, name: u32) -> Option<Global> {
+        let mut guard = self.contents.lock().unwrap();
+        let idx = guard.iter().position(|i| i.name == name)?;
+        Some(guard.remove(idx))
+    }
+}
+
+impl<D> Dispatch<wl_registry::WlRegistry, D> for GlobalListContents
+where
+    D: GlobalListHandler,
+{
+    fn event(
+        &self,
+        state: &mut D,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        conn: &Connection,
+        qh: &QueueHandle<D>,
+    ) {
+        let globals = GlobalList { registry: registry.clone() };
+        match event {
+            wl_registry::Event::Global { name, interface, version } => {
+                self.add(Global { name, interface: interface.clone(), version });
+                state.runtime_add_global(&globals, conn, qh, name, &interface, version);
+            }
+            wl_registry::Event::GlobalRemove { name } => {
+                if let Some(global) = self.remove(name) {
+                    state.runtime_remove_global(&globals, conn, qh, name, &global.interface);
+                }
+            }
+        }
+    }
 }
 
 struct RegistryState<State> {
@@ -331,56 +387,43 @@ struct RegistryState<State> {
     initial_roundtrip_done: AtomicBool,
 }
 
-impl<State: 'static> ObjectData for RegistryState<State>
+impl<State> ObjectData for RegistryState<State>
 where
-    GlobalListContents: Dispatch<wl_registry::WlRegistry, State>,
+    State: GlobalListHandler + 'static,
 {
     fn event(
         self: Arc<Self>,
         backend: &Backend,
         msg: Message<ObjectId, OwnedFd>,
     ) -> Option<Arc<dyn ObjectData>> {
-        let conn = Connection::from_backend(backend.clone());
+        // For initial roundtrip, update immediately without waiting for dispatch.
+        // So globals are available after `registry_queue_init` returns.
+        // later, handle in `Dispatch` implementation.
+        if !self.initial_roundtrip_done.load(Ordering::Relaxed) {
+            let conn = Connection::from_backend(backend.clone());
+            // Can't do much if the server sends a malformed message
+            if let Ok((registry, event)) = wl_registry::WlRegistry::parse_event(&conn, msg) {
+                match event {
+                    wl_registry::Event::Global { name, interface, version } => {
+                        let wl_fixes_ver = 1u32..=1;
+                        if interface == "wl_fixes" && version >= *wl_fixes_ver.start() {
+                            let _ = self.globals.fixes.set(registry.bind(
+                                name,
+                                version.min(*wl_fixes_ver.end()),
+                                &self.handle,
+                                crate::Noop,
+                            ));
+                        }
 
-        // The registry messages don't contain any fd, so use some type trickery to
-        // clone the message
-        #[derive(Debug, Clone)]
-        enum Void {}
-        let msg: Message<ObjectId, Void> = msg.map_fd(|_| unreachable!());
-        let to_forward = if self.initial_roundtrip_done.load(Ordering::Relaxed) {
-            Some(msg.clone().map_fd(|v| match v {}))
-        } else {
-            None
-        };
-        // and restore the type
-        let msg = msg.map_fd(|v| match v {});
-
-        // Can't do much if the server sends a malformed message
-        if let Ok((registry, event)) = wl_registry::WlRegistry::parse_event(&conn, msg) {
-            match event {
-                wl_registry::Event::Global { name, interface, version } => {
-                    let wl_fixes_ver = 1u32..=1;
-                    if interface == "wl_fixes" && version >= *wl_fixes_ver.start() {
-                        let _ = self.globals.fixes.set(registry.bind(
-                            name,
-                            version.min(*wl_fixes_ver.end()),
-                            &self.handle,
-                            crate::Noop,
-                        ));
+                        self.globals.add(Global { name, interface, version });
                     }
 
-                    let mut guard = self.globals.contents.lock().unwrap();
-                    guard.push(Global { name, interface, version });
+                    wl_registry::Event::GlobalRemove { name: remove } => {
+                        self.globals.remove(remove);
+                    }
                 }
-
-                wl_registry::Event::GlobalRemove { name: remove } => {
-                    let mut guard = self.globals.contents.lock().unwrap();
-                    guard.retain(|Global { name, .. }| name != &remove);
-                }
-            }
-        };
-
-        if let Some(msg) = to_forward {
+            };
+        } else {
             // forward the message to the event queue as normal
             self.handle
                 .inner

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -84,19 +84,18 @@ where
 {
     let event_queue = conn.new_event_queue();
     let display = conn.display();
-    let fixes = Arc::new(OnceLock::<wl_fixes::WlFixes>::new());
+    let fixes = OnceLock::<wl_fixes::WlFixes>::new();
 
     let data = Arc::new(RegistryState {
-        globals: GlobalListContents { contents: Default::default() },
+        globals: GlobalListContents { contents: Default::default(), fixes },
         handle: event_queue.handle(),
-        fixes: fixes.clone(),
         initial_roundtrip_done: AtomicBool::new(false),
     });
     let registry = display.send_constructor(wl_display::Request::GetRegistry {}, data.clone())?;
     // We don't need to dispatch the event queue as for now nothing will be sent to it
     conn.roundtrip()?;
     data.initial_roundtrip_done.store(true, Ordering::Relaxed);
-    Ok((GlobalList { registry, fixes }, event_queue))
+    Ok((GlobalList { registry }, event_queue))
 }
 
 /// A helper for global initialization.
@@ -105,7 +104,6 @@ where
 #[derive(Debug)]
 pub struct GlobalList {
     registry: wl_registry::WlRegistry,
-    fixes: Arc<OnceLock<wl_fixes::WlFixes>>,
 }
 
 struct Fixes;
@@ -213,7 +211,7 @@ impl GlobalList {
     /// This might end up doing nothing if the compositor doesn't support `wl_fixes`
     /// in which case the registry cannot be destroyed without closing the connection.
     pub fn destroy(self) {
-        if let Some(fixes) = self.fixes.get() {
+        if let Some(fixes) = self.contents().fixes.get() {
             let id = self.registry.id();
             fixes.destroy_registry(&self.registry);
             if let Some(backend) = fixes.backend().upgrade() {
@@ -323,6 +321,7 @@ pub struct Global {
 #[derive(Debug)]
 pub struct GlobalListContents {
     contents: Mutex<Vec<Global>>,
+    fixes: OnceLock<wl_fixes::WlFixes>,
 }
 
 impl GlobalListContents {
@@ -344,7 +343,6 @@ impl GlobalListContents {
 struct RegistryState<State> {
     globals: GlobalListContents,
     handle: QueueHandle<State>,
-    fixes: Arc<OnceLock<wl_fixes::WlFixes>>,
     initial_roundtrip_done: AtomicBool,
 }
 
@@ -378,7 +376,7 @@ where
                 wl_registry::Event::Global { name, interface, version } => {
                     let wl_fixes_ver = 1u32..=1;
                     if interface == "wl_fixes" && version >= *wl_fixes_ver.start() {
-                        let _ = self.fixes.set(
+                        let _ = self.globals.fixes.set(
                             registry
                                 .send_constructor(
                                     wl_registry::Request::Bind {

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -106,21 +106,6 @@ pub struct GlobalList {
     registry: wl_registry::WlRegistry,
 }
 
-struct Fixes;
-
-impl ObjectData for Fixes {
-    fn event(
-        self: Arc<Self>,
-        _backend: &Backend,
-        _msg: Message<ObjectId, OwnedFd>,
-    ) -> Option<Arc<dyn ObjectData>> {
-        // wl_fixes has no events
-        None
-    }
-
-    fn destroyed(&self, _object_id: ObjectId) {}
-}
-
 impl GlobalList {
     /// Access the contents of the list of globals
     pub fn contents(&self) -> &GlobalListContents {
@@ -376,20 +361,12 @@ where
                 wl_registry::Event::Global { name, interface, version } => {
                     let wl_fixes_ver = 1u32..=1;
                     if interface == "wl_fixes" && version >= *wl_fixes_ver.start() {
-                        let _ = self.globals.fixes.set(
-                            registry
-                                .send_constructor(
-                                    wl_registry::Request::Bind {
-                                        name,
-                                        id: (
-                                            wl_fixes::WlFixes::interface(),
-                                            version.min(*wl_fixes_ver.end()),
-                                        ),
-                                    },
-                                    Arc::new(Fixes),
-                                )
-                                .expect("We just created this registry"),
-                        );
+                        let _ = self.globals.fixes.set(registry.bind(
+                            name,
+                            version.min(*wl_fixes_ver.end()),
+                            &self.handle,
+                            crate::Noop,
+                        ));
                     }
 
                     let mut guard = self.globals.contents.lock().unwrap();

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -101,7 +101,7 @@ where
 /// A helper for global initialization.
 ///
 /// See [the module level documentation][self] for more.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GlobalList {
     registry: wl_registry::WlRegistry,
 }

--- a/wayland-tests/tests/client_globals_helpers.rs
+++ b/wayland-tests/tests/client_globals_helpers.rs
@@ -10,8 +10,8 @@ use ways::protocol::wl_compositor::WlCompositor as ServerCompositor;
 use ways::protocol::wl_output::WlOutput as ServerOutput;
 use ways::protocol::wl_shell::WlShell as ServerShell;
 
-use wayc::globals::{Global, GlobalListContents, registry_queue_init};
-use wayc::protocol::{wl_compositor, wl_registry, wl_subcompositor};
+use wayc::globals::{Global, GlobalListHandler, registry_queue_init};
+use wayc::protocol::{wl_compositor, wl_subcompositor};
 
 #[test]
 fn client_global_helpers_init() {
@@ -203,25 +203,31 @@ server_ignore_global_impl!(ServerHandler => [ServerCompositor, ServerShell, Serv
 
 struct ClientHandler(bool);
 
-impl wayc::Dispatch<wl_registry::WlRegistry, ClientHandler> for GlobalListContents {
-    fn event(
-        &self,
-        state: &mut ClientHandler,
-        _: &wl_registry::WlRegistry,
-        event: wl_registry::Event,
-        _: &wayc::Connection,
-        _: &wayc::QueueHandle<ClientHandler>,
+impl GlobalListHandler for ClientHandler {
+    fn runtime_add_global(
+        &mut self,
+        _globals: &wayc::globals::GlobalList,
+        _conn: &wayc::Connection,
+        _qh: &wayc::QueueHandle<Self>,
+        name: u32,
+        interface: &str,
+        version: u32,
     ) {
-        if let wl_registry::Event::Global { name, interface, version } = event {
-            assert_eq!(name, 3);
-            assert_eq!(interface, "wl_output");
-            assert_eq!(version, 2);
-            state.0 = true;
-        } else if let wl_registry::Event::GlobalRemove { name } = event {
-            assert_eq!(name, 3);
-            state.0 = false;
-        } else {
-            unreachable!()
-        }
+        assert_eq!(name, 3);
+        assert_eq!(interface, "wl_output");
+        assert_eq!(version, 2);
+        self.0 = true;
+    }
+
+    fn runtime_remove_global(
+        &mut self,
+        _globals: &wayc::globals::GlobalList,
+        _conn: &wayc::Connection,
+        _qh: &wayc::QueueHandle<Self>,
+        name: u32,
+        _interface: &str,
+    ) {
+        assert_eq!(name, 3);
+        self.0 = false;
     }
 }


### PR DESCRIPTION
If `delegate_dispatch!` is removed, it would be good in smithay-client-toolkit doesn't require a `delegate_registry!` macro to implement `Dispatch` for `GlobalListContents`.

At a minimum, we can simply provide a trait here that is a little bit simpler than `Dispatch`. We know new events won't be added. Also manually implementing `Dispatch` is potentially less clear of an API when that implementation won't get initial globals.

I was wondering if we could then eliminate the use of the lower-level API here (`send_constructor`, cloning and forwarding `Message`), but `registry_queue_init` then can't get initial globals since the `State` isn't available yet.