### PR TITLE
backend: Make `ReadEventsGuard` implement `Send+Sync` on `sys`

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -16,6 +16,7 @@
 - client/sys: Fix deadlock if `Backend` is used in `ObjectData::destroyed`
 - client/sys: Fix some race conditions accessing udata in a thread while it is
   being set, or the proxy is being destroyed.
+- client/sys: Make `ReadEventsGuard` impl `Send+Sync`, like `rs` backend
 
 ## 0.3.15 -- 2026-03-30
 

--- a/wayland-backend/src/sys/client_impl/mod.rs
+++ b/wayland-backend/src/sys/client_impl/mod.rs
@@ -432,6 +432,9 @@ pub struct InnerReadEventsGuard {
     done: bool,
 }
 
+unsafe impl Send for InnerReadEventsGuard {}
+unsafe impl Sync for InnerReadEventsGuard {}
+
 impl InnerReadEventsGuard {
     pub fn try_new(backend: InnerBackend) -> Option<Self> {
         let (display, evq) = {

--- a/wayland-backend/tests/rs_sys_impls.rs
+++ b/wayland-backend/tests/rs_sys_impls.rs
@@ -178,5 +178,8 @@ mod client {
 
         // Backend
         assert_impl!(client::Backend: Send, Sync, Debug);
+
+        // ReadEventsGuard
+        assert_impl!(client::ReadEventsGuard: Send, Sync, Debug);
     }
 }


### PR DESCRIPTION
This should be consistent with the `rs` backend.

`*mut wl_display` is generally safe to use in multiple threads. For this guard in particular, the operations that mutate take `mut`, so `Sync` should be fine in this particular case too, if not particularly helpful.