### PR TITLE
egl: Make `wayland-backend` a default optional features

### DIFF
--- a/wayland-egl/CHANGELOG.md
+++ b/wayland-egl/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Breaking changes
 - Use `NonNull` in argument accepting pointer
+- Make `wayland-backend` a default optional feature
 
 ## 0.32.0 -- 2023-09-02
 

--- a/wayland-egl/Cargo.toml
+++ b/wayland-egl/Cargo.toml
@@ -13,8 +13,11 @@ description = "Bindings to libwayland-egl."
 readme = "README.md"
 
 [dependencies]
-wayland-backend = { version = "0.3.15", path = "../wayland-backend", features = ["client_system"] }
+wayland-backend = { version = "0.3.15", path = "../wayland-backend", features = ["client_system"], optional = true }
 wayland-sys = { version = "0.31.11", path="../wayland-sys", features = ["egl"] }
+
+[features]
+default = ["wayland-backend"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wayland-egl/src/lib.rs
+++ b/wayland-egl/src/lib.rs
@@ -12,6 +12,7 @@
 
 use std::{fmt, os::raw::c_void, ptr::NonNull};
 
+#[cfg(feature = "wayland-backend")]
 use wayland_backend::client::ObjectId;
 use wayland_sys::{client::wl_proxy, egl::*, ffi_dispatch};
 
@@ -43,6 +44,7 @@ impl WlEglSurface {
     ///
     /// You must always destroy the [`WlEglSurface`] *before* the underling `wl_surface`
     /// protocol object.
+    #[cfg(feature = "wayland-backend")]
     pub fn new(surface: ObjectId, width: i32, height: i32) -> Result<Self, Error> {
         if surface.interface().name != "wl_surface" {
             return Err(Error::InvalidId);


### PR DESCRIPTION
Can use `new_from_raw` without that, so it may as well be optional.