### PR TITLE
client: Use `registry_queue_init` in example, and add example demonstating use with `tokio`

### DIFF
--- a/wayland-backend/src/rs/client_impl/mod.rs
+++ b/wayland-backend/src/rs/client_impl/mod.rs
@@ -3,7 +3,7 @@
 use std::{
     fmt,
     os::unix::{
-        io::{AsRawFd, BorrowedFd, OwnedFd},
+        io::{AsFd, AsRawFd, BorrowedFd, OwnedFd},
         net::UnixStream,
     },
     sync::{Arc, Condvar, Mutex, MutexGuard, Weak},
@@ -198,7 +198,7 @@ impl InnerBackend {
     }
 
     pub fn poll_fd(&self) -> BorrowedFd<'_> {
-        let raw_fd = self.state.lock_protocol().socket.as_raw_fd();
+        let raw_fd = self.state.lock_protocol().socket.as_fd().as_raw_fd();
         // This allows the lifetime of the BorrowedFd to be tied to &self rather than the lock guard,
         // which is the real safety concern
         unsafe { BorrowedFd::borrow_raw(raw_fd) }
@@ -223,7 +223,7 @@ impl InnerReadEventsGuard {
 
     /// Access the Wayland socket FD for polling
     pub fn connection_fd(&self) -> BorrowedFd<'_> {
-        let raw_fd = self.state.lock_protocol().socket.as_raw_fd();
+        let raw_fd = self.state.lock_protocol().socket.as_fd().as_raw_fd();
         // This allows the lifetime of the BorrowedFd to be tied to &self rather than the lock guard,
         // which is the real safety concern
         unsafe { BorrowedFd::borrow_raw(raw_fd) }

--- a/wayland-backend/src/rs/socket.rs
+++ b/wayland-backend/src/rs/socket.rs
@@ -3,7 +3,7 @@
 use std::collections::VecDeque;
 use std::io::{ErrorKind, IoSlice, IoSliceMut, Result as IoResult};
 use std::mem::MaybeUninit;
-use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
+use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
 use std::os::unix::net::UnixStream;
 use std::slice;
 
@@ -113,12 +113,6 @@ impl From<UnixStream> for Socket {
 impl AsFd for Socket {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.stream.as_fd()
-    }
-}
-
-impl AsRawFd for Socket {
-    fn as_raw_fd(&self) -> RawFd {
-        self.stream.as_raw_fd()
     }
 }
 
@@ -312,12 +306,6 @@ impl BufferedSocket {
     pub fn set_max_buffer_size(&mut self, max_buffer_size: Option<usize>) {
         // TODO: what if it decreases?
         self.max_buffer_size = max_buffer_size.map(round_max_buffer_size);
-    }
-}
-
-impl AsRawFd for BufferedSocket {
-    fn as_raw_fd(&self) -> RawFd {
-        self.socket.as_raw_fd()
     }
 }
 

--- a/wayland-client/CHANGELOG.md
+++ b/wayland-client/CHANGELOG.md
@@ -16,6 +16,7 @@
 #### Additions
 - Add `GlobalList::bind_specific`
 - Updated Wayland core protocol to 1.26
+- Implement `AsRawFd` for `Connection` and `EventQueue`
 
 ## 0.31.14-- 2026-03-30
 

--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -24,6 +24,7 @@ wayland-protocols = { path = "../wayland-protocols", features = ["client"] }
 futures-channel = "0.3.16"
 futures-util = "0.3"
 tempfile = "3.2"
+tokio = {version = "1", features = ["macros", "rt-multi-thread", "net"] }
 
 [features]
 system = ["wayland-backend/client_system"]

--- a/wayland-client/examples/simple_window.rs
+++ b/wayland-client/examples/simple_window.rs
@@ -2,7 +2,8 @@ use std::{fs::File, os::unix::io::AsFd};
 
 use wayland_client::{
     Connection, Dispatch, NoopIgnore, QueueHandle,
-    protocol::{wl_buffer, wl_compositor, wl_keyboard, wl_registry, wl_seat, wl_shm, wl_surface},
+    globals::{Global, GlobalList, GlobalListHandler, registry_queue_init},
+    protocol::{wl_buffer, wl_compositor, wl_keyboard, wl_seat, wl_shm, wl_surface},
 };
 
 use wayland_protocols::xdg::shell::client::{xdg_surface, xdg_toplevel, xdg_wm_base};
@@ -12,20 +13,47 @@ struct GlobalData;
 fn main() {
     let conn = Connection::connect_to_env().unwrap();
 
-    let mut event_queue = conn.new_event_queue();
-    let qhandle = event_queue.handle();
+    let (globals, mut event_queue) = registry_queue_init(&conn).unwrap();
+    let qh = event_queue.handle();
 
-    let display = conn.display();
-    display.get_registry(&qhandle, GlobalData);
+    let wm_base =
+        globals.bind_singleton::<xdg_wm_base::XdgWmBase, _, _>(&qh, 1..=1, GlobalData).unwrap();
+    let compositor = globals
+        .bind_singleton::<wl_compositor::WlCompositor, _, _>(&qh, 1..=1, NoopIgnore)
+        .unwrap();
 
-    let mut state = State {
-        running: true,
-        base_surface: None,
-        buffer: None,
-        wm_base: None,
-        xdg_surface: None,
-        configured: false,
-    };
+    let base_surface = compositor.create_surface(&qh, NoopIgnore);
+    let xdg_surface = wm_base.get_xdg_surface(&base_surface, &qh, GlobalData);
+    let xdg_toplevel = xdg_surface.get_toplevel(&qh, GlobalData);
+    xdg_toplevel.set_title("A fantastic window!".into());
+    base_surface.commit();
+
+    for global in globals.contents().clone_list() {
+        if global.interface == "wl_seat" {
+            globals
+                .bind_specific::<wl_seat::WlSeat, _, _>(&qh, global.name, 1..=1, GlobalData)
+                .unwrap();
+        }
+    }
+
+    let shm = globals.bind_singleton::<wl_shm::WlShm, _, _>(&qh, 1..=1, NoopIgnore).unwrap();
+
+    let (init_w, init_h) = (320, 240);
+
+    let mut file = tempfile::tempfile().unwrap();
+    draw(&mut file, (init_w, init_h));
+    let pool = shm.create_pool(file.as_fd(), (init_w * init_h * 4) as i32, &qh, NoopIgnore);
+    let buffer = pool.create_buffer(
+        0,
+        init_w as i32,
+        init_h as i32,
+        (init_w * 4) as i32,
+        wl_shm::Format::Argb8888,
+        &qh,
+        NoopIgnore,
+    );
+
+    let mut state = State { running: true, base_surface, buffer, configured: false };
 
     println!("Starting the example window app, press <ESC> to quit.");
 
@@ -36,74 +64,23 @@ fn main() {
 
 struct State {
     running: bool,
-    base_surface: Option<wl_surface::WlSurface>,
-    buffer: Option<wl_buffer::WlBuffer>,
-    wm_base: Option<xdg_wm_base::XdgWmBase>,
-    xdg_surface: Option<(xdg_surface::XdgSurface, xdg_toplevel::XdgToplevel)>,
+    base_surface: wl_surface::WlSurface,
+    buffer: wl_buffer::WlBuffer,
     configured: bool,
 }
 
-impl Dispatch<wl_registry::WlRegistry, State> for GlobalData {
-    fn event(
-        &self,
-        state: &mut State,
-        registry: &wl_registry::WlRegistry,
-        event: wl_registry::Event,
-        _: &Connection,
-        qh: &QueueHandle<State>,
+impl GlobalListHandler for State {
+    fn runtime_add_global(
+        &mut self,
+        globals: &GlobalList,
+        _conn: &Connection,
+        qh: &QueueHandle<Self>,
+        global: &Global,
     ) {
-        if let wl_registry::Event::Global { name, interface, .. } = event {
-            match &interface[..] {
-                "wl_compositor" => {
-                    let compositor =
-                        registry.bind::<wl_compositor::WlCompositor, _, _>(name, 1, qh, NoopIgnore);
-                    let surface = compositor.create_surface(qh, NoopIgnore);
-                    state.base_surface = Some(surface);
-
-                    if state.wm_base.is_some() && state.xdg_surface.is_none() {
-                        state.init_xdg_surface(qh);
-                    }
-                }
-                "wl_shm" => {
-                    let shm = registry.bind::<wl_shm::WlShm, _, _>(name, 1, qh, NoopIgnore);
-
-                    let (init_w, init_h) = (320, 240);
-
-                    let mut file = tempfile::tempfile().unwrap();
-                    draw(&mut file, (init_w, init_h));
-                    let pool =
-                        shm.create_pool(file.as_fd(), (init_w * init_h * 4) as i32, qh, NoopIgnore);
-                    let buffer = pool.create_buffer(
-                        0,
-                        init_w as i32,
-                        init_h as i32,
-                        (init_w * 4) as i32,
-                        wl_shm::Format::Argb8888,
-                        qh,
-                        NoopIgnore,
-                    );
-                    state.buffer = Some(buffer.clone());
-
-                    if state.configured {
-                        let surface = state.base_surface.as_ref().unwrap();
-                        surface.attach(Some(&buffer), 0, 0);
-                        surface.commit();
-                    }
-                }
-                "wl_seat" => {
-                    registry.bind::<wl_seat::WlSeat, _, _>(name, 1, qh, GlobalData);
-                }
-                "xdg_wm_base" => {
-                    let wm_base =
-                        registry.bind::<xdg_wm_base::XdgWmBase, _, _>(name, 1, qh, GlobalData);
-                    state.wm_base = Some(wm_base);
-
-                    if state.base_surface.is_some() && state.xdg_surface.is_none() {
-                        state.init_xdg_surface(qh);
-                    }
-                }
-                _ => {}
-            }
+        if global.interface == "wl_seat" {
+            globals
+                .bind_specific::<wl_seat::WlSeat, _, _>(qh, global.name, 1..=1, GlobalData)
+                .unwrap();
         }
     }
 }
@@ -121,21 +98,6 @@ fn draw(tmp: &mut File, (buf_x, buf_y): (u32, u32)) {
         }
     }
     buf.flush().unwrap();
-}
-
-impl State {
-    fn init_xdg_surface(&mut self, qh: &QueueHandle<State>) {
-        let wm_base = self.wm_base.as_ref().unwrap();
-        let base_surface = self.base_surface.as_ref().unwrap();
-
-        let xdg_surface = wm_base.get_xdg_surface(base_surface, qh, GlobalData);
-        let toplevel = xdg_surface.get_toplevel(qh, GlobalData);
-        toplevel.set_title("A fantastic window!".into());
-
-        base_surface.commit();
-
-        self.xdg_surface = Some((xdg_surface, toplevel));
-    }
 }
 
 impl Dispatch<xdg_wm_base::XdgWmBase, State> for GlobalData {
@@ -164,12 +126,9 @@ impl Dispatch<xdg_surface::XdgSurface, State> for GlobalData {
     ) {
         if let xdg_surface::Event::Configure { serial, .. } = event {
             xdg_surface.ack_configure(serial);
+            state.base_surface.attach(Some(&state.buffer), 0, 0);
+            state.base_surface.commit();
             state.configured = true;
-            let surface = state.base_surface.as_ref().unwrap();
-            if let Some(ref buffer) = state.buffer {
-                surface.attach(Some(buffer), 0, 0);
-                surface.commit();
-            }
         }
     }
 }

--- a/wayland-client/examples/tokio.rs
+++ b/wayland-client/examples/tokio.rs
@@ -1,0 +1,169 @@
+// A variation on the `simple_window` example that uses tokio to poll the Wayland
+// socket asynchronously.
+//
+// This displays a white window and prints pointer events to the console.
+
+use std::{io::Write, os::unix::io::AsFd};
+use tokio::io::unix::AsyncFd;
+use wayland_client::{
+    Connection, Dispatch, NoopIgnore, QueueHandle,
+    globals::{GlobalListHandler, registry_queue_init},
+    protocol::{wl_buffer, wl_compositor, wl_pointer, wl_seat, wl_shm, wl_surface},
+};
+
+use wayland_protocols::xdg::shell::client::{xdg_surface, xdg_toplevel, xdg_wm_base};
+
+struct GlobalData;
+
+#[tokio::main]
+async fn main() {
+    let conn = Connection::connect_to_env().unwrap();
+
+    let (globals, event_queue) = registry_queue_init(&conn).unwrap();
+    let qh = event_queue.handle();
+
+    let wm_base =
+        globals.bind_singleton::<xdg_wm_base::XdgWmBase, _, _>(&qh, 1..=1, GlobalData).unwrap();
+    let compositor = globals
+        .bind_singleton::<wl_compositor::WlCompositor, _, _>(&qh, 1..=1, NoopIgnore)
+        .unwrap();
+
+    let base_surface = compositor.create_surface(&qh, NoopIgnore);
+    let xdg_surface = wm_base.get_xdg_surface(&base_surface, &qh, GlobalData);
+    let _xdg_toplevel = xdg_surface.get_toplevel(&qh, GlobalData);
+    base_surface.commit();
+
+    for global in globals.contents().clone_list() {
+        if global.interface == "wl_seat" {
+            globals
+                .bind_specific::<wl_seat::WlSeat, _, _>(&qh, global.name, 1..=1, GlobalData)
+                .unwrap();
+        }
+    }
+
+    let shm = globals.bind_singleton::<wl_shm::WlShm, _, _>(&qh, 1..=1, NoopIgnore).unwrap();
+
+    let (init_w, init_h) = (320, 240);
+
+    let mut file = tempfile::tempfile().unwrap();
+    // File buffer with white pixels
+    for _ in 0..init_w * init_h * 4 {
+        file.write_all(&[255]).unwrap();
+    }
+    let pool = shm.create_pool(file.as_fd(), init_w * init_h * 4, &qh, NoopIgnore);
+    let buffer = pool.create_buffer(
+        0,
+        init_w,
+        init_h,
+        init_w * 4,
+        wl_shm::Format::Argb8888,
+        &qh,
+        NoopIgnore,
+    );
+
+    conn.flush().unwrap();
+
+    let mut state = State { running: true, base_surface, buffer, configured: false };
+
+    let mut event_queue = AsyncFd::new(event_queue).unwrap();
+    while state.running {
+        // Prepare read before polling file descritor
+        // (Needed for synchronization if multiple threads are reading)
+        if let Some(read_events_guard) = event_queue.get_ref().prepare_read() {
+            let mut read_ready_guard = event_queue.readable_mut().await.unwrap();
+            read_events_guard.read().unwrap();
+            // `ReadEventsGuard` has read fd until `WouldBlock`; clear ready state
+            read_ready_guard.clear_ready();
+        }
+        // Dispatch events to event handlers
+        event_queue.get_mut().dispatch_pending(&mut state).unwrap();
+        conn.flush().unwrap();
+    }
+}
+
+struct State {
+    running: bool,
+    base_surface: wl_surface::WlSurface,
+    buffer: wl_buffer::WlBuffer,
+    configured: bool,
+}
+
+impl GlobalListHandler for State {}
+
+impl Dispatch<xdg_wm_base::XdgWmBase, State> for GlobalData {
+    fn event(
+        &self,
+        _: &mut State,
+        wm_base: &xdg_wm_base::XdgWmBase,
+        event: xdg_wm_base::Event,
+        _: &Connection,
+        _: &QueueHandle<State>,
+    ) {
+        if let xdg_wm_base::Event::Ping { serial } = event {
+            wm_base.pong(serial);
+        }
+    }
+}
+
+impl Dispatch<xdg_surface::XdgSurface, State> for GlobalData {
+    fn event(
+        &self,
+        state: &mut State,
+        xdg_surface: &xdg_surface::XdgSurface,
+        event: xdg_surface::Event,
+        _: &Connection,
+        _: &QueueHandle<State>,
+    ) {
+        if let xdg_surface::Event::Configure { serial, .. } = event {
+            xdg_surface.ack_configure(serial);
+            state.base_surface.attach(Some(&state.buffer), 0, 0);
+            state.base_surface.commit();
+            state.configured = true;
+        }
+    }
+}
+
+impl Dispatch<xdg_toplevel::XdgToplevel, State> for GlobalData {
+    fn event(
+        &self,
+        state: &mut State,
+        _: &xdg_toplevel::XdgToplevel,
+        event: xdg_toplevel::Event,
+        _: &Connection,
+        _: &QueueHandle<State>,
+    ) {
+        if let xdg_toplevel::Event::Close = event {
+            state.running = false;
+        }
+    }
+}
+
+impl Dispatch<wl_seat::WlSeat, State> for GlobalData {
+    fn event(
+        &self,
+        _: &mut State,
+        seat: &wl_seat::WlSeat,
+        event: wl_seat::Event,
+        _: &Connection,
+        qh: &QueueHandle<State>,
+    ) {
+        if let wl_seat::Event::Capabilities { capabilities } = event {
+            if capabilities.contains(wl_seat::Capability::Pointer) {
+                seat.get_pointer(qh, GlobalData);
+            }
+        }
+    }
+}
+
+impl Dispatch<wl_pointer::WlPointer, State> for GlobalData {
+    fn event(
+        &self,
+        _state: &mut State,
+        _: &wl_pointer::WlPointer,
+        event: wl_pointer::Event,
+        _: &Connection,
+        _: &QueueHandle<State>,
+    ) {
+        println!("{:?}", event);
+    }
+}

--- a/wayland-client/src/conn.rs
+++ b/wayland-client/src/conn.rs
@@ -1,7 +1,7 @@
 use std::{
     env, fmt,
     io::ErrorKind,
-    os::unix::io::{AsFd, BorrowedFd, FromRawFd, OwnedFd},
+    os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd},
     os::unix::net::UnixStream,
     path::PathBuf,
     sync::{
@@ -281,6 +281,13 @@ impl AsFd for Connection {
     /// Provides fd from [`Backend::poll_fd()`] for polling.
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.backend.poll_fd()
+    }
+}
+
+impl AsRawFd for Connection {
+    /// Provides fd from [`Backend::poll_fd()`] for polling.
+    fn as_raw_fd(&self) -> RawFd {
+        self.backend.poll_fd().as_raw_fd()
     }
 }
 

--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::collections::VecDeque;
 use std::convert::Infallible;
 use std::marker::PhantomData;
-use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
 use std::sync::{Arc, Condvar, Mutex, atomic::Ordering};
 use std::task;
 
@@ -356,6 +356,13 @@ impl<State> AsFd for EventQueue<State> {
     /// Provides fd from [`Backend::poll_fd`] for polling.
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.conn.as_fd()
+    }
+}
+
+impl<State> AsRawFd for EventQueue<State> {
+    /// Provides fd from [`Backend::poll_fd`] for polling.
+    fn as_raw_fd(&self) -> RawFd {
+        self.conn.as_raw_fd()
     }
 }
 


### PR DESCRIPTION
It would be good if there could be an async version of `registry_queue_init`...