### PR TITLE
protocols: Bump version to release this crate

### DIFF
--- a/wayland-protocols/CHANGELOG.md
+++ b/wayland-protocols/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.32.13 -- 2026-06-19
+
 - Bump wayland-protocols to 1.48
 - Bump wayland-protocols to 1.49
 

--- a/wayland-protocols/Cargo.toml
+++ b/wayland-protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-protocols"
-version = "0.32.12"
+version = "0.32.13"
 documentation = "https://docs.rs/wayland-protocols/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]


### PR DESCRIPTION
The `master` branch has API breaking changes, but `wayland-protocols` does not. So we can release this crate individually without a backport branch, as long as it's released manually rather than through CI.