### PR TITLE
backend/client/rs: Don't return `WouldBlock` on `ReadEventsGuard::read`

### DIFF
--- a/wayland-backend/CHANGELOG.md
+++ b/wayland-backend/CHANGELOG.md
@@ -18,6 +18,7 @@
   being set, or the proxy is being destroyed.
 - client/sys: Make `ReadEventsGuard` impl `Send+Sync`, like `rs` backend
 - client/sys: Fix double mutex lock in `set_data`
+- client/rs: Don't return `WouldBlock` on `ReadEventsGuard::read`, like `sys`
 
 #### Changes
 - rs: Log dates with format matching `libwayland` 1.26

--- a/wayland-backend/src/client_api.rs
+++ b/wayland-backend/src/client_api.rs
@@ -349,8 +349,9 @@ impl ReadEventsGuard {
     /// will read events from the socket and invoke the callbacks for the received events. All
     /// threads will then resume their execution.
     ///
-    /// This returns the number of dispatched events, or `0` if an other thread handled the dispatching.
-    /// If no events are available to read from the socket, this returns a [`WouldBlock`] IO error.
+    /// This returns the number of dispatched events, or `0` if no events are available to read from
+    /// the socket, or an other thread handled the dispatching. On success, the socket has been
+    /// read until EOF or `WouldBlock`.
     #[inline]
     pub fn read(self) -> Result<usize, WaylandError> {
         self.guard.read()

--- a/wayland-backend/src/rs/client_impl/mod.rs
+++ b/wayland-backend/src/rs/client_impl/mod.rs
@@ -229,15 +229,6 @@ impl InnerReadEventsGuard {
         unsafe { BorrowedFd::borrow_raw(raw_fd) }
     }
 
-    /// Attempt to read events from the Wayland socket
-    ///
-    /// If multiple threads have a live reading guard, this method will block until all of them
-    /// are either dropped or have their `read()` method invoked, at which point on of the threads
-    /// will read events from the socket and invoke the callbacks for the received events. All
-    /// threads will then resume their execution.
-    ///
-    /// This returns the number of dispatched events, or `0` if an other thread handled the dispatching.
-    /// If no events are available to read from the socket, this returns a `WouldBlock` IO error.
     pub fn read(mut self) -> Result<usize, WaylandError> {
         let mut guard = self.state.lock_read();
         guard.prepared_reads -= 1;
@@ -653,12 +644,10 @@ fn dispatch_events(state: Arc<ConnectionState>) -> Result<usize, WaylandError> {
             Err(MessageParseError::MissingData) | Err(MessageParseError::MissingFD) => {
                 // need to read more data
                 if let Err(e) = guard.socket.fill_incoming_buffers() {
-                    if e.kind() != std::io::ErrorKind::WouldBlock {
-                        return Err(guard.store_and_return_error(e));
-                    } else if dispatched == 0 {
-                        return Err(e.into());
-                    } else {
+                    if e.kind() == std::io::ErrorKind::WouldBlock {
                         break;
+                    } else {
+                        return Err(guard.store_and_return_error(e));
                     }
                 }
                 continue;


### PR DESCRIPTION
This matches the behavior of the `sys` backend, since `wl_display_read_events` seems to read until `WouldBlock` without returning that as an error.

This is a breaking change in code that uses the `rs` backend and relies on this behavior, but that should be corrected so the code can work with `client_system`.