### PR TITLE
scanner: Add `available_since()` variant to enums

### DIFF
--- a/wayland-scanner/src/common.rs
+++ b/wayland-scanner/src/common.rs
@@ -118,6 +118,17 @@ impl ToTokens for Enum {
                 }
             });
 
+            let since_arms = self.entries.iter().map(|entry| {
+                let prefix = if entry.name.chars().next().unwrap().is_numeric() { "_" } else { "" };
+                let variant = format_ident!("{}{}", prefix, snake_to_camel(&entry.name));
+
+                let since = entry.since as u32;
+
+                quote! {
+                    Self::#variant => Some(#since)
+                }
+            });
+
             // `from_bits_retain` is used so generated code can work for either enum or bitflags.
             // But can be hidden; application code can just use enum name to construct.
             enum_impl = quote! {
@@ -125,6 +136,17 @@ impl ToTokens for Enum {
                     #[doc(hidden)]
                     pub fn from_bits_retain(bits: u32) -> Self {
                         #ident(bits)
+                    }
+
+                    /// First protocol version enum variant is avilable in
+                    ///
+                    /// `None` for unrecognized value.
+                    pub fn available_since(self) -> Option<u32> {
+                        match self {
+                            #(#since_arms,)*
+                            _ => None
+                        }
+
                     }
                 }
 

--- a/wayland-scanner/tests/scanner_assets/test-client-code.rs
+++ b/wayland-scanner/tests/scanner_assets/test-client-code.rs
@@ -39,6 +39,18 @@ pub mod wl_display {
         pub fn from_bits_retain(bits: u32) -> Self {
             Error(bits)
         }
+        #[doc = r" First protocol version enum variant is avilable in"]
+        #[doc = r""]
+        #[doc = r" `None` for unrecognized value."]
+        pub fn available_since(self) -> Option<u32> {
+            match self {
+                Self::InvalidObject => Some(1u32),
+                Self::InvalidMethod => Some(1u32),
+                Self::NoMemory => Some(1u32),
+                Self::Implementation => Some(1u32),
+                _ => None,
+            }
+        }
     }
     impl std::convert::TryFrom<u32> for Error {
         type Error = ();


### PR DESCRIPTION
May want to provide for bitflags too.

Where or not this is `Some` indicates if enum variant is recognized, as of version used for binding generation.