### PR TITLE
Use `expr` instead of `expr_2021` in macros

### DIFF
--- a/wayland-backend/src/lib.rs
+++ b/wayland-backend/src/lib.rs
@@ -53,7 +53,7 @@ pub extern crate smallvec;
 /// Helper macro for quickly making a [`Message`][crate::protocol::Message]
 #[macro_export]
 macro_rules! message {
-    ($sender_id: expr_2021, $opcode: expr_2021, [$($args: expr_2021),* $(,)?] $(,)?) => {
+    ($sender_id: expr, $opcode: expr, [$($args: expr),* $(,)?] $(,)?) => {
         $crate::protocol::Message {
             sender_id: $sender_id,
             opcode: $opcode,

--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -162,7 +162,7 @@ where
 #[macro_export]
 macro_rules! event_created_child {
     // Must match `pat` to allow paths `wl_data_device::EVT_DONE_OPCODE` and expressions `0` to both work.
-    ($(@< $( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? $selftype:ty, $iface:ty, [$($opcode:pat => ($child_iface:ty, $child_udata:expr_2021)),* $(,)?]) => {
+    ($(@< $( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? $selftype:ty, $iface:ty, [$($opcode:pat => ($child_iface:ty, $child_udata:expr)),* $(,)?]) => {
         fn event_created_child(
             opcode: u16,
             qhandle: &$crate::QueueHandle<$selftype>

--- a/wayland-protocols-experimental/src/protocol_macro.rs
+++ b/wayland-protocols-experimental/src/protocol_macro.rs
@@ -1,5 +1,5 @@
 macro_rules! wayland_protocol(
-    ($path:expr_2021, [$($imports:path),*]) => {
+    ($path:expr, [$($imports:path),*]) => {
         #[cfg(feature = "client")]
         pub use self::generated::client;
 

--- a/wayland-protocols-misc/src/protocol_macro.rs
+++ b/wayland-protocols-misc/src/protocol_macro.rs
@@ -1,5 +1,5 @@
 macro_rules! wayland_protocol(
-    ($path:expr_2021, [$($imports:path),*]) => {
+    ($path:expr, [$($imports:path),*]) => {
         #[cfg(feature = "client")]
         pub use self::generated::client;
 

--- a/wayland-protocols-plasma/src/protocol_macro.rs
+++ b/wayland-protocols-plasma/src/protocol_macro.rs
@@ -1,5 +1,5 @@
 macro_rules! wayland_protocol(
-    ($path:expr_2021, [$($imports:path),*]) => {
+    ($path:expr, [$($imports:path),*]) => {
         #[cfg(feature = "client")]
         pub use self::generated::client;
 

--- a/wayland-protocols-wlr/src/protocol_macro.rs
+++ b/wayland-protocols-wlr/src/protocol_macro.rs
@@ -1,5 +1,5 @@
 macro_rules! wayland_protocol(
-    ($path:expr_2021, [$($imports:path),*]) => {
+    ($path:expr, [$($imports:path),*]) => {
         #[cfg(feature = "client")]
         pub use self::generated::client;
 

--- a/wayland-protocols/src/protocol_macro.rs
+++ b/wayland-protocols/src/protocol_macro.rs
@@ -1,5 +1,5 @@
 macro_rules! wayland_protocol(
-    ($path:expr_2021, [$($imports:path),*]) => {
+    ($path:expr, [$($imports:path),*]) => {
         #[cfg(feature = "client")]
         pub use self::generated::client;
 

--- a/wayland-sys/src/lib.rs
+++ b/wayland-sys/src/lib.rs
@@ -61,7 +61,7 @@ pub use libc::{gid_t, pid_t, uid_t};
 #[cfg(feature = "dlopen")]
 #[macro_export]
 macro_rules! ffi_dispatch(
-    ($handle: expr_2021, $func: ident $(, $arg: expr_2021)* $(,)?) => (
+    ($handle: expr, $func: ident $(, $arg: expr)* $(,)?) => (
         ($handle.$func)($($arg),*)
     )
 );

--- a/wayland-sys/src/server.rs
+++ b/wayland-sys/src/server.rs
@@ -208,13 +208,13 @@ pub mod signal {
     use std::ptr;
 
     macro_rules! container_of(
-        ($ptr: expr_2021, $container: ident, $field: ident) => {
+        ($ptr: expr, $container: ident, $field: ident) => {
             ($ptr as *mut u8).sub(memoffset::offset_of!($container, $field)) as *mut $container
         }
     );
 
     macro_rules! list_for_each(
-        ($pos: ident, $head:expr_2021, $container: ident, $field: ident, $action: block) => {
+        ($pos: ident, $head:expr, $container: ident, $field: ident, $action: block) => {
             let mut $pos = container_of!((*$head).next, $container, $field);
             while &mut (*$pos).$field as *mut _ != $head {
                 $action;
@@ -224,7 +224,7 @@ pub mod signal {
     );
 
     macro_rules! list_for_each_safe(
-        ($pos: ident, $head: expr_2021, $container: ident, $field: ident, $action: block) => {
+        ($pos: ident, $head: expr, $container: ident, $field: ident, $action: block) => {
             let mut $pos = container_of!((*$head).next, $container, $field);
             let mut tmp = container_of!((*$pos).$field.next, $container, $field);
             while &mut (*$pos).$field as *mut _ != $head {


### PR DESCRIPTION
Probably technically a breaking change, but this will be released in a major version anyway.