### PR TITLE
wayland-sys: Remove dependency on `memoffset`

### DIFF
--- a/wayland-sys/Cargo.toml
+++ b/wayland-sys/Cargo.toml
@@ -15,7 +15,6 @@ readme = "README.md"
 dlib = { version = "0.5.3", optional = true }
 libc = { version = "0.2", optional = true }
 once_cell = { version = "1.0", optional = true }
-memoffset = { version = "0.9", optional = true }
 log = { version = "0.4", optional = true }
 
 [build-dependencies]
@@ -26,7 +25,7 @@ dlopen = ["once_cell"]
 client = ["dep:dlib", "dep:log"]
 cursor = ["client"]
 egl = ["client"]
-server = ["libc", "memoffset", "dep:dlib", "dep:log"]
+server = ["libc", "dep:dlib", "dep:log"]
 libwayland_client_1_23 = []
 libwayland_server_1_22 = []
 libwayland_server_1_23 = ["libwayland_server_1_22"]

--- a/wayland-sys/src/server.rs
+++ b/wayland-sys/src/server.rs
@@ -209,7 +209,7 @@ pub mod signal {
 
     macro_rules! container_of(
         ($ptr: expr, $container: ident, $field: ident) => {
-            ($ptr as *mut u8).sub(memoffset::offset_of!($container, $field)) as *mut $container
+            ($ptr as *mut u8).sub(core::mem::offset_of!($container, $field)) as *mut $container
         }
     );
 


### PR DESCRIPTION
Hi, thank you for your crates! I like niri a lot so I'm indirectly using it.
I'm going down the list of reverse dependencies on `memoffset`.

This PR aims to remove the `memoffset` crate from your dependencies.
[`core::mem::offset_of`](https://doc.rust-lang.org/core/mem/macro.offset_of.html) was stabilised in rustc 1.77 which I believe is at or below your MSRV.

The `memoffset` crate 0.9.1 says that

> If you're using a rustc version greater or equal to 1.77,
> this crate's offset_of!() macro simply forwards to core::mem::offset_of!().

I consider it very unlikely (see [here](https://github.com/rust-lang/rust/issues/111839)) for any usage of the `offset_of!` macro to break but please check anyway.
I hope we can all enjoy the benefits of one less dependency :)