### PR TITLE
wayland-scanner: Bump `quick-xml` dependency to `0.41`

### DIFF
--- a/wayland-scanner/CHANGELOG.md
+++ b/wayland-scanner/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update `quick-xml` to 0.41
+
 #### Breaking changes
 - Generate tuple struct for enums, and don't use `WEnum`
 

--- a/wayland-scanner/Cargo.toml
+++ b/wayland-scanner/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.11"
 quote = "1.0"
-quick-xml = "0.40"
+quick-xml = "0.41"
 
 [dev-dependencies]
 similar = "3"


### PR DESCRIPTION
Two vulnerabilities were just issued for `quick-xml`:

https://rustsec.org/advisories/RUSTSEC-2026-0194.html
https://rustsec.org/advisories/RUSTSEC-2026-0195.html

These were both addressed in the `0.41` release, with no new code incompatibilities in `wayland-scanner`.
