### PR TITLE
Use Rust 1.86 casts and eliminate `downcast-rs` dependency

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -8,6 +8,7 @@
   * (This API is generally used internally by `wayland-scanner`)
 - Return `NonNull` from `as_ptr()`
 - Remove `WEnum`
+- Do not use `downcast_rs` traits in API
 
 ## 0.3.15 -- 2026-03-30
 

--- a/wayland-backend/Cargo.toml
+++ b/wayland-backend/Cargo.toml
@@ -17,7 +17,6 @@ build = "build.rs"
 wayland-sys = { version = "0.31.11", path = "../wayland-sys", features = [], optional = true }
 log = { version = "0.4", optional = true }
 scoped-tls = { version = "1.0", optional = true }
-downcast-rs = "1.2"
 raw-window-handle = { version = "0.5.0", optional = true }
 rwh_06 = { package = "raw-window-handle", version = "0.6.0", optional = true }
 

--- a/wayland-backend/src/client_api.rs
+++ b/wayland-backend/src/client_api.rs
@@ -63,8 +63,6 @@ impl std::fmt::Debug for dyn ObjectData {
     }
 }
 
-downcast_rs::impl_downcast!(sync ObjectData);
-
 /// An ID representing a Wayland object
 ///
 /// The backend internally tracks which IDs are still valid, invalidates them when the protocol object they

--- a/wayland-backend/src/client_api.rs
+++ b/wayland-backend/src/client_api.rs
@@ -24,7 +24,8 @@ pub use crate::types::client::{InvalidId, NoWaylandLib, WaylandError};
 ///
 /// The methods of this trait will be invoked internally every time a
 /// new object is created to initialize its data.
