### PR TITLE
fix(backend): prevent SEGV/panic when destroy_object is called on the display

### DIFF
--- a/wayland-backend/src/rs/client_impl/mod.rs
+++ b/wayland-backend/src/rs/client_impl/mod.rs
@@ -301,6 +301,14 @@ impl InnerBackend {
     pub fn destroy_object(&self, id: &ObjectId) -> Result<(), InvalidId> {
         let mut guard = self.state.lock_protocol();
         let object = guard.get_object(id.id.clone())?;
+
+        // Do not allow destroying the display object; it uses DumbObjectData whose
+        // destroyed() panics, and the display lifecycle is managed by the connection
+        // itself. Attempting to destroy the display will return Err(InvalidId).
+        if same_interface(id.id.interface, &WL_DISPLAY_INTERFACE) {
+            return Err(InvalidId);
+        }
+
         guard
             .map
             .with(id.id.id, |obj| {

--- a/wayland-backend/src/sys/client_impl/mod.rs
+++ b/wayland-backend/src/sys/client_impl/mod.rs
@@ -559,6 +559,14 @@ impl InnerBackend {
             return Err(InvalidId);
         }
 
+        // Do not allow destroying the display object; it has no ProxyUserData and
+        // wl_proxy_destroy on it would cause a segfault. The display lifecycle is
+        // managed by the connection itself. Attempting to destroy the display will
+        // return Err(InvalidId).
+        if same_interface(id.id.interface, &WL_DISPLAY_INTERFACE) {
+            return Err(InvalidId);
+        }
+
         self.destroy_object_inner(guard, id);
         Ok(())
     }

--- a/wayland-tests/tests/threads.rs
+++ b/wayland-tests/tests/threads.rs
@@ -28,9 +28,6 @@ fn test_thread_destroy_object() {
     }
 }
 
-/*
-// TODO consider why this panics without `client_system`,
-// segfaults with `client_system`?
 #[test]
 fn test_thread_destroy_display() {
     let mut server = TestServer::<()>::new();
@@ -47,16 +44,17 @@ fn test_thread_destroy_display() {
             s.spawn(|| {
                 barrier.wait();
                 for _ in 0..100 {
+                    // get_data on the display should succeed
                     let _ = backend.get_data(display_id.clone());
                 }
             });
 
             barrier.wait();
-            let _ = backend.destroy_object(&display_id);
+            // destroy_object on the display should return InvalidId
+            assert!(backend.destroy_object(&display_id).is_err());
         });
     }
 }
-*/
 
 #[test]
 fn test_thread_destroys() {


### PR DESCRIPTION
## Summary

- Fixed the `test_thread_destroy_display` test that was causing SEGV/panic
- Added guards in both `client_sys` and `client_rs` backends to prevent `destroy_object` from being called on the display object (id == 1), returning `InvalidId` instead

## Root Cause

The display object is the root of a Wayland connection and has special handling:

- **`client_sys`** (libwayland backend): The display proxy has no `ProxyUserData`, so `wl_proxy_get_user_data` returns NULL, causing a segfault when `destroy_object_inner` tries to reclaim it
- **`client_rs`** (pure Rust backend): The display uses `DumbObjectData` whose `destroyed()` method contains `unreachable!()`, causing a panic

## Changes

| File | Change |
|------|--------|
| `wayland-backend/src/sys/client_impl/mod.rs` | Added display check in `destroy_object` returning `InvalidId` |
| `wayland-backend/src/rs/client_impl/mod.rs` | Added display check in `destroy_object` returning `InvalidId` |
| `wayland-tests/tests/threads.rs` | Enabled `test_thread_destroy_display` test, now verifies `destroy_object` returns error for display |

## Test Plan

- [x] `cargo test -p wayland-tests test_thread` passes (all 3 thread tests)
- [x] `cargo clippy -p wayland-backend` passes

Fixes #924
