### PR TITLE
Backports for 0.31.x

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG: wayland-backend
 
-## Unreleased
+## 0.3.16 -- 2026-07-22
+
+Backport from `master`.
 
 #### Bugfixes
 - client/sys: Fix deadlock if `Backend` is used in `ObjectData::destroyed`

--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+#### Bugfixes
+- client/sys: Fix deadlock if `Backend` is used in `ObjectData::destroyed`
+
 ## 0.3.15 -- 2026-03-30
 
 #### Bugfixes

--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### Bugfixes
 - client/sys: Fix deadlock if `Backend` is used in `ObjectData::destroyed`
+- client/sys: Fix some race conditions accessing udata in a thread while it is
+  being set, or the proxy is being destroyed.
 
 ## 0.3.15 -- 2026-03-30
 

--- a/wayland-backend/Cargo.toml
+++ b/wayland-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-backend"
-version = "0.3.15"
+version = "0.3.16"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
 edition = "2021"
 rust-version = "1.71"

--- a/wayland-backend/src/sys/client_impl/mod.rs
+++ b/wayland-backend/src/sys/client_impl/mod.rs
@@ -126,7 +126,9 @@ impl InnerObjectId {
         );
 
         let alive = if is_rust_managed {
-            // Safety: the object is rust_managed, so its user-data pointer must be valid
+            // SAFETY: the object is rust_managed, so its user-data pointer must be valid
+            // The udata won't be concurrently destroyed because the caller of this function
+            // guarantees the `*mut wl_proxy` is valid until it returns.
             let udata = unsafe {
                 &*(ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, ptr)
                     as *mut ProxyUserData)
@@ -173,6 +175,7 @@ impl std::fmt::Debug for InnerObjectId {
     }
 }
 