-pub trait ObjectData: downcast_rs::DowncastSync {
+#[allow(private_bounds)]
+pub trait ObjectData: AsAny + Any + Send + Sync {
     /// Dispatch an event for the associated object
     ///
     /// If the event has a `NewId` argument, the callback must return the object data
@@ -49,10 +50,20 @@ pub trait ObjectData: downcast_rs::DowncastSync {
     /// Helper for accessing user data
     ///
     /// This function is used to back the `Proxy::data()` function in `wayland_client`.  By default,
-    /// it returns `self` (via [`Downcast`][downcast_rs::DowncastSync]), but this may be overridden to allow downcasting user data
+    /// it returns `self`, but this may be overridden to allow downcasting user data
     /// without needing to have access to the full type.
     fn data_as_any(&self) -> &dyn Any {
         self.as_any()
+    }
+}
+
+trait AsAny: 'static {
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl<T: 'static> AsAny for T {
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/wayland-backend/src/rs/server_impl/handle.rs
+++ b/wayland-backend/src/rs/server_impl/handle.rs
@@ -215,7 +215,7 @@ impl InnerHandle {
     pub fn get_object_data_any(
         &self,
         id: InnerObjectId,
-    ) -> Result<Arc<dyn std::any::Any + Send + Sync>, InvalidId> {
+    ) -> Result<Arc<dyn Any + Send + Sync>, InvalidId> {
         self.state.lock().unwrap().get_object_data_any(id)
     }
 
@@ -333,7 +333,7 @@ pub(crate) trait ErasedState: Any {
     fn get_object_data_any(
         &self,
         id: InnerObjectId,
-    ) -> Result<Arc<dyn std::any::Any + Send + Sync>, InvalidId>;
+    ) -> Result<Arc<dyn Any + Send + Sync>, InvalidId>;
     fn send_event(&mut self, msg: Message<ObjectId, BorrowedFd>) -> Result<(), InvalidId>;
     fn post_error(&mut self, object_id: InnerObjectId, error_code: u32, message: CString);
     fn kill_client(&mut self, client_id: InnerClientId, reason: DisconnectReason);
@@ -453,11 +453,11 @@ impl<D> ErasedState for State<D> {
     fn get_object_data_any(
         &self,
         id: InnerObjectId,
-    ) -> Result<Arc<dyn std::any::Any + Send + Sync>, InvalidId> {
+    ) -> Result<Arc<dyn Any + Send + Sync>, InvalidId> {
         self.clients
             .get_client(id.client_id.clone())?
             .get_object_data(id)
-            .map(|arc| arc.into_any_arc())
+            .map(|arc| -> Arc<dyn Any + Send + Sync> { arc })
     }
 
     fn send_event(&mut self, msg: Message<ObjectId, BorrowedFd>) -> Result<(), InvalidId> {

--- a/wayland-backend/src/server_api.rs
+++ b/wayland-backend/src/server_api.rs
@@ -1,4 +1,5 @@
 use std::{
+    any::Any,
     ffi::CString,
     fmt,
     os::unix::{
@@ -20,7 +21,7 @@ use super::server_impl;
 ///
 /// The methods of this trait will be invoked internally every time a
 /// new object is created to initialize its data.
-pub trait ObjectData<D>: downcast_rs::DowncastSync {
+pub trait ObjectData<D>: Any + Send + Sync {
     /// Dispatch a request for the associated object
     ///
     /// If the request has a `NewId` argument, the callback must return the object data
@@ -57,7 +58,7 @@ impl<D: 'static> std::fmt::Debug for dyn ObjectData<D> {
 }
 
 /// A trait representing the handling of new bound globals
-pub trait GlobalHandler<D>: downcast_rs::DowncastSync {
+pub trait GlobalHandler<D>: Any + Send + Sync {
     /// Check if given client is allowed to interact with given global
     ///
     /// If this function returns false, the client will not be notified of the existence
@@ -103,7 +104,7 @@ impl<D: 'static> std::fmt::Debug for dyn GlobalHandler<D> {
 }
 
 /// A trait representing your data associated to a client
-pub trait ClientData: downcast_rs::DowncastSync {
+pub trait ClientData: Any + Send + Sync {
     /// Notification that the client was initialized
     fn initialized(&self, _client_id: ClientId) {}
     /// Notification that the client is disconnected
@@ -401,7 +402,7 @@ impl Handle {
     pub fn get_object_data_any(
         &self,
         id: ObjectId,
-    ) -> Result<Arc<dyn std::any::Any + Send + Sync>, InvalidId> {
+    ) -> Result<Arc<dyn Any + Send + Sync>, InvalidId> {
         self.handle.get_object_data_any(id.id)
     }
 

--- a/wayland-backend/src/server_api.rs
+++ b/wayland-backend/src/server_api.rs
@@ -49,8 +49,6 @@ pub trait ObjectData<D>: downcast_rs::DowncastSync {
     }
 }
 
-downcast_rs::impl_downcast!(sync ObjectData<D>);
-
 impl<D: 'static> std::fmt::Debug for dyn ObjectData<D> {
     #[cfg_attr(unstable_coverage, coverage(off))]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -104,8 +102,6 @@ impl<D: 'static> std::fmt::Debug for dyn GlobalHandler<D> {
     }
 }
 
-downcast_rs::impl_downcast!(sync GlobalHandler<D>);
-
 /// A trait representing your data associated to a client
 pub trait ClientData: downcast_rs::DowncastSync {
     /// Notification that the client was initialized
@@ -129,8 +125,6 @@ impl std::fmt::Debug for dyn ClientData {
 }
 
 impl ClientData for () {}
-
-downcast_rs::impl_downcast!(sync ClientData);
 
 /// An ID representing a Wayland object
 ///

--- a/wayland-backend/src/sys/server_impl/mod.rs
+++ b/wayland-backend/src/sys/server_impl/mod.rs
@@ -1098,7 +1098,7 @@ impl<D: 'static> ErasedState for State<D> {
                 as *mut ResourceUserData<D>)
         };
 
-        Ok(udata.data.clone().into_any_arc())
+        Ok(udata.data.clone())
     }
 
     fn send_event(

--- a/wayland-backend/tests/rs_sys_impls.rs
+++ b/wayland-backend/tests/rs_sys_impls.rs
@@ -153,17 +153,22 @@ mod server {
 }
 
 mod client {
+    use std::{
+        any::Any,
+        fmt::{Debug, Display},
+    };
+
     #[test]
     fn test_impls() {
         // ObjectData
         assert_impl!(
-            dyn client::ObjectData: std::fmt::Debug, downcast_rs::DowncastSync
+            dyn client::ObjectData: Debug, Any, Send, Sync
         );
 
         // ObjectId
         assert_impl!(
-            client::ObjectId: std::fmt::Debug,
-            std::fmt::Display,
+            client::ObjectId: Debug,
+            Display,
             Clone,
             Send,
             Sync,
@@ -172,6 +177,6 @@ mod client {
         );
 
         // Backend
-        assert_impl!(client::Backend: Send, Sync, std::fmt::Debug);
+        assert_impl!(client::Backend: Send, Sync, Debug);
     }
 }

--- a/wayland-backend/tests/rs_sys_impls.rs
+++ b/wayland-backend/tests/rs_sys_impls.rs
@@ -105,27 +105,32 @@ macro_rules! assert_impl {
 }
 
 mod server {
+    use std::{
+        any::Any,
+        fmt::{Debug, Display},
+    };
+
     #[test]
     fn test_impls() {
         // ObjectData
         assert_impl!(
-            dyn server::ObjectData<()>: std::fmt::Debug, downcast_rs::DowncastSync
+            dyn server::ObjectData<()>: Debug, Any, Send, Sync
         );
 
         // GlobalHandler
         assert_impl!(
-            dyn server::GlobalHandler<()>: std::fmt::Debug, downcast_rs::DowncastSync
+            dyn server::GlobalHandler<()>: Debug, Any, Send, Sync
         );
 
         // ClientData
         assert_impl!(
-            dyn server::ClientData: std::fmt::Debug, downcast_rs::DowncastSync
+            dyn server::ClientData: Debug, Any, Send, Send
         );
 
         // ObjectId
         assert_impl!(
-            server::ObjectId: std::fmt::Debug,
-            std::fmt::Display,
+            server::ObjectId: Debug,
+            Display,
             Send,
             Sync,
             PartialEq,
@@ -134,13 +139,13 @@ mod server {
         );
 
         // ClientId
-        assert_impl!(server::ClientId: std::fmt::Debug, Clone, Send, Sync, PartialEq, Eq);
+        assert_impl!(server::ClientId: Debug, Clone, Send, Sync, PartialEq, Eq);
 
         // GlobalId
-        assert_impl!(server::GlobalId: std::fmt::Debug, Clone, Send, Sync, PartialEq, Eq);
+        assert_impl!(server::GlobalId: Debug, Clone, Send, Sync, PartialEq, Eq);
 
         // Handle
-        assert_impl!(server::Handle: std::fmt::Debug);
+        assert_impl!(server::Handle: Debug);
 
         // Backend
         assert_impl!(server::Backend<()>: Send, Sync);

--- a/wayland-server/src/client.rs
+++ b/wayland-server/src/client.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{any::Any, sync::Arc};
 
 use wayland_backend::{
     protocol::ProtocolError,
@@ -29,7 +29,7 @@ impl Client {
     ///
     /// Returns [`None`] if the provided `Data` type parameter is not the correct one.
     pub fn get_data<Data: ClientData + 'static>(&self) -> Option<&Data> {
-        (*self.data).downcast_ref()
+        (&*self.data as &dyn Any).downcast_ref()
     }
 
     /// Access the pid/uid/gid of this client

--- a/wayland-server/src/client.rs
+++ b/wayland-server/src/client.rs
@@ -66,7 +66,7 @@ impl Client {
             self.id.clone(),
             I::interface(),
             version,
-            Arc::new(ResourceData::<I, U>::new(user_data)) as Arc<_>,
+            Arc::new(ResourceData::<I, U>::new(user_data)),
         )?;
         I::from_id(handle, id)
     }

--- a/wayland-server/src/dispatch.rs
+++ b/wayland-server/src/dispatch.rs
@@ -160,7 +160,7 @@ impl<D> DataInit<'_, D> {
         U: Dispatch<I, D> + Send + Sync + 'static,
     {
         let arc = Arc::new(ResourceData::<I, _>::new(data));
-        *self.store = Some(arc.clone() as Arc<_>);
+        *self.store = Some(arc.clone());
         let mut obj = resource.id;
         obj.__set_object_data(arc);
         obj
@@ -179,7 +179,7 @@ impl<D> DataInit<'_, D> {
     ) -> I {
         *self.store = Some(data.clone());
         let mut obj = resource.id;
-        obj.__set_object_data(data.into_any_arc());
+        obj.__set_object_data(data);
         obj
     }
 


### PR DESCRIPTION
Follow up on https://github.com/Smithay/wayland-rs/pull/905, with the changes that do break API. Though user code generally shouldn't be affected.

[Rust 1.86](https://blog.rust-lang.org/2025/04/03/Rust-1.86.0) added trait upcasting that seems to address every use of `downcast_rs` other than `client_api::ObjectData::data_as_any`. Having `downcast-rs` for just that seems unnecessary, so simply define a small trait as a workaround there. Also unlike downcast-rs, this trait can be private.