### PR TITLE
backend/client/sys: Guard udata get/set behind state lock

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 #### Bugfixes
 - client/sys: Fix deadlock if `Backend` is used in `ObjectData::destroyed`
+- client/sys: Fix some race conditions accessing udata in a thread while it is
+  being set, or the proxy is being destroyed.
 
 ## 0.3.15 -- 2026-03-30
 

--- a/wayland-backend/src/sys/client_impl/mod.rs
+++ b/wayland-backend/src/sys/client_impl/mod.rs
@@ -518,6 +518,7 @@ impl InnerBackend {
 
     fn destroy_object_inner(&self, mut guard: MutexGuard<ConnectionState>, id: &ObjectId) {
         if let Some(ref alive) = id.id.alive {
+            // Safety: the udata_ptr must be valid as we are in a rust-managed object, and we are done with using udata
             let udata = unsafe {
                 Box::from_raw(ffi_dispatch!(
                     wayland_client_handle(),
@@ -1030,24 +1031,16 @@ unsafe extern "C" fn dispatcher_func(
         if let Some((ref new_id, _)) = created {
             guard.known_proxies.insert(new_id.ptr);
         }
-        if message_desc.is_destructor {
-            guard.known_proxies.remove(&proxy);
-        }
         std::mem::drop(guard);
-        udata.data.clone().event(
+        let ret = udata.data.clone().event(
             backend,
             Message { sender_id: id.clone(), opcode: opcode as u16, args: parsed_args },
-        )
+        );
+        if message_desc.is_destructor {
+            backend.backend.destroy_object_inner(backend.backend.lock_state(), &id);
+        }
+        ret
     });
-
-    if message_desc.is_destructor {
-        // Safety: the udata_ptr must be valid as we are in a rust-managed object, and we are done with using udata
-        let udata = unsafe { Box::from_raw(udata_ptr) };
-        ffi_dispatch!(wayland_client_handle(), wl_proxy_set_user_data, proxy, std::ptr::null_mut());
-        udata.alive.store(false, Ordering::Release);
-        udata.data.destroyed(id);
-        ffi_dispatch!(wayland_client_handle(), wl_proxy_destroy, proxy);
-    }
 
     match (created, ret) {
         (Some((_, child_udata_ptr)), Some(child_data)) => {

--- a/wayland-backend/src/sys/client_impl/mod.rs
+++ b/wayland-backend/src/sys/client_impl/mod.rs
@@ -520,12 +520,11 @@ impl InnerBackend {
         if let Some(ref alive) = id.id.alive {
             // Safety: the udata_ptr must be valid as we are in a rust-managed object, and we are done with using udata
             let udata = unsafe {
-                Box::from_raw(ffi_dispatch!(
-                    wayland_client_handle(),
-                    wl_proxy_get_user_data,
-                    id.id.ptr
-                ) as *mut ProxyUserData)
+                ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, id.id.ptr)
             };
+            if udata.is_null() {
+                panic!("NULL user data on object {id:?}");
+            }
             unsafe {
                 ffi_dispatch!(
                     wayland_client_handle(),
@@ -534,6 +533,7 @@ impl InnerBackend {
                     std::ptr::null_mut()
                 );
             }
+            let udata = unsafe { Box::from_raw(udata as *mut ProxyUserData) };
             alive.store(false, Ordering::Release);
             guard.known_proxies.remove(&id.id.ptr);
             drop(guard);
@@ -770,11 +770,12 @@ impl InnerBackend {
             return Ok(Arc::new(DumbObjectData));
         }
 
-        let udata = unsafe {
-            &*(ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, id.ptr)
-                as *mut ProxyUserData)
-        };
-        Ok(udata.data.clone())
+        let udata =
+            unsafe { ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, id.ptr) };
+        if udata.is_null() {
+            panic!("NULL user data on object {id:?}");
+        }
+        Ok(unsafe { &*(udata as *mut ProxyUserData) }.data.clone())
     }
 
     pub fn set_data(
@@ -791,10 +792,12 @@ impl InnerBackend {
             return Err(InvalidId);
         }
 
-        let udata = unsafe {
-            &mut *(ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, id.ptr)
-                as *mut ProxyUserData)
-        };
+        let udata =
+            unsafe { ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, id.ptr) };
+        if udata.is_null() {
+            panic!("NULL user data on object {id:?}");
+        }
+        let udata = unsafe { &mut *(udata as *mut ProxyUserData) };
 
         udata.data = data;
 

--- a/wayland-backend/src/sys/client_impl/mod.rs
+++ b/wayland-backend/src/sys/client_impl/mod.rs
@@ -127,7 +127,9 @@ impl InnerObjectId {
         );
 
         let alive = if is_rust_managed {
-            // Safety: the object is rust_managed, so its user-data pointer must be valid
+            // SAFETY: the object is rust_managed, so its user-data pointer must be valid
+            // The udata won't be concurrently destroyed because the caller of this function
+            // guarantees the `*mut wl_proxy` is valid until it returns.
             let udata = unsafe {
                 &*(ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, ptr)
                     as *mut ProxyUserData)
@@ -174,6 +176,7 @@ impl std::fmt::Debug for InnerObjectId {
     }
 }
 
+#[derive(Clone)]
 struct ProxyUserData {
     alive: Arc<AtomicBool>,
     data: Arc<dyn ObjectData>,
@@ -400,6 +403,10 @@ impl Dispatcher {
         // We erase the lifetime of the Handle to be able to store it in the tls,
         // it's safe as it'll only last until the end of this function call anyway
         let ret = BACKEND.set(&backend, || unsafe {
+            // SAFETY: The `display` pointer will remain valid until `ConnectionState` is dropped, which
+            // we hold a strong reference to.
+            // Proxy pointers a ref-counted internally in libwayland, so a proxy destroy in another
+            // thread won't free a proxy that is being dispatched here until it is done.
             ffi_dispatch!(wayland_client_handle(), wl_display_dispatch_queue_pending, display, evq)
         });
         if ret < 0 {
@@ -518,7 +525,7 @@ impl InnerBackend {
 
     fn destroy_object_inner(&self, mut guard: MutexGuard<ConnectionState>, id: &ObjectId) {
         if let Some(ref alive) = id.id.alive {
-            // Safety: the udata_ptr must be valid as we are in a rust-managed object, and we are done with using udata
+            // SAFTETY: the udata_ptr must be valid as we are in a rust-managed object, and we are done with using udata
             let udata = unsafe {
                 ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, id.id.ptr)
             };
@@ -546,11 +553,13 @@ impl InnerBackend {
     }
 
     pub fn destroy_object(&self, id: &ObjectId) -> Result<(), InvalidId> {
+        let guard = self.lock_state();
+
         if !id.id.alive.as_ref().map(|a| a.load(Ordering::Acquire)).unwrap_or(false) {
             return Err(InvalidId);
         }
 
-        self.destroy_object_inner(self.lock_state(), id);
+        self.destroy_object_inner(guard, id);
         Ok(())
     }
 
@@ -761,6 +770,8 @@ impl InnerBackend {
     }
 
     pub fn get_data(&self, ObjectId { id }: ObjectId) -> Result<Arc<dyn ObjectData>, InvalidId> {
+        let mut _guard = self.lock_state();
+
         if !id.alive.as_ref().map(|a| a.load(Ordering::Acquire)).unwrap_or(false) {
             return Err(InvalidId);
         }
@@ -783,6 +794,8 @@ impl InnerBackend {
         ObjectId { id }: ObjectId,
         data: Arc<dyn ObjectData>,
     ) -> Result<(), InvalidId> {
+        let mut _guard = self.lock_state();
+
         if !id.alive.as_ref().map(|a| a.load(Ordering::Acquire)).unwrap_or(false) {
             return Err(InvalidId);
         }
@@ -792,6 +805,7 @@ impl InnerBackend {
             return Err(InvalidId);
         }
 
+        let mut _guard = self.lock_state();
         let udata =
             unsafe { ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, id.ptr) };
         if udata.is_null() {
@@ -870,17 +884,29 @@ unsafe extern "C" fn dispatcher_func(
 ) -> c_int {
     let proxy = proxy as *mut wl_proxy;
 
-    // Safety: if our dispatcher fun is called, then the associated proxy must be rust_managed and have a valid user_data
-    let udata_ptr = unsafe {
-        ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, proxy) as *mut ProxyUserData
+    let Some(udata) = BACKEND.with(|backend| {
+        // SAFETY: if our dispatcher func is called, then the associated proxy must be rust_managed and have a valid user_data
+        // If another thread calls `wl_proxy_destroy()`, the proxy will still be valid due to ref
+        // counting in libwayland. But we may get a `NULL` user data.
+        let _guard = backend.backend.lock_state();
+        let udata = ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, proxy);
+        if udata.is_null() {
+            return None;
+        }
+        Some(unsafe { &*(udata as *mut ProxyUserData) }.clone())
+    }) else {
+        // Another thread has destroyed the proxy, so drop the event.
+        return 0;
     };
-    let udata = unsafe { &mut *udata_ptr };
 
-    let interface = udata.interface;
-    let message_desc = match interface.events.get(opcode as usize) {
+    let message_desc = match udata.interface.events.get(opcode as usize) {
         Some(desc) => desc,
         None => {
-            crate::log_error!("Unknown event opcode {} for interface {}.", opcode, interface.name);
+            crate::log_error!(
+                "Unknown event opcode {} for interface {}.",
+                opcode,
+                udata.interface.name
+            );
             return -1;
         }
     };
@@ -925,17 +951,39 @@ unsafe extern "C" fn dispatcher_func(
                     let listener =
                         ffi_dispatch!(wayland_client_handle(), wl_proxy_get_listener, obj);
                     if ptr::eq(listener, &RUST_MANAGED as *const u8 as *const c_void) {
-                        // Safety: the object is rust-managed, its user-data must be valid
-                        let obj_udata = unsafe {
-                            &*(ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, obj)
-                                as *mut ProxyUserData)
+                        let Some(obj_udata) = BACKEND.with(|backend| {
+                            let _guard = backend.backend.lock_state();
+                            // SAFETY: the object is rust-managed, its user-data must be valid
+                            // If another thread calls `wl_proxy_destroy()`, the proxy will still be valid due to ref
+                            // counting in libwayland. But we may get a `NULL` user data.
+                            let udata = unsafe {
+                                ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, obj)
+                            };
+                            if !udata.is_null() {
+                                Some(unsafe { &mut *(udata as *mut ProxyUserData) }.clone())
+                            } else {
+                                None
+                            }
+                        }) else {
+                            // If arg has object been destroyed in another thread, treat the same
+                            // way as a argument received as `NULL` from libwayland.
+                            // TODO Add a test for this
+                            parsed_args.push(Argument::Object(ObjectId {
+                                id: InnerObjectId {
+                                    alive: None,
+                                    id: 0,
+                                    ptr: std::ptr::null_mut(),
+                                    interface: &ANONYMOUS_INTERFACE,
+                                },
+                            }));
+                            continue;
                         };
                         if !same_interface(next_interface, obj_udata.interface) {
                             crate::log_error!(
                                 "Received object {}@{} in {}.{} but expected interface {}.",
                                 obj_udata.interface.name,
                                 obj_id,
-                                interface.name,
+                                udata.interface.name,
                                 message_desc.name,
                                 next_interface.name,
                             );
@@ -978,7 +1026,7 @@ unsafe extern "C" fn dispatcher_func(
                     let child_interface = message_desc.child_interface.unwrap_or_else(|| {
                         crate::log_warn!(
                             "Event {}.{} creates an anonymous object.",
-                            interface.name,
+                            udata.interface.name,
                             opcode
                         );
                         &ANONYMOUS_INTERFACE
@@ -1074,6 +1122,10 @@ impl Drop for ConnectionState {
         // Cleanup the objects we know about, libwayland will discard any future message
         // they receive.
         for proxy_ptr in self.known_proxies.drain() {
+            // SAFETY: `InnerBackend::get_data()` cannot be called after this point since we
+            // are dropping the backend.
+            // If the proxy is in `known_proxies`, it is managed by us and has not yet been
+            // destroyed.
             let _ = unsafe {
                 Box::from_raw(ffi_dispatch!(
                     wayland_client_handle(),

--- a/wayland-tests/tests/threads.rs
+++ b/wayland-tests/tests/threads.rs
@@ -1,0 +1,97 @@
+use std::{sync::Barrier, thread};
+use wayland_client::Proxy;
+use wayland_tests::{TestServer, wayc};
+
+#[test]
+fn test_thread_destroy_object() {
+    let mut server = TestServer::<()>::new();
+    let (_, client) = server.add_client();
+
+    let qh = client.event_queue.handle();
+    let backend = client.conn.backend();
+
+    for _ in 0..10 {
+        let cb_id = client.display.sync(&qh, ()).id();
+
+        let barrier = Barrier::new(2);
+        thread::scope(|s| {
+            s.spawn(|| {
+                barrier.wait();
+                for _ in 0..100 {
+                    let _ = backend.get_data(cb_id.clone());
+                }
+            });
+
+            barrier.wait();
+            let _ = backend.destroy_object(&cb_id);
+        });
+    }
+}
+
+/*
+// TODO consider why this panics without `client_system`,
+// segfaults with `client_system`?
+#[test]
+fn test_thread_destroy_display() {
+    let mut server = TestServer::<()>::new();
+
+    for _ in 0..10 {
+        let (_, client) = server.add_client::<()>();
+
+        let backend = client.conn.backend();
+
+        let display_id = client.display.id();
+
+        let barrier = Barrier::new(2);
+        thread::scope(|s| {
+            s.spawn(|| {
+                barrier.wait();
+                for _ in 0..100 {
+                    let _ = backend.get_data(display_id.clone());
+                }
+            });
+
+            barrier.wait();
+            let _ = backend.destroy_object(&display_id);
+        });
+    }
+}
+*/
+
+#[test]
+fn test_thread_destroys() {
+    let mut server = TestServer::<()>::new();
+    let (_, client) = server.add_client();
+
+    let qh = client.event_queue.handle();
+    let backend = client.conn.backend();
+
+    for _ in 0..10000 {
+        let cb_id = client.display.sync(&qh, ()).id();
+
+        let barrier = Barrier::new(2);
+        thread::scope(|s| {
+            s.spawn(|| {
+                barrier.wait();
+                let _ = backend.destroy_object(&cb_id);
+            });
+
+            barrier.wait();
+            let _ = backend.destroy_object(&cb_id);
+        });
+    }
+}
+
+struct ClientHandler;
+
+impl wayc::Dispatch<wayc::protocol::wl_callback::WlCallback, ClientHandler> for () {
+    fn event(
+        &self,
+        _: &mut ClientHandler,
+        _: &wayc::protocol::wl_callback::WlCallback,
+        _: wayc::protocol::wl_callback::Event,
+        _: &wayc::Connection,
+        _: &wayc::QueueHandle<ClientHandler>,
+    ) {
+    }
+}


### PR DESCRIPTION
This seems to fix the segfault reproduction on https://github.com/Smithay/wayland-rs/issues/885.

Though there may be other cases where a proxy pointer could be used after being freed. For instance if two threads where racing to destroy the same object? For use in `dispatcher_func` itself, maybe libwayland's internal ref counting with prevent this...