+#[derive(Clone)]
 struct ProxyUserData {
     alive: Arc<AtomicBool>,
     data: Arc<dyn ObjectData>,
@@ -403,6 +406,10 @@ impl Dispatcher {
         // We erase the lifetime of the Handle to be able to store it in the tls,
         // it's safe as it'll only last until the end of this function call anyway
         let ret = BACKEND.set(&backend, || unsafe {
+            // SAFETY: The `display` pointer will remain valid until `ConnectionState` is dropped, which
+            // we hold a strong reference to.
+            // Proxy pointers a ref-counted internally in libwayland, so a proxy destroy in another
+            // thread won't free a proxy that is being dispatched here until it is done.
             ffi_dispatch!(wayland_client_handle(), wl_display_dispatch_queue_pending, display, evq)
         });
         if ret < 0 {
@@ -525,7 +532,7 @@ impl InnerBackend {
 
     fn destroy_object_inner(&self, mut guard: MutexGuard<ConnectionState>, id: &ObjectId) {
         if let Some(ref alive) = id.id.alive {
-            // Safety: the udata_ptr must be valid as we are in a rust-managed object, and we are done with using udata
+            // SAFTETY: the udata_ptr must be valid as we are in a rust-managed object, and we are done with using udata
             let udata = unsafe {
                 ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, id.id.ptr)
             };
@@ -553,11 +560,13 @@ impl InnerBackend {
     }
 
     pub fn destroy_object(&self, id: &ObjectId) -> Result<(), InvalidId> {
+        let guard = self.lock_state();
+
         if !id.id.alive.as_ref().map(|a| a.load(Ordering::Acquire)).unwrap_or(false) {
             return Err(InvalidId);
         }
 
-        self.destroy_object_inner(self.lock_state(), id);
+        self.destroy_object_inner(guard, id);
         Ok(())
     }
 
@@ -766,6 +775,8 @@ impl InnerBackend {
     }
 
     pub fn get_data(&self, ObjectId { id }: ObjectId) -> Result<Arc<dyn ObjectData>, InvalidId> {
+        let mut _guard = self.lock_state();
+
         if !id.alive.as_ref().map(|a| a.load(Ordering::Acquire)).unwrap_or(false) {
             return Err(InvalidId);
         }
@@ -788,6 +799,8 @@ impl InnerBackend {
         ObjectId { id }: ObjectId,
         data: Arc<dyn ObjectData>,
     ) -> Result<(), InvalidId> {
+        let mut _guard = self.lock_state();
+
         if !id.alive.as_ref().map(|a| a.load(Ordering::Acquire)).unwrap_or(false) {
             return Err(InvalidId);
         }
@@ -797,6 +810,7 @@ impl InnerBackend {
             return Err(InvalidId);
         }
 
+        let mut _guard = self.lock_state();
         let udata =
             unsafe { ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, id.ptr) };
         if udata.is_null() {
@@ -875,17 +889,29 @@ unsafe extern "C" fn dispatcher_func(
 ) -> c_int {
     let proxy = proxy as *mut wl_proxy;
 
-    // Safety: if our dispatcher fun is called, then the associated proxy must be rust_managed and have a valid user_data
-    let udata_ptr = unsafe {
-        ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, proxy) as *mut ProxyUserData
+    let Some(udata) = BACKEND.with(|backend| {
+        // SAFETY: if our dispatcher func is called, then the associated proxy must be rust_managed and have a valid user_data
+        // If another thread calls `wl_proxy_destroy()`, the proxy will still be valid due to ref
+        // counting in libwayland. But we may get a `NULL` user data.
+        let _guard = backend.backend.lock_state();
+        let udata = ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, proxy);
+        if udata.is_null() {
+            return None;
+        }
+        Some(unsafe { &*(udata as *mut ProxyUserData) }.clone())
+    }) else {
+        // Another thread has destroyed the proxy, so drop the event.
+        return 0;
     };
-    let udata = unsafe { &mut *udata_ptr };
 
-    let interface = udata.interface;
-    let message_desc = match interface.events.get(opcode as usize) {
+    let message_desc = match udata.interface.events.get(opcode as usize) {
         Some(desc) => desc,
         None => {
-            crate::log_error!("Unknown event opcode {} for interface {}.", opcode, interface.name);
+            crate::log_error!(
+                "Unknown event opcode {} for interface {}.",
+                opcode,
+                udata.interface.name
+            );
             return -1;
         }
     };
@@ -930,17 +956,39 @@ unsafe extern "C" fn dispatcher_func(
                     let listener =
                         ffi_dispatch!(wayland_client_handle(), wl_proxy_get_listener, obj);
                     if ptr::eq(listener, &RUST_MANAGED as *const u8 as *const c_void) {
-                        // Safety: the object is rust-managed, its user-data must be valid
-                        let obj_udata = unsafe {
-                            &*(ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, obj)
-                                as *mut ProxyUserData)
+                        let Some(obj_udata) = BACKEND.with(|backend| {
+                            let _guard = backend.backend.lock_state();
+                            // SAFETY: the object is rust-managed, its user-data must be valid
+                            // If another thread calls `wl_proxy_destroy()`, the proxy will still be valid due to ref
+                            // counting in libwayland. But we may get a `NULL` user data.
+                            let udata = unsafe {
+                                ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, obj)
+                            };
+                            if !udata.is_null() {
+                                Some(unsafe { &mut *(udata as *mut ProxyUserData) }.clone())
+                            } else {
+                                None
+                            }
+                        }) else {
+                            // If arg has object been destroyed in another thread, treat the same
+                            // way as a argument received as `NULL` from libwayland.
+                            // TODO Add a test for this
+                            parsed_args.push(Argument::Object(ObjectId {
+                                id: InnerObjectId {
+                                    alive: None,
+                                    id: 0,
+                                    ptr: std::ptr::null_mut(),
+                                    interface: &ANONYMOUS_INTERFACE,
+                                },
+                            }));
+                            continue;
                         };
                         if !same_interface(next_interface, obj_udata.interface) {
                             crate::log_error!(
                                 "Received object {}@{} in {}.{} but expected interface {}.",
                                 obj_udata.interface.name,
                                 obj_id,
-                                interface.name,
+                                udata.interface.name,
                                 message_desc.name,
                                 next_interface.name,
                             );
@@ -983,7 +1031,7 @@ unsafe extern "C" fn dispatcher_func(
                     let child_interface = message_desc.child_interface.unwrap_or_else(|| {
                         crate::log_warn!(
                             "Event {}.{} creates an anonymous object.",
-                            interface.name,
+                            udata.interface.name,
                             opcode
                         );
                         &ANONYMOUS_INTERFACE
@@ -1079,6 +1127,10 @@ impl Drop for ConnectionState {
         // Cleanup the objects we know about, libwayland will discard any future message
         // they receive.
         for proxy_ptr in self.known_proxies.drain() {
+            // SAFETY: `InnerBackend::get_data()` cannot be called after this point since we
+            // are dropping the backend.
+            // If the proxy is in `known_proxies`, it is managed by us and has not yet been
+            // destroyed.
             let _ = unsafe {
                 Box::from_raw(ffi_dispatch!(
                     wayland_client_handle(),

--- a/wayland-backend/src/sys/client_impl/mod.rs
+++ b/wayland-backend/src/sys/client_impl/mod.rs
@@ -523,7 +523,7 @@ impl InnerBackend {
         }
     }
 
-    fn destroy_object_inner(&self, guard: &mut MutexGuard<ConnectionState>, id: &ObjectId) {
+    fn destroy_object_inner(&self, mut guard: MutexGuard<ConnectionState>, id: &ObjectId) {
         if let Some(ref alive) = id.id.alive {
             let udata = unsafe {
                 Box::from_raw(ffi_dispatch!(
@@ -541,10 +541,10 @@ impl InnerBackend {
                 );
             }
             alive.store(false, Ordering::Release);
+            guard.known_proxies.remove(&id.id.ptr);
+            drop(guard);
             udata.data.destroyed(id.clone());
         }
-
-        guard.known_proxies.remove(&id.id.ptr);
 
         unsafe {
             ffi_dispatch!(wayland_client_handle(), wl_proxy_destroy, id.id.ptr);
@@ -556,7 +556,7 @@ impl InnerBackend {
             return Err(InvalidId);
         }
 
-        self.destroy_object_inner(&mut self.lock_state(), id);
+        self.destroy_object_inner(self.lock_state(), id);
         Ok(())
     }
 
@@ -758,7 +758,7 @@ impl InnerBackend {
         };
 
         if message_desc.is_destructor {
-            self.destroy_object_inner(&mut guard, &ObjectId { id })
+            self.destroy_object_inner(guard, &ObjectId { id })
         }
 
         Ok(child_id)

--- a/wayland-backend/src/sys/client_impl/mod.rs
+++ b/wayland-backend/src/sys/client_impl/mod.rs
@@ -525,6 +525,7 @@ impl InnerBackend {
 
     fn destroy_object_inner(&self, mut guard: MutexGuard<ConnectionState>, id: &ObjectId) {
         if let Some(ref alive) = id.id.alive {
+            // Safety: the udata_ptr must be valid as we are in a rust-managed object, and we are done with using udata
             let udata = unsafe {
                 Box::from_raw(ffi_dispatch!(
                     wayland_client_handle(),
@@ -1035,24 +1036,16 @@ unsafe extern "C" fn dispatcher_func(
         if let Some((ref new_id, _)) = created {
             guard.known_proxies.insert(new_id.ptr);
         }
-        if message_desc.is_destructor {
-            guard.known_proxies.remove(&proxy);
-        }
         std::mem::drop(guard);
-        udata.data.clone().event(
+        let ret = udata.data.clone().event(
             backend,
             Message { sender_id: id.clone(), opcode: opcode as u16, args: parsed_args },
-        )
+        );
+        if message_desc.is_destructor {
+            backend.backend.destroy_object_inner(backend.backend.lock_state(), &id);
+        }
+        ret
     });
-
-    if message_desc.is_destructor {
-        // Safety: the udata_ptr must be valid as we are in a rust-managed object, and we are done with using udata
-        let udata = unsafe { Box::from_raw(udata_ptr) };
-        ffi_dispatch!(wayland_client_handle(), wl_proxy_set_user_data, proxy, std::ptr::null_mut());
-        udata.alive.store(false, Ordering::Release);
-        udata.data.destroyed(id);
-        ffi_dispatch!(wayland_client_handle(), wl_proxy_destroy, proxy);
-    }
 
     match (created, ret) {
         (Some((_, child_udata_ptr)), Some(child_data)) => {

--- a/wayland-backend/src/sys/client_impl/mod.rs
+++ b/wayland-backend/src/sys/client_impl/mod.rs
@@ -527,12 +527,11 @@ impl InnerBackend {
         if let Some(ref alive) = id.id.alive {
             // Safety: the udata_ptr must be valid as we are in a rust-managed object, and we are done with using udata
             let udata = unsafe {
-                Box::from_raw(ffi_dispatch!(
-                    wayland_client_handle(),
-                    wl_proxy_get_user_data,
-                    id.id.ptr
-                ) as *mut ProxyUserData)
+                ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, id.id.ptr)
             };
+            if udata.is_null() {
+                panic!("NULL user data on object {id:?}");
+            }
             unsafe {
                 ffi_dispatch!(
                     wayland_client_handle(),
@@ -541,6 +540,7 @@ impl InnerBackend {
                     std::ptr::null_mut()
                 );
             }
+            let udata = unsafe { Box::from_raw(udata as *mut ProxyUserData) };
             alive.store(false, Ordering::Release);
             guard.known_proxies.remove(&id.id.ptr);
             drop(guard);
@@ -775,11 +775,12 @@ impl InnerBackend {
             return Ok(Arc::new(DumbObjectData));
         }
 
-        let udata = unsafe {
-            &*(ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, id.ptr)
-                as *mut ProxyUserData)
-        };
-        Ok(udata.data.clone())
+        let udata =
+            unsafe { ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, id.ptr) };
+        if udata.is_null() {
+            panic!("NULL user data on object {id:?}");
+        }
+        Ok(unsafe { &*(udata as *mut ProxyUserData) }.data.clone())
     }
 
     pub fn set_data(
@@ -796,10 +797,12 @@ impl InnerBackend {
             return Err(InvalidId);
         }
 
-        let udata = unsafe {
-            &mut *(ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, id.ptr)
-                as *mut ProxyUserData)
-        };
+        let udata =
+            unsafe { ffi_dispatch!(wayland_client_handle(), wl_proxy_get_user_data, id.ptr) };
+        if udata.is_null() {
+            panic!("NULL user data on object {id:?}");
+        }
+        let udata = unsafe { &mut *(udata as *mut ProxyUserData) };
 
         udata.data = data;
 

--- a/wayland-client/CHANGELOG.md
+++ b/wayland-client/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG: wayland-client
 
-## Unreleased
+## 0.31.15 -- 2026-07-22
+
+Backport from `master`.
 
 #### Additions
 - Updated Wayland core protocol to 1.26

--- a/wayland-client/CHANGELOG.md
+++ b/wayland-client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+#### Additions
+- Updated Wayland core protocol to 1.26
+
 ## 0.31.14-- 2026-03-30
 
 - Updated Wayland core protocol to 1.25

--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-client"
-version = "0.31.14"
+version = "0.31.15"
 documentation = "https://docs.rs/wayland-client/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]

--- a/wayland-client/wayland.xml
+++ b/wayland-client/wayland.xml
@@ -100,11 +100,15 @@
 
     <event name="delete_id">
       <description summary="acknowledge object ID deletion">
-        This event is used internally by the object ID management
-        logic. When a client deletes an object that it had created,
-        the server will send this event to acknowledge that it has
-        seen the delete request. When the client receives this event,
-        it will know that it can safely reuse the object ID.
+        This event is used internally by the object ID management logic.
+
+        When the server stops using an object created by the client, the server
+        sends this event. In particular, after sending this event, the server
+        will no longer send any events that contain the object as the receiver
+        or as an argument.
+
+        When the client receives this event, it knows that it can reuse the
+        object ID.
       </description>
       <arg name="id" type="uint" summary="deleted object ID"/>
     </event>
@@ -140,7 +144,7 @@
         specified name as the identifier.
       </description>
       <arg name="name" type="uint" summary="unique numeric name of the object"/>
-      <arg name="id" type="new_id" summary="bounded object"/>
+      <arg name="id" type="new_id" summary="bound object"/>
     </request>
 
     <event name="global">
@@ -220,7 +224,7 @@
     </request>
   </interface>
 
-  <interface name="wl_shm_pool" version="2">
+  <interface name="wl_shm_pool" version="3">
     <description summary="a shared memory pool">
       The wl_shm_pool object encapsulates a piece of memory shared
       between the compositor and client.  Through the wl_shm_pool
@@ -230,6 +234,14 @@
       setup/teardown overhead and is useful when interactively resizing
       a surface or for many small buffers.
     </description>
+
+    <enum name="error" since="3">
+      <description summary="wl_shm_pool error values">
+        These errors can be emitted in response to wl_shm_pool requests.
+      </description>
+      <entry name="invalid_format" value="0" summary="buffer format is not known"/>
+      <entry name="invalid_stride" value="1" summary="invalid size or stride during buffer creation"/>
+    </enum>
 
     <request name="create_buffer">
       <description summary="create a buffer from the pool">
@@ -280,7 +292,7 @@
     </request>
   </interface>
 
-  <interface name="wl_shm" version="2">
+  <interface name="wl_shm" version="3">
     <description summary="shared memory support">
       A singleton global object that provides support for shared
       memory.
@@ -293,12 +305,12 @@
       that can be used for buffers.
     </description>
 
-    <enum name="error">
+    <enum name="error" since="3">
       <description summary="wl_shm error values">
         These errors can be emitted in response to wl_shm requests.
       </description>
-      <entry name="invalid_format" value="0" summary="buffer format is not known"/>
-      <entry name="invalid_stride" value="1" summary="invalid size or stride during pool or buffer creation"/>
+      <entry name="invalid_format" value="0" summary="buffer format is not known" deprecated-since="3"/>
+      <entry name="invalid_stride" value="1" summary="invalid size or stride during pool creation"/>
       <entry name="invalid_fd" value="2" summary="mmapping the file descriptor failed"/>
     </enum>
 
@@ -331,7 +343,7 @@
       <entry name="bgrx4444" value="0x32315842" summary="16-bit BGRx format, [15:0] B:G:R:x 4:4:4:4 little endian"/>
       <entry name="argb4444" value="0x32315241" summary="16-bit ARGB format, [15:0] A:R:G:B 4:4:4:4 little endian"/>
       <entry name="abgr4444" value="0x32314241" summary="16-bit ABGR format, [15:0] A:B:G:R 4:4:4:4 little endian"/>
-      <entry name="rgba4444" value="0x32314152" summary="16-bit RBGA format, [15:0] R:G:B:A 4:4:4:4 little endian"/>
+      <entry name="rgba4444" value="0x32314152" summary="16-bit RGBA format, [15:0] R:G:B:A 4:4:4:4 little endian"/>
       <entry name="bgra4444" value="0x32314142" summary="16-bit BGRA format, [15:0] B:G:R:A 4:4:4:4 little endian"/>
       <entry name="xrgb1555" value="0x35315258" summary="16-bit xRGB format, [15:0] x:R:G:B 1:5:5:5 little endian"/>
       <entry name="xbgr1555" value="0x35314258" summary="16-bit xBGR 1555 format, [15:0] x:B:G:R 1:5:5:5 little endian"/>
@@ -449,9 +461,9 @@
       <entry name="gr1616f" value="0x48205247" summary="[31:0] G:R 16:16 little endian"/>
       <entry name="bgr161616f" value="0x48524742" summary="[47:0] B:G:R 16:16:16 little endian"/>
       <entry name="r32f" value="0x46202052" summary="[31:0] R 32 little endian"/>
-      <entry name="gr3232f" value="0x46205247" summary="[63:0] R:G 32:32 little endian"/>
-      <entry name="bgr323232f" value="0x46524742" summary="[95:0] R:G:B 32:32:32 little endian"/>
-      <entry name="abgr32323232f" value="0x46384241" summary="[127:0] R:G:B:A 32:32:32:32 little endian"/>
+      <entry name="gr3232f" value="0x46205247" summary="[63:0] G:R 32:32 little endian"/>
+      <entry name="bgr323232f" value="0x46524742" summary="[95:0] B:G:R 32:32:32 little endian"/>
+      <entry name="abgr32323232f" value="0x46384241" summary="[127:0] A:B:G:R 32:32:32:32 little endian"/>
       <entry name="nv20" value="0x3032564e" summary="2x1 subsampled Cr:Cb plane"/>
       <entry name="nv30" value="0x3033564e" summary="non-subsampled Cr:Cb plane"/>
       <entry name="s010" value="0x30313053" summary="2x2 subsampled Cb (1) and Cr (2) planes 10 bits per channel"/>
@@ -463,6 +475,11 @@
       <entry name="s016" value="0x36313053" summary="2x2 subsampled Cb (1) and Cr (2) planes 16 bits per channel"/>
       <entry name="s216" value="0x36313253" summary="2x1 subsampled Cb (1) and Cr (2) planes 16 bits per channel"/>
       <entry name="s416" value="0x36313453" summary="non-subsampled Cb (1) and Cr (2) planes 16 bits per channel"/>
+      <entry name="xvuy2101010" value="0x30335958" summary="[31:0] x:Cr:Cb:Y 2:10:10:10 little endian"/>
+      <entry name="p230" value="0x30333250" summary="2x1 subsampled Cr:Cb plane 10 bits per channel packed"/>
+      <entry name="t430" value="0x30333454"/>
+      <entry name="y8" value="0x59455247" summary="8-bit Y-only"/>
+      <entry name="xyyy2101010" value="0x34415059" summary="[31:0] x:Y2:Y1:Y0 2:10:10:10 little endian"/>
     </enum>
 
     <request name="create_pool">
@@ -847,8 +864,8 @@
         acceptance, wl_data_source.cancelled may still be emitted afterwards
         if the drop destination does not accept any mime type.
 
-        However, this event might however not be received if the compositor
-        cancelled the drag-and-drop operation before this event could happen.
+        However, this event might not be received if the compositor cancelled
+        the drag-and-drop operation before this event could happen.
 
         Note that the data_source may still be used in the future and should
         not be destroyed here.
@@ -889,7 +906,7 @@
         The most recent action received is always the valid one. The chosen
         action may change alongside negotiation (e.g. an "ask" action can turn
         into a "move" operation), so the effects of the final action must
-        always be applied in wl_data_offer.dnd_finished.
+        always be applied in wl_data_source.dnd_finished.
 
         Clients can trigger cursor surface changes from this point, so
         they reflect the current action.
@@ -1984,7 +2001,7 @@
     </request>
    </interface>
 
-  <interface name="wl_seat" version="10">
+  <interface name="wl_seat" version="11">
     <description summary="group of input devices">
       A seat is a group of keyboards, pointer and touch devices. This
       object is published as a global during start up, or when such a
@@ -2098,7 +2115,7 @@
         shared across processes to refer to a specific wl_seat global.
 
         The name event is sent after binding to the seat global, and should be sent
-        before announcing capabilities. This event only sent once per seat object,
+        before announcing capabilities. This event is only sent once per seat object,
         and the name does not change over the lifetime of the wl_seat global.
 
         Compositors may re-use the same seat name if the wl_seat global is
@@ -2118,7 +2135,7 @@
 
   </interface>
 
-  <interface name="wl_pointer" version="10">
+  <interface name="wl_pointer" version="11">
     <description summary="pointer input device">
       The wl_pointer interface represents one or more input devices,
       such as mice, which control the pointer location and pointer_focus
@@ -2228,7 +2245,7 @@
       <description summary="pointer button event">
         Mouse button click and release notifications.
 
-        The location of the click is given by the last motion or
+        The location of the click is given by the last motion, warp or
         enter event.
         The time argument is a timestamp with millisecond
         granularity, with an undefined base.
@@ -2529,9 +2546,31 @@
       <arg name="direction" type="uint" enum="axis_relative_direction"
           summary="physical direction relative to axis motion"/>
     </event>
+
+    <!-- Version 11 additions -->
+
+    <event name="warp" since="11">
+      <description summary="pointer warp event">
+	Notification of pointer location change within a surface.
+
+	This location change is not due to events on the input device,
+	but because either the surface under the pointer was moved and
+	thus the relative position of the pointer changed, or because
+	the compositor changed the pointer position in response to an
+	event like pointer confinement being exited.
+
+	The arguments surface_x and surface_y are the location relative to
+	the focused surface.
+
+	This event must not occur in the same wl_pointer.frame as a
+	wl_pointer.enter or wl_pointer.motion event.
+      </description>
+      <arg name="surface_x" type="fixed" summary="surface-local x coordinate"/>
+      <arg name="surface_y" type="fixed" summary="surface-local y coordinate"/>
+    </event>
   </interface>
 
-  <interface name="wl_keyboard" version="10">
+  <interface name="wl_keyboard" version="11">
     <description summary="keyboard input device">
       The wl_keyboard interface represents one or more keyboards
       associated with a seat.
@@ -2712,7 +2751,7 @@
     </event>
   </interface>
 
-  <interface name="wl_touch" version="10">
+  <interface name="wl_touch" version="11">
     <description summary="touchscreen input device">
       The wl_touch interface represents a touchscreen
       associated with a seat.
@@ -2816,7 +2855,7 @@
         of the ellipse, while the minor axis length describes the shorter
         diameter. Major and minor are orthogonal and both are specified in
         surface-local coordinates. The center of the ellipse is always at the
-        touchpoint location as reported by wl_touch.down or wl_touch.move.
+        touchpoint location as reported by wl_touch.down or wl_touch.motion.
 
         This event is only sent by the compositor if the touch device supports
         shape reports. The client has to make reasonable assumptions about the
@@ -3335,11 +3374,19 @@
     </request>
   </interface>
 
-  <interface name="wl_fixes" version="1">
+  <interface name="wl_fixes" version="2">
     <description summary="wayland protocol fixes">
       This global fixes problems with other core-protocol interfaces that
       cannot be fixed in these interfaces themselves.
     </description>
+
+    <enum name="error">
+      <description summary="wl_fixes error values">
+        These errors can be emitted in response to wl_fixes requests.
+      </description>
+      <entry name="invalid_ack_remove" value="0"
+             summary="unknown global or the global is not removed"/>
+    </enum>
 
     <request name="destroy" type="destructor">
       <description summary="destroys this object"/>
@@ -3359,6 +3406,36 @@
       </description>
       <arg name="registry" type="object" interface="wl_registry"
            summary="the registry to destroy"/>
+    </request>
+
+    <request name="ack_global_remove" since="2">
+      <description summary="acknowledge global removal">
+        Acknowledge the removal of the specified global.
+
+        If no global with the specified name exists or the global is not removed,
+        the wl_fixes.invalid_ack_remove protocol error will be posted.
+
+        Due to the Wayland protocol being asynchronous, the wl_global objects
+        cannot be destroyed immediately. For example, if a wl_global is removed
+        and a client attempts to bind that global around same time, it can
+        result in a protocol error due to an unknown global name in the bind
+        request.
+
+        In order to avoid crashing clients, the compositor should remove the
+        wl_global once it is guaranteed that no more bind requests will come.
+
+        The wl_fixes.ack_global_remove() request is used to signal to the
+        compositor that the client will not bind the given global anymore. After
+        all clients acknowledge the removal of the global, the compositor can
+        safely destroy it.
+
+        The client must call the wl_fixes.ack_global_remove() request in
+        response to a wl_registry.global_remove() event even if it did not bind
+        the corresponding global.
+      </description>
+      <arg name="registry" type="object" interface="wl_registry"
+           summary="the registry object"/>
+      <arg name="name" type="uint" summary="unique name of the global"/>
     </request>
   </interface>
 

--- a/wayland-scanner/CHANGELOG.md
+++ b/wayland-scanner/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update `quick-xml` to 0.41
+
 ## 0.31.8 -- 2025-12-30
 
 - Update `quick-xml` to 0.38

--- a/wayland-scanner/CHANGELOG.md
+++ b/wayland-scanner/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG: wayland-scanner
 
-## Unreleased
+## 0.31.11 -- 2026-07-22
+
+Backport from `master`.
 
 - Update `quick-xml` to 0.41
 

--- a/wayland-scanner/Cargo.toml
+++ b/wayland-scanner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-scanner"
-version = "0.31.10"
+version = "0.31.11"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
 repository = "https://github.com/smithay/wayland-rs"
 documentation = "https://docs.rs/wayland-scanner/"

--- a/wayland-scanner/Cargo.toml
+++ b/wayland-scanner/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.11"
 quote = "1.0"
-quick-xml = "0.40"
+quick-xml = "0.41"
 
 [dev-dependencies]
 similar = "3"

--- a/wayland-scanner/Cargo.toml
+++ b/wayland-scanner/Cargo.toml
@@ -18,10 +18,10 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.11"
 quote = "1.0"
-quick-xml = "0.39"
+quick-xml = "0.40"
 
 [dev-dependencies]
-similar = "2"
+similar = "3"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wayland-scanner/src/parse.rs
+++ b/wayland-scanner/src/parse.rs
@@ -86,7 +86,7 @@ fn parse_protocol<R: BufRead>(mut reader: Reader<R>) -> Protocol {
                                 Ok(Event::GeneralRef(byte_ref)) => {
                                     if let Ok(Some(c)) = byte_ref.resolve_char_ref() {
                                         copyright.push(c);
-                                    } else if let Ok(content) = byte_ref.xml_content() {
+                                    } else if let Ok(content) = byte_ref.xml10_content() {
                                         if let Some(s) =
                                             quick_xml::escape::resolve_xml_entity(&content)
                                         {

--- a/wayland-server/CHANGELOG.md
+++ b/wayland-server/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+#### Additions
+- Updated Wayland core protocol to 1.26
+
 ## 0.31.13-- 2026-03-30
 
 - Updated Wayland core protocol to 1.25

--- a/wayland-server/CHANGELOG.md
+++ b/wayland-server/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG: wayland-server
 
-## Unreleased
+## 0.31.14 -- 2026-07-22
 
 #### Additions
 - Updated Wayland core protocol to 1.26

--- a/wayland-server/Cargo.toml
+++ b/wayland-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wayland-server"
-version = "0.31.13"
+version = "0.31.14"
 documentation = "https://docs.rs/wayland-server/"
 repository = "https://github.com/smithay/wayland-rs"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]

--- a/wayland-server/wayland.xml
+++ b/wayland-server/wayland.xml
@@ -100,11 +100,15 @@
 
     <event name="delete_id">
       <description summary="acknowledge object ID deletion">
-        This event is used internally by the object ID management
-        logic. When a client deletes an object that it had created,
-        the server will send this event to acknowledge that it has
-        seen the delete request. When the client receives this event,
-        it will know that it can safely reuse the object ID.
+        This event is used internally by the object ID management logic.
+
+        When the server stops using an object created by the client, the server
+        sends this event. In particular, after sending this event, the server
+        will no longer send any events that contain the object as the receiver
+        or as an argument.
+
+        When the client receives this event, it knows that it can reuse the
+        object ID.
       </description>
       <arg name="id" type="uint" summary="deleted object ID"/>
     </event>
@@ -140,7 +144,7 @@
         specified name as the identifier.
       </description>
       <arg name="name" type="uint" summary="unique numeric name of the object"/>
-      <arg name="id" type="new_id" summary="bounded object"/>
+      <arg name="id" type="new_id" summary="bound object"/>
     </request>
 
     <event name="global">
@@ -220,7 +224,7 @@
     </request>
   </interface>
 
-  <interface name="wl_shm_pool" version="2">
+  <interface name="wl_shm_pool" version="3">
     <description summary="a shared memory pool">
       The wl_shm_pool object encapsulates a piece of memory shared
       between the compositor and client.  Through the wl_shm_pool
@@ -230,6 +234,14 @@
       setup/teardown overhead and is useful when interactively resizing
       a surface or for many small buffers.
     </description>
+
+    <enum name="error" since="3">
+      <description summary="wl_shm_pool error values">
+        These errors can be emitted in response to wl_shm_pool requests.
+      </description>
+      <entry name="invalid_format" value="0" summary="buffer format is not known"/>
+      <entry name="invalid_stride" value="1" summary="invalid size or stride during buffer creation"/>
+    </enum>
 
     <request name="create_buffer">
       <description summary="create a buffer from the pool">
@@ -280,7 +292,7 @@
     </request>
   </interface>
 
-  <interface name="wl_shm" version="2">
+  <interface name="wl_shm" version="3">
     <description summary="shared memory support">
       A singleton global object that provides support for shared
       memory.
@@ -293,12 +305,12 @@
       that can be used for buffers.
     </description>
 
-    <enum name="error">
+    <enum name="error" since="3">
       <description summary="wl_shm error values">
         These errors can be emitted in response to wl_shm requests.
       </description>
-      <entry name="invalid_format" value="0" summary="buffer format is not known"/>
-      <entry name="invalid_stride" value="1" summary="invalid size or stride during pool or buffer creation"/>
+      <entry name="invalid_format" value="0" summary="buffer format is not known" deprecated-since="3"/>
+      <entry name="invalid_stride" value="1" summary="invalid size or stride during pool creation"/>
       <entry name="invalid_fd" value="2" summary="mmapping the file descriptor failed"/>
     </enum>
 
@@ -331,7 +343,7 @@
       <entry name="bgrx4444" value="0x32315842" summary="16-bit BGRx format, [15:0] B:G:R:x 4:4:4:4 little endian"/>
       <entry name="argb4444" value="0x32315241" summary="16-bit ARGB format, [15:0] A:R:G:B 4:4:4:4 little endian"/>
       <entry name="abgr4444" value="0x32314241" summary="16-bit ABGR format, [15:0] A:B:G:R 4:4:4:4 little endian"/>
-      <entry name="rgba4444" value="0x32314152" summary="16-bit RBGA format, [15:0] R:G:B:A 4:4:4:4 little endian"/>
+      <entry name="rgba4444" value="0x32314152" summary="16-bit RGBA format, [15:0] R:G:B:A 4:4:4:4 little endian"/>
       <entry name="bgra4444" value="0x32314142" summary="16-bit BGRA format, [15:0] B:G:R:A 4:4:4:4 little endian"/>
       <entry name="xrgb1555" value="0x35315258" summary="16-bit xRGB format, [15:0] x:R:G:B 1:5:5:5 little endian"/>
       <entry name="xbgr1555" value="0x35314258" summary="16-bit xBGR 1555 format, [15:0] x:B:G:R 1:5:5:5 little endian"/>
@@ -449,9 +461,9 @@
       <entry name="gr1616f" value="0x48205247" summary="[31:0] G:R 16:16 little endian"/>
       <entry name="bgr161616f" value="0x48524742" summary="[47:0] B:G:R 16:16:16 little endian"/>
       <entry name="r32f" value="0x46202052" summary="[31:0] R 32 little endian"/>
-      <entry name="gr3232f" value="0x46205247" summary="[63:0] R:G 32:32 little endian"/>
-      <entry name="bgr323232f" value="0x46524742" summary="[95:0] R:G:B 32:32:32 little endian"/>
-      <entry name="abgr32323232f" value="0x46384241" summary="[127:0] R:G:B:A 32:32:32:32 little endian"/>
+      <entry name="gr3232f" value="0x46205247" summary="[63:0] G:R 32:32 little endian"/>
+      <entry name="bgr323232f" value="0x46524742" summary="[95:0] B:G:R 32:32:32 little endian"/>
+      <entry name="abgr32323232f" value="0x46384241" summary="[127:0] A:B:G:R 32:32:32:32 little endian"/>
       <entry name="nv20" value="0x3032564e" summary="2x1 subsampled Cr:Cb plane"/>
       <entry name="nv30" value="0x3033564e" summary="non-subsampled Cr:Cb plane"/>
       <entry name="s010" value="0x30313053" summary="2x2 subsampled Cb (1) and Cr (2) planes 10 bits per channel"/>
@@ -463,6 +475,11 @@
       <entry name="s016" value="0x36313053" summary="2x2 subsampled Cb (1) and Cr (2) planes 16 bits per channel"/>
       <entry name="s216" value="0x36313253" summary="2x1 subsampled Cb (1) and Cr (2) planes 16 bits per channel"/>
       <entry name="s416" value="0x36313453" summary="non-subsampled Cb (1) and Cr (2) planes 16 bits per channel"/>
+      <entry name="xvuy2101010" value="0x30335958" summary="[31:0] x:Cr:Cb:Y 2:10:10:10 little endian"/>
+      <entry name="p230" value="0x30333250" summary="2x1 subsampled Cr:Cb plane 10 bits per channel packed"/>
+      <entry name="t430" value="0x30333454"/>
+      <entry name="y8" value="0x59455247" summary="8-bit Y-only"/>
+      <entry name="xyyy2101010" value="0x34415059" summary="[31:0] x:Y2:Y1:Y0 2:10:10:10 little endian"/>
     </enum>
 
     <request name="create_pool">
@@ -847,8 +864,8 @@
         acceptance, wl_data_source.cancelled may still be emitted afterwards
         if the drop destination does not accept any mime type.
 
-        However, this event might however not be received if the compositor
-        cancelled the drag-and-drop operation before this event could happen.
+        However, this event might not be received if the compositor cancelled
+        the drag-and-drop operation before this event could happen.
 
         Note that the data_source may still be used in the future and should
         not be destroyed here.
@@ -889,7 +906,7 @@
         The most recent action received is always the valid one. The chosen
         action may change alongside negotiation (e.g. an "ask" action can turn
         into a "move" operation), so the effects of the final action must
-        always be applied in wl_data_offer.dnd_finished.
+        always be applied in wl_data_source.dnd_finished.
 
         Clients can trigger cursor surface changes from this point, so
         they reflect the current action.
@@ -1984,7 +2001,7 @@
     </request>
    </interface>
 
-  <interface name="wl_seat" version="10">
+  <interface name="wl_seat" version="11">
     <description summary="group of input devices">
       A seat is a group of keyboards, pointer and touch devices. This
       object is published as a global during start up, or when such a
@@ -2098,7 +2115,7 @@
         shared across processes to refer to a specific wl_seat global.
 
         The name event is sent after binding to the seat global, and should be sent
-        before announcing capabilities. This event only sent once per seat object,
+        before announcing capabilities. This event is only sent once per seat object,
         and the name does not change over the lifetime of the wl_seat global.
 
         Compositors may re-use the same seat name if the wl_seat global is
@@ -2118,7 +2135,7 @@
 
   </interface>
 
-  <interface name="wl_pointer" version="10">
+  <interface name="wl_pointer" version="11">
     <description summary="pointer input device">
       The wl_pointer interface represents one or more input devices,
       such as mice, which control the pointer location and pointer_focus
@@ -2228,7 +2245,7 @@
       <description summary="pointer button event">
         Mouse button click and release notifications.
 
-        The location of the click is given by the last motion or
+        The location of the click is given by the last motion, warp or
         enter event.
         The time argument is a timestamp with millisecond
         granularity, with an undefined base.
@@ -2529,9 +2546,31 @@
       <arg name="direction" type="uint" enum="axis_relative_direction"
           summary="physical direction relative to axis motion"/>
     </event>
+
+    <!-- Version 11 additions -->
+
+    <event name="warp" since="11">
+      <description summary="pointer warp event">
+	Notification of pointer location change within a surface.
+
+	This location change is not due to events on the input device,
+	but because either the surface under the pointer was moved and
+	thus the relative position of the pointer changed, or because
+	the compositor changed the pointer position in response to an
+	event like pointer confinement being exited.
+
+	The arguments surface_x and surface_y are the location relative to
+	the focused surface.
+
+	This event must not occur in the same wl_pointer.frame as a
+	wl_pointer.enter or wl_pointer.motion event.
+      </description>
+      <arg name="surface_x" type="fixed" summary="surface-local x coordinate"/>
+      <arg name="surface_y" type="fixed" summary="surface-local y coordinate"/>
+    </event>
   </interface>
 
-  <interface name="wl_keyboard" version="10">
+  <interface name="wl_keyboard" version="11">
     <description summary="keyboard input device">
       The wl_keyboard interface represents one or more keyboards
       associated with a seat.
@@ -2712,7 +2751,7 @@
     </event>
   </interface>
 
-  <interface name="wl_touch" version="10">
+  <interface name="wl_touch" version="11">
     <description summary="touchscreen input device">
       The wl_touch interface represents a touchscreen
       associated with a seat.
@@ -2816,7 +2855,7 @@
         of the ellipse, while the minor axis length describes the shorter
         diameter. Major and minor are orthogonal and both are specified in
         surface-local coordinates. The center of the ellipse is always at the
-        touchpoint location as reported by wl_touch.down or wl_touch.move.
+        touchpoint location as reported by wl_touch.down or wl_touch.motion.
 
         This event is only sent by the compositor if the touch device supports
         shape reports. The client has to make reasonable assumptions about the
@@ -3335,11 +3374,19 @@
     </request>
   </interface>
 
-  <interface name="wl_fixes" version="1">
+  <interface name="wl_fixes" version="2">
     <description summary="wayland protocol fixes">
       This global fixes problems with other core-protocol interfaces that
       cannot be fixed in these interfaces themselves.
     </description>
+
+    <enum name="error">
+      <description summary="wl_fixes error values">
+        These errors can be emitted in response to wl_fixes requests.
+      </description>
+      <entry name="invalid_ack_remove" value="0"
+             summary="unknown global or the global is not removed"/>
+    </enum>
 
     <request name="destroy" type="destructor">
       <description summary="destroys this object"/>
@@ -3359,6 +3406,36 @@
       </description>
       <arg name="registry" type="object" interface="wl_registry"
            summary="the registry to destroy"/>
+    </request>
+
+    <request name="ack_global_remove" since="2">
+      <description summary="acknowledge global removal">
+        Acknowledge the removal of the specified global.
+
+        If no global with the specified name exists or the global is not removed,
+        the wl_fixes.invalid_ack_remove protocol error will be posted.
+
+        Due to the Wayland protocol being asynchronous, the wl_global objects
+        cannot be destroyed immediately. For example, if a wl_global is removed
+        and a client attempts to bind that global around same time, it can
+        result in a protocol error due to an unknown global name in the bind
+        request.
+
+        In order to avoid crashing clients, the compositor should remove the
+        wl_global once it is guaranteed that no more bind requests will come.
+
+        The wl_fixes.ack_global_remove() request is used to signal to the
+        compositor that the client will not bind the given global anymore. After
+        all clients acknowledge the removal of the global, the compositor can
+        safely destroy it.
+
+        The client must call the wl_fixes.ack_global_remove() request in
+        response to a wl_registry.global_remove() event even if it did not bind
+        the corresponding global.
+      </description>
+      <arg name="registry" type="object" interface="wl_registry"
+           summary="the registry object"/>
+      <arg name="name" type="uint" summary="unique name of the global"/>
     </request>
   </interface>
 


### PR DESCRIPTION
It seems like a good idea to backport the segfault fix from https://github.com/Smithay/wayland-rs/pull/920, even if we do a 0.32.x release of wayland-client/wayland-server soon.

This also includes the bump of `quick-xml`, and the updated version of the core wayland protocol. Once tests pass I'll merge and manually release these four crates.