### PR TITLE
client/registry: Add `GlobalList::bind_specific`

### DIFF
--- a/wayland-client/CHANGELOG.md
+++ b/wayland-client/CHANGELOG.md
@@ -12,6 +12,9 @@
 - `GlobalList` now is updated with normal queueing, requires a `GlobalListHandler` implementation
 - Rename `GlobalList::bind` to `bind_singleton`
 
+#### Additions
+- Add `GlobalList::bind_specific`
+
 ## 0.31.14-- 2026-03-30
 
 - Updated Wayland core protocol to 1.25

--- a/wayland-client/CHANGELOG.md
+++ b/wayland-client/CHANGELOG.md
@@ -10,6 +10,7 @@
   dispatch implementations
 - `BindError` now includes the requested and available version, or interface name that failed to bind.
 - `GlobalList` now is updated with normal queueing, requires a `GlobalListHandler` implementation
+- Rename `GlobalList::bind` to `bind_singleton`
 
 ## 0.31.14-- 2026-03-30
 

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -141,8 +141,8 @@ impl GlobalList {
     ///
     /// This function is not intended to be used with globals that have multiple instances such as `wl_output`
     /// and `wl_seat`. These types of globals need their own initialization mechanism because these
-    /// multi-instance globals may be removed at runtime. To handle then, you should instead rely on the
-    /// [`GlobalListHandler`] of your `State`.
+    /// multi-instance globals may be removed at runtime. To handle then, you should instead call
+    /// [`Self::bind_specific`] in the [`GlobalListHandler`] of your `State`.
     ///
     /// # Panics
     ///
@@ -159,8 +159,6 @@ impl GlobalList {
         State: 'static,
         U: Dispatch<I, State> + Send + Sync + 'static,
     {
-        let version_start = *version.start();
-        let version_end = *version.end();
         let interface = I::interface();
 
         if *version.end() > interface.version {
@@ -175,26 +173,78 @@ impl GlobalList {
 
         let globals = &self.registry.data::<GlobalListContents>().unwrap().contents;
         let guard = globals.lock().unwrap();
-        let &Global { name, version, .. } = guard
+        let global = guard
             .iter()
             // Find the global with the correct interface
             .find(|Global { interface: interface_name, .. }| interface.name == interface_name)
             .ok_or(BindError::NotPresent(interface.name))?;
 
         // Test version requirements
-        if version_start > version {
+        if *version.start() > global.version {
             return Err(BindError::UnsupportedVersion {
                 interface: interface.name,
-                requested: version_start,
-                available: version,
+                requested: *version.start(),
+                available: global.version,
             });
         }
 
         // To get the version to bind, take the lower of the version advertised by the server and the maximum
         // requested version.
-        let version = version.min(version_end);
+        let negotiated_version = global.version.min(*version.end());
 
-        Ok(self.registry.bind(name, version, qh, udata))
+        Ok(self.registry.bind(global.name, negotiated_version, qh, udata))
+    }
+
+    /// Binds a global, returning a new object associated with the global.
+    ///
+    /// This binds a specific object by its name.
+    ///
+    /// Typically, this should be called in [`GlobalListHandler::runtime_add_global`] for dynamically
+    /// added globals.
+    pub fn bind_specific<I, State, U>(
+        &self,
+        qh: &QueueHandle<State>,
+        name: u32,
+        version: std::ops::RangeInclusive<u32>,
+        udata: U,
+    ) -> Result<I, BindError>
+    where
+        I: Proxy + 'static,
+        State: 'static,
+        U: Dispatch<I, State> + Send + Sync + 'static,
+    {
+        let interface = I::interface();
+
+        if *version.end() > interface.version {
+            // This is a panic because it's a compile-time programmer error, not a runtime error.
+            panic!(
+                "Maximum version ({}) of {} was higher than the proxy's maximum version ({}); outdated wayland XML files?",
+                version.end(),
+                interface.name,
+                interface.version
+            );
+        }
+
+        let globals = &self.registry.data::<GlobalListContents>().unwrap().contents;
+        let guard = globals.lock().unwrap();
+        let global = guard
+            .iter()
+            // Find the global with correct name and interface
+            .find(|global| global.name == name && global.interface == interface.name)
+            // TODO Error for not finding name, rather than interface?
+            .ok_or(BindError::NotPresent(interface.name))?;
+
+        if global.version < *version.start() {
+            return Err(BindError::UnsupportedVersion {
+                interface: interface.name,
+                requested: *version.start(),
+                available: global.version,
+            });
+        }
+
+        let negotiated_version = global.version.min(*version.end());
+
+        Ok(self.registry.bind(name, negotiated_version, qh, udata))
     }
 
     /// Returns the [`WlRegistry`][wl_registry] protocol object.

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -38,7 +38,7 @@
 //! #     ) {}
 //! # }
 //! // now you can bind the globals you need for your app
-//! let compositor: wl_compositor::WlCompositor = globals.bind(&queue.handle(), 4..=5, ()).unwrap();
+//! let compositor: wl_compositor::WlCompositor = globals.bind_singleton(&queue.handle(), 4..=5, ()).unwrap();
 //! ```
 
 use std::{
@@ -142,13 +142,13 @@ impl GlobalList {
     /// This function is not intended to be used with globals that have multiple instances such as `wl_output`
     /// and `wl_seat`. These types of globals need their own initialization mechanism because these
     /// multi-instance globals may be removed at runtime. To handle then, you should instead rely on the
-    /// `Dispatch` implementation for `WlRegistry` of your `State`.
+    /// [`GlobalListHandler`] of your `State`.
     ///
     /// # Panics
     ///
     /// This function will panic if the maximum requested version is greater than the known maximum version of
     /// the interface. The known maximum version is determined by the code generated using wayland-scanner.
-    pub fn bind<I, State, U>(
+    pub fn bind_singleton<I, State, U>(
         &self,
         qh: &QueueHandle<State>,
         version: RangeInclusive<u32>,

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -179,20 +179,7 @@ impl GlobalList {
             .find(|Global { interface: interface_name, .. }| interface.name == interface_name)
             .ok_or(BindError::NotPresent(interface.name))?;
 
-        // Test version requirements
-        if *version.start() > global.version {
-            return Err(BindError::UnsupportedVersion {
-                interface: interface.name,
-                requested: *version.start(),
-                available: global.version,
-            });
-        }
-
-        // To get the version to bind, take the lower of the version advertised by the server and the maximum
-        // requested version.
-        let negotiated_version = global.version.min(*version.end());
-
-        Ok(self.registry.bind(global.name, negotiated_version, qh, udata))
+        self.bind_inner(qh, global, version, udata)
     }
 
     /// Binds a global, returning a new object associated with the global.
@@ -234,17 +221,35 @@ impl GlobalList {
             // TODO Error for not finding name, rather than interface?
             .ok_or(BindError::NotPresent(interface.name))?;
 
-        if global.version < *version.start() {
+        self.bind_inner(qh, global, version, udata)
+    }
+
+    fn bind_inner<I, State, U>(
+        &self,
+        qh: &QueueHandle<State>,
+        global: &Global,
+        version: RangeInclusive<u32>,
+        udata: U,
+    ) -> Result<I, BindError>
+    where
+        I: Proxy + 'static,
+        State: 'static,
+        U: Dispatch<I, State> + Send + Sync + 'static,
+    {
+        // Test version requirements
+        if *version.start() > global.version {
             return Err(BindError::UnsupportedVersion {
-                interface: interface.name,
+                interface: I::interface().name,
                 requested: *version.start(),
                 available: global.version,
             });
         }
 
+        // To get the version to bind, take the lower of the version advertised by the server and the maximum
+        // requested version.
         let negotiated_version = global.version.min(*version.end());
 
-        Ok(self.registry.bind(name, negotiated_version, qh, udata))
+        Ok(self.registry.bind(global.name, negotiated_version, qh, udata))
     }
 
     /// Returns the [`WlRegistry`][wl_registry] protocol object.

--- a/wayland-client/src/globals.rs
+++ b/wayland-client/src/globals.rs
@@ -97,9 +97,7 @@ pub trait GlobalListHandler: Sized {
         _globals: &GlobalList,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        _name: u32,
-        _interface: &str,
-        _version: u32,
+        _global: &Global,
     ) {
     }
 
@@ -111,8 +109,7 @@ pub trait GlobalListHandler: Sized {
         _globals: &GlobalList,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        _name: u32,
-        _interface: &str,
+        _global: &Global,
     ) {
     }
 }
@@ -369,12 +366,13 @@ where
         let globals = GlobalList { registry: registry.clone() };
         match event {
             wl_registry::Event::Global { name, interface, version } => {
-                self.add(Global { name, interface: interface.clone(), version });
-                state.runtime_add_global(&globals, conn, qh, name, &interface, version);
+                let global = Global { name, interface, version };
+                self.add(global.clone());
+                state.runtime_add_global(&globals, conn, qh, &global);
             }
             wl_registry::Event::GlobalRemove { name } => {
                 if let Some(global) = self.remove(name) {
-                    state.runtime_remove_global(&globals, conn, qh, name, &global.interface);
+                    state.runtime_remove_global(&globals, conn, qh, &global);
                 }
             }
         }

--- a/wayland-tests/tests/client_globals_helpers.rs
+++ b/wayland-tests/tests/client_globals_helpers.rs
@@ -209,13 +209,11 @@ impl GlobalListHandler for ClientHandler {
         _globals: &wayc::globals::GlobalList,
         _conn: &wayc::Connection,
         _qh: &wayc::QueueHandle<Self>,
-        name: u32,
-        interface: &str,
-        version: u32,
+        global: &Global,
     ) {
-        assert_eq!(name, 3);
-        assert_eq!(interface, "wl_output");
-        assert_eq!(version, 2);
+        assert_eq!(global.name, 3);
+        assert_eq!(global.interface, "wl_output");
+        assert_eq!(global.version, 2);
         self.0 = true;
     }
 
@@ -224,10 +222,9 @@ impl GlobalListHandler for ClientHandler {
         _globals: &wayc::globals::GlobalList,
         _conn: &wayc::Connection,
         _qh: &wayc::QueueHandle<Self>,
-        name: u32,
-        _interface: &str,
+        global: &Global,
     ) {
-        assert_eq!(name, 3);
+        assert_eq!(global.name, 3);
         self.0 = false;
     }
 }

--- a/wayland-tests/tests/client_globals_helpers.rs
+++ b/wayland-tests/tests/client_globals_helpers.rs
@@ -51,13 +51,17 @@ fn client_global_helpers_init() {
     // Too high version fails
     assert!(
         globals
-            .bind::<wl_compositor::WlCompositor, _, _>(&queue.handle(), 5..=5, wayc::NoopIgnore)
+            .bind_singleton::<wl_compositor::WlCompositor, _, _>(
+                &queue.handle(),
+                5..=5,
+                wayc::NoopIgnore
+            )
             .is_err()
     );
     // Missing global fails
     assert!(
         globals
-            .bind::<wl_subcompositor::WlSubcompositor, _, _>(
+            .bind_singleton::<wl_subcompositor::WlSubcompositor, _, _>(
                 &queue.handle(),
                 1..=1,
                 wayc::NoopIgnore
@@ -67,7 +71,11 @@ fn client_global_helpers_init() {
     // Compatible spec succeeds
     assert!(
         globals
-            .bind::<wl_compositor::WlCompositor, _, _>(&queue.handle(), 1..=5, wayc::NoopIgnore)
+            .bind_singleton::<wl_compositor::WlCompositor, _, _>(
+                &queue.handle(),
+                1..=5,
+                wayc::NoopIgnore
+            )
             .is_ok()
     );
 
@@ -189,7 +197,7 @@ fn too_high_global_version() {
     let max_compositor_version =
         <wl_compositor::WlCompositor as wayland_client::Proxy>::interface().version;
     // invoking bind with too high a target version should panic
-    let _ = globals.bind::<wl_compositor::WlCompositor, _, _>(
+    let _ = globals.bind_singleton::<wl_compositor::WlCompositor, _, _>(
         &queue.handle(),
         1..=max_compositor_version + 1,
         wayc::NoopIgnore,


### PR DESCRIPTION
Based on `RegistryState::bind_specific` from smithay-client-toolkit.

This should help sctk avoid duplicating functionality provided in wayland-rs.