### PR TITLE
backend: Remove deprecated `raw-window-handle` 0.5 support

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Return `NonNull` from `as_ptr()`
 - Remove `WEnum`
 - Do not use `downcast_rs` traits in API
+- Remove depreacted raw-window-handle 0.5 support
 
 ## 0.3.15 -- 2026-03-30
 

--- a/wayland-backend/Cargo.toml
+++ b/wayland-backend/Cargo.toml
@@ -17,7 +17,6 @@ build = "build.rs"
 wayland-sys = { version = "0.31.11", path = "../wayland-sys", features = [], optional = true }
 log = { version = "0.4", optional = true }
 scoped-tls = { version = "1.0", optional = true }
-raw-window-handle = { version = "0.5.0", optional = true }
 rwh_06 = { package = "raw-window-handle", version = "0.6.0", optional = true }
 
 [dependencies.smallvec]

--- a/wayland-backend/src/lib.rs
+++ b/wayland-backend/src/lib.rs
@@ -33,12 +33,8 @@
 //!
 //! ## raw-window-handle integration
 //!
-//! The `rwh_06` feature activates the [`HasDisplayHandle`][raw_window_handle::HasDisplayHandle] implementation
+//! The `rwh_06` feature activates the [`HasDisplayHandle`][rwh_06::HasDisplayHandle] implementation
 //! for the client module [`Backend`][client::Backend].
-//!
-//! ### Deprecated raw-window-handle versions
-//!
-//! While raw-window-handle 0.5 is supported via the `raw-window-handle` feature, it is deprecated and will be removed in the future.
 //!
 //! Note that the `client_system` feature must also be enabled for the implementation to be activated.
 

--- a/wayland-backend/src/sys/mod.rs
+++ b/wayland-backend/src/sys/mod.rs
@@ -149,19 +149,6 @@ impl client::ReadEventsGuard {
     }
 }
 
-// SAFETY:
-// - The display_ptr will not change for the lifetime of the backend.
-// - The display_ptr will be valid, either because we have created the pointer or the caller which created the
-//   backend has ensured the pointer is valid when `Backend::from_foreign_display` was called.
-#[cfg(feature = "raw-window-handle")]
-unsafe impl raw_window_handle::HasRawDisplayHandle for client::Backend {
-    fn raw_display_handle(&self) -> raw_window_handle::RawDisplayHandle {
-        let mut handle = raw_window_handle::WaylandDisplayHandle::empty();
-        handle.display = self.display_ptr().cast();
-        raw_window_handle::RawDisplayHandle::Wayland(handle)
-    }
-}
-
 #[cfg(all(feature = "rwh_06", feature = "client_system"))]
 impl rwh_06::HasDisplayHandle for client::Backend {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {


### PR DESCRIPTION
This should no long be needed.

This is a breaking change.