### PR TITLE
server: implement ListeningSocket::socket_path

### DIFF
--- a/wayland-server/CHANGELOG.md
+++ b/wayland-server/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Remove `delegate_dispatch!` and `delegate_global_dispatch!` in favor of
   implementation that is generic over `D` for a particular user data type
 
+#### Additions
+- Add `ListeningSocket::socket_path`.
+
 ## 0.31.13-- 2026-03-30
 
 - Updated Wayland core protocol to 1.25

--- a/wayland-server/src/socket.rs
+++ b/wayland-server/src/socket.rs
@@ -9,7 +9,7 @@ use std::{
         net::{UnixListener, UnixStream},
         prelude::MetadataExt,
     },
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use rustix::fs::{FlockOperation, flock};
@@ -155,6 +155,11 @@ impl ListeningSocket {
     /// [`bind_auto()`][Self::bind_auto()].
     pub fn socket_name(&self) -> Option<&OsStr> {
         self.socket_name.as_deref()
+    }
+
+    /// Returns the path of the listening socket.
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
     }
 }
 


### PR DESCRIPTION
This is useful particularly with sockets that don't have names.  The absolute socket path can be used for the value of `WAYLAND_DISPLAY`.