### PR TITLE
WIP backend: Don't use `downcast-rs` in API

### DIFF
--- a/wayland-backend/src/client_api.rs
+++ b/wayland-backend/src/client_api.rs
@@ -24,7 +24,8 @@ pub use crate::types::client::{InvalidId, NoWaylandLib, WaylandError};
 ///
 /// The methods of this trait will be invoked internally every time a
 /// new object is created to initialize its data.
-pub trait ObjectData: downcast_rs::DowncastSync {
+#[allow(private_bounds)]
+pub trait ObjectData: AsAny {
     /// Dispatch an event for the associated object
     ///
     /// If the event has a `NewId` argument, the callback must return the object data
@@ -56,14 +57,22 @@ pub trait ObjectData: downcast_rs::DowncastSync {
     }
 }
 
+trait AsAny: 'static {
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl<T: 'static> AsAny for T {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
 impl std::fmt::Debug for dyn ObjectData {
     #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.debug(f)
     }
 }
-
-downcast_rs::impl_downcast!(sync ObjectData);
 
 /// An ID representing a Wayland object
 ///

--- a/wayland-backend/src/client_api.rs
+++ b/wayland-backend/src/client_api.rs
@@ -25,7 +25,7 @@ pub use crate::types::client::{InvalidId, NoWaylandLib, WaylandError};
 /// The methods of this trait will be invoked internally every time a
 /// new object is created to initialize its data.
 #[allow(private_bounds)]
-pub trait ObjectData: AsAny {
+pub trait ObjectData: AsAny + Send + Sync {
     /// Dispatch an event for the associated object
     ///
     /// If the event has a `NewId` argument, the callback must return the object data

--- a/wayland-backend/src/server_api.rs
+++ b/wayland-backend/src/server_api.rs
@@ -49,8 +49,6 @@ pub trait ObjectData<D>: downcast_rs::DowncastSync {
     }
 }
 
-downcast_rs::impl_downcast!(sync ObjectData<D>);
-
 impl<D: 'static> std::fmt::Debug for dyn ObjectData<D> {
     #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -104,8 +102,6 @@ impl<D: 'static> std::fmt::Debug for dyn GlobalHandler<D> {
     }
 }
 
-downcast_rs::impl_downcast!(sync GlobalHandler<D>);
-
 /// A trait representing your data associated to a client
 pub trait ClientData: downcast_rs::DowncastSync {
     /// Notification that the client was initialized
@@ -129,8 +125,6 @@ impl std::fmt::Debug for dyn ClientData {
 }
 
 impl ClientData for () {}
-
-downcast_rs::impl_downcast!(sync ClientData);
 
 /// An ID representing a Wayland object
 ///

--- a/wayland-backend/tests/rs_sys_impls.rs
+++ b/wayland-backend/tests/rs_sys_impls.rs
@@ -107,21 +107,6 @@ macro_rules! assert_impl {
 mod server {
     #[test]
     fn test_impls() {
-        // ObjectData
-        assert_impl!(
-            dyn server::ObjectData<()>: std::fmt::Debug, downcast_rs::DowncastSync
-        );
-
-        // GlobalHandler
-        assert_impl!(
-            dyn server::GlobalHandler<()>: std::fmt::Debug, downcast_rs::DowncastSync
-        );
-
-        // ClientData
-        assert_impl!(
-            dyn server::ClientData: std::fmt::Debug, downcast_rs::DowncastSync
-        );
-
         // ObjectId
         assert_impl!(
             server::ObjectId: std::fmt::Debug,

--- a/wayland-backend/tests/rs_sys_impls.rs
+++ b/wayland-backend/tests/rs_sys_impls.rs
@@ -135,11 +135,6 @@ mod server {
 mod client {
     #[test]
     fn test_impls() {
-        // ObjectData
-        assert_impl!(
-            dyn client::ObjectData: std::fmt::Debug, downcast_rs::DowncastSync
-        );
-
         // ObjectId
         assert_impl!(
             client::ObjectId: std::fmt::Debug,

--- a/wayland-server/src/client.rs
+++ b/wayland-server/src/client.rs
@@ -29,7 +29,7 @@ impl Client {
     ///
     /// Returns [`None`] if the provided `Data` type parameter is not the correct one.
     pub fn get_data<Data: ClientData + 'static>(&self) -> Option<&Data> {
-        (*self.data).downcast_ref()
+        (*self.data).as_any().downcast_ref()
     }
 
     /// Access the pid/uid/gid of this client


### PR DESCRIPTION
We don't want anything from `downcast-rs` to be in the public API, so it isn't technically a public dependency (although that may not matter much). If we don't need it for much, we may as well drop the dep alltogether.

Without the `ObjectData: AsAny`, it seems the compiler can infer the trait is available, but gets "borrowed data escapes outside of method" errors?