### PR TITLE
server: Provide implementation for `Resource::data`

### DIFF
--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -221,7 +221,7 @@ pub mod protocol {
 }
 
 /// Trait representing a Wayland interface
-pub trait Proxy: Clone + std::fmt::Debug + Sized {
+pub trait Proxy: Clone + std::fmt::Debug + Sized + 'static {
     /// The event enum for this interface
     type Event;
     /// The request enum for this interface
@@ -247,7 +247,7 @@ pub trait Proxy: Clone + std::fmt::Debug + Sized {
 
     /// Access the user-data associated with this object
     fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
-        self.object_data().as_ref().and_then(|arc| arc.data_as_any().downcast_ref::<U>())
+        self.object_data()?.data_as_any().downcast_ref::<U>()
     }
 
     /// Access the raw data associated with this object.

--- a/wayland-scanner/src/server_gen.rs
+++ b/wayland-scanner/src/server_gen.rs
@@ -136,11 +136,6 @@ fn generate_objects_for(interface: &Interface) -> TokenStream {
                 }
 
                 #[inline]
-                fn data<U: 'static>(&self) -> Option<&U> {
-                    self.data.as_ref().and_then(|arc| (&**arc).downcast_ref::<ResourceData<Self, U>>()).map(|data| &data.udata)
-                }
-
-                #[inline]
                 fn object_data(&self) -> Option<&Arc<dyn std::any::Any + Send + Sync>> {
                     self.data.as_ref()
                 }

--- a/wayland-scanner/tests/scanner_assets/test-server-code.rs
+++ b/wayland-scanner/tests/scanner_assets/test-server-code.rs
@@ -122,13 +122,6 @@ pub mod wl_registry {
             self.version
         }
         #[inline]
-        fn data<U: 'static>(&self) -> Option<&U> {
-            self.data
-                .as_ref()
-                .and_then(|arc| (&**arc).downcast_ref::<ResourceData<Self, U>>())
-                .map(|data| &data.udata)
-        }
-        #[inline]
         fn object_data(&self) -> Option<&Arc<dyn std::any::Any + Send + Sync>> {
             self.data.as_ref()
         }
@@ -295,13 +288,6 @@ pub mod wl_callback {
         #[inline]
         fn version(&self) -> u32 {
             self.version
-        }
-        #[inline]
-        fn data<U: 'static>(&self) -> Option<&U> {
-            self.data
-                .as_ref()
-                .and_then(|arc| (&**arc).downcast_ref::<ResourceData<Self, U>>())
-                .map(|data| &data.udata)
         }
         #[inline]
         fn object_data(&self) -> Option<&Arc<dyn std::any::Any + Send + Sync>> {
@@ -557,13 +543,6 @@ pub mod test_global {
         #[inline]
         fn version(&self) -> u32 {
             self.version
-        }
-        #[inline]
-        fn data<U: 'static>(&self) -> Option<&U> {
-            self.data
-                .as_ref()
-                .and_then(|arc| (&**arc).downcast_ref::<ResourceData<Self, U>>())
-                .map(|data| &data.udata)
         }
         #[inline]
         fn object_data(&self) -> Option<&Arc<dyn std::any::Any + Send + Sync>> {
@@ -1065,13 +1044,6 @@ pub mod secondary {
             self.version
         }
         #[inline]
-        fn data<U: 'static>(&self) -> Option<&U> {
-            self.data
-                .as_ref()
-                .and_then(|arc| (&**arc).downcast_ref::<ResourceData<Self, U>>())
-                .map(|data| &data.udata)
-        }
-        #[inline]
         fn object_data(&self) -> Option<&Arc<dyn std::any::Any + Send + Sync>> {
             self.data.as_ref()
         }
@@ -1224,13 +1196,6 @@ pub mod tertiary {
             self.version
         }
         #[inline]
-        fn data<U: 'static>(&self) -> Option<&U> {
-            self.data
-                .as_ref()
-                .and_then(|arc| (&**arc).downcast_ref::<ResourceData<Self, U>>())
-                .map(|data| &data.udata)
-        }
-        #[inline]
         fn object_data(&self) -> Option<&Arc<dyn std::any::Any + Send + Sync>> {
             self.data.as_ref()
         }
@@ -1381,13 +1346,6 @@ pub mod quad {
         #[inline]
         fn version(&self) -> u32 {
             self.version
-        }
-        #[inline]
-        fn data<U: 'static>(&self) -> Option<&U> {
-            self.data
-                .as_ref()
-                .and_then(|arc| (&**arc).downcast_ref::<ResourceData<Self, U>>())
-                .map(|data| &data.udata)
         }
         #[inline]
         fn object_data(&self) -> Option<&Arc<dyn std::any::Any + Send + Sync>> {

--- a/wayland-server/src/lib.rs
+++ b/wayland-server/src/lib.rs
@@ -131,7 +131,7 @@ use std::{
 };
 
 /// Trait representing a Wayland interface
-pub trait Resource: Clone + std::fmt::Debug + Sized {
+pub trait Resource: Clone + std::fmt::Debug + Sized + 'static {
     /// The event enum for this interface
     type Event<'a>;
     /// The request enum for this interface
@@ -167,7 +167,9 @@ pub trait Resource: Clone + std::fmt::Debug + Sized {
     }
 
     /// Access the user-data associated with this object
-    fn data<U: 'static>(&self) -> Option<&U>;
+    fn data<U: 'static>(&self) -> Option<&U> {
+        Some(&self.object_data()?.downcast_ref::<ResourceData<Self, U>>()?.udata)
+    }
 
     /// Access the raw data associated with this object.
     ///


### PR DESCRIPTION
In principle `'static` bound is a breaking change, but only `wayland-scanner` implements this, and it isn't an issue